### PR TITLE
feat: trigger wiki link pipeline on PUT /wiki/{id}

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,12 @@
-# arkeon
+# arkeon-wiki
+
+Forked from `Arkeon-Technologies/arkeon` at the `wiki-rewrite` branch. Wiki-centric knowledge graph — diverged enough from core arkeon to be its own repo.
+
+**Repo**: `Arkeon-Technologies/arkeon-wiki`
 
 Three npm workspaces. Only two are published to npm.
 
-- `packages/arkeon` — the main package, published as `arkeon` on npm. Contains the CLI binary, the Hono API server, the database schema migrations, and shared TypeScript types. Single source tree under `src/`:
+- `packages/arkeon` — the main package (npm name TBD for this fork). Contains the CLI binary, the Hono API server, the database schema migrations, and shared TypeScript types. Single source tree under `src/`:
   - `src/index.ts` — CLI entry (commander wiring)
   - `src/cli/commands/**` + `src/cli/lib/**` — CLI commands and helpers
   - `src/server/**` — Hono API server (routes, middleware, wiki pipeline)
@@ -208,22 +212,11 @@ After any feature work, ask: "Can an agent discover and use this?" Specifically:
 
 ## Publishing to npm
 
-Publishing is automated via GitHub Actions (`.github/workflows/publish.yml`) and triggered by **GitHub Releases with specific tag prefixes**:
+**Not yet configured for this repo.** The CI workflows were carried over from the original arkeon repo but npm trusted publishing (OIDC) is scoped per-repo. Before publishing from arkeon-wiki:
 
-- `arkeon-v<version>` → publishes `arkeon` to npm (e.g., `arkeon-v0.3.6`)
-- `sdk-v<version>` → publishes `@arkeon-technologies/sdk` to npm (e.g., `sdk-v0.1.11`)
+1. Decide on a package name (the original `arkeon` name belongs to the upstream repo)
+2. Configure OIDC trusted publishing on npmjs.com for `Arkeon-Technologies/arkeon-wiki`
+3. Update `packages/arkeon/package.json` with the new package name
+4. Update `.github/workflows/publish.yml` tag prefixes if needed
 
-Tags like `v0.3.6` (without the `arkeon-` prefix) will NOT trigger a publish. The workflow uses npm trusted publishing (OIDC) — no token needed.
-
-### Release checklist
-
-1. Bump `version` in `packages/arkeon/package.json` (or `packages/sdk-ts/package.json` for SDK)
-2. Commit and push to main
-3. Create a GitHub release with the correct tag prefix:
-   ```bash
-   gh release create arkeon-v0.3.6 --title "arkeon v0.3.6" --generate-notes
-   ```
-4. The publish workflow runs automatically — check Actions to confirm
-5. Verify on npm: `npm view arkeon version`
-
-Do NOT create releases with bare `v*` tags — they won't publish.
+Until then, `npm pack` locally for testing.

--- a/packages/arkeon/src/server/lib/wiki-pipeline.ts
+++ b/packages/arkeon/src/server/lib/wiki-pipeline.ts
@@ -9,7 +9,7 @@
 
 import type { Actor } from "../types";
 import type { SqlClient } from "./sql";
-import { withTransaction } from "./sql";
+import { createSql, withTransaction } from "./sql";
 import { setActorContext } from "./actor-context";
 import { generateUlid } from "./ids";
 import { isLlmConfigured } from "./llm";
@@ -22,14 +22,22 @@ import { resolveLinks } from "./wiki-resolve";
 type PlaceholderStatus = "placeholder" | "assigned";
 
 export interface WikiContentResult {
-  /** Content with all links replaced by [[entity:ULID]] */
+  /** Content with all links replaced by [[entity:ULID]]. When mintInTransaction=false,
+   *  this only includes entity/resolve replacements — call applyLinkReplacements with
+   *  pendingReplacements + mintResult.replacements to get the final content. */
   resolvedContent: string;
-  /** Placeholders minted during this run */
+  /** Placeholders minted during this run (empty when mintInTransaction=false) */
   placeholders: Array<{ id: string; label: string; status: PlaceholderStatus }>;
-  /** Relationship targets to create */
+  /** Relationship targets to create (excludes pending-mint targets when mintInTransaction=false) */
   targets: LinkTarget[];
   /** Warnings from resolve: links that fell back */
   resolveWarnings: Array<{ label: string; reason: "llm_not_configured" | "no_match" }>;
+  /** Present only when mintInTransaction=false — call mintPlaceholders yourself */
+  pendingMints?: PendingMint[];
+  /** Raw replacements from entity/resolve link resolution. Present only when
+   *  mintInTransaction=false. Combine with mintResult.replacements and call
+   *  applyLinkReplacements(originalContent, combined) for final content. */
+  _replacements?: Array<{ offset: number; length: number; value: string }>;
 }
 
 export interface LinkTarget {
@@ -57,8 +65,13 @@ const REL_PREDICATE_REFERENCES = "references";
 
 /**
  * Process wiki content: parse links, validate entity refs, resolve via
- * LLM, mint placeholders, queue assign links. Returns the resolved
- * content and all side-effect records.
+ * LLM. Does NOT mint placeholders — returns a plan with pending mints.
+ * Call {@link mintPlaceholders} inside your own transaction to create them.
+ *
+ * For convenience, passing `mintInTransaction: true` (the default) mints
+ * placeholders in a standalone transaction. Pass `false` and call
+ * `mintPlaceholders` yourself when you need atomicity with other writes
+ * (e.g. the POST handler's wiki insert).
  */
 export async function processWikiContent(params: {
   actor: Actor;
@@ -66,8 +79,13 @@ export async function processWikiContent(params: {
   content: string;
   depth: number;
   maxDepth: number;
+  /** When true (default), placeholders are minted in a standalone txn.
+   *  Set false and call mintPlaceholders yourself for atomicity. */
+  mintInTransaction?: boolean;
 }): Promise<WikiContentResult> {
   const { actor, spaceId, content, depth, maxDepth } = params;
+  const autoMint = params.mintInTransaction !== false;
+  const sql = createSql();
 
   // Parse links
   let links: ParsedLink[];
@@ -89,7 +107,7 @@ export async function processWikiContent(params: {
   const canonicalEntityIds = new Map<string, string>();
   if (entityLinks.length > 0) {
     for (const link of entityLinks) {
-      const canonicalId = await resolveVisibleEntityId(actor, link.id!);
+      const canonicalId = await resolveVisibleEntityId(sql, actor, link.id!);
       if (!canonicalId) {
         throw new ApiError(404, "not_found", `Entity ${link.id} not found or not visible`);
       }
@@ -134,51 +152,35 @@ export async function processWikiContent(params: {
     }
   }
 
-  // Mint placeholders for placeholder: and assign: links
-  const placeholders: Array<{ id: string; label: string; status: PlaceholderStatus }> = [];
-  const placeholderLinks: Array<{ id: string; link: ParsedLink }> = [];
-  const now = new Date().toISOString();
-
-  const stage1Mints: Array<{ link: ParsedLink; status: PlaceholderStatus }> = [
+  // Build pending placeholder mints
+  const pendingMints: PendingMint[] = [
     ...placeholderLinksIn.map((link) => ({ link, status: "placeholder" as const })),
     ...assignLinksIn.map((link) => ({ link, status: "assigned" as const })),
   ];
 
-  if (stage1Mints.length > 0) {
+  // Collect unresolved resolve: links as pending unqueued placeholders
+  const unresolvedLinks: ParsedLink[] = [];
+  for (const r of resolved) {
+    if (!r.entityId) {
+      unresolvedLinks.push(r.link);
+    }
+  }
+  for (const link of unresolvedLinks) {
+    pendingMints.push({ link, status: "placeholder" });
+  }
+
+  // Mint placeholders (auto or deferred)
+  const placeholders: Array<{ id: string; label: string; status: PlaceholderStatus }> = [];
+  const placeholderLinks: Array<{ id: string; link: ParsedLink }> = [];
+
+  if (pendingMints.length > 0 && autoMint) {
     await withTransaction(async (tx) => {
-      for (const q of setActorContext(tx, actor)) await q;
-
-      for (const { link, status } of stage1Mints) {
-        const phId = generateUlid();
-        const phProps = { label: link.label, description: link.description ?? null, status };
-
-        await tx`
-          INSERT INTO entities (
-            id, kind, type, ver, properties, owner_id,
-            edited_by, note, created_at, updated_at
-          ) VALUES (
-            ${phId}, 'entity', 'placeholder', 1, ${phProps}::jsonb, ${actor.id},
-            ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
-          )
-        `;
-
-        await tx`
-          INSERT INTO space_entities (space_id, entity_id, added_by, added_at)
-          VALUES (${spaceId}, ${phId}, ${actor.id}, ${now}::timestamptz)
-          ON CONFLICT (space_id, entity_id) DO NOTHING
-        `;
-
-        if (status === "assigned") {
-          await tx`
-            INSERT INTO wiki_draft_queue (entity_id, depth, owner_agent, deadline, status, created_at)
-            VALUES (${phId}, ${depth + 1}, ${actor.id}, ${new Date(Date.now() + 3600_000).toISOString()}::timestamptz, 'pending', ${now}::timestamptz)
-          `;
-        }
-
-        placeholders.push({ id: phId, label: link.label ?? "", status });
-        placeholderLinks.push({ id: phId, link });
-        replacements.push({ offset: link.offset, length: link.length, value: `[[entity:${phId}]]` });
-      }
+      const result = await mintPlaceholders(tx, {
+        actor, spaceId, depth, mints: pendingMints,
+      });
+      placeholders.push(...result.placeholders);
+      placeholderLinks.push(...result.placeholderLinks);
+      replacements.push(...result.replacements);
     });
   }
 
@@ -194,7 +196,7 @@ export async function processWikiContent(params: {
     });
   }
 
-  // Placeholder/assign links
+  // Placeholder/assign links (only if minted)
   for (const pl of placeholderLinks) {
     targets.push({
       targetId: pl.id,
@@ -204,54 +206,105 @@ export async function processWikiContent(params: {
   }
 
   // Resolved links
-  const unresolvedLinks: ParsedLink[] = [];
   for (const r of resolved) {
     if (r.entityId) {
       targets.push({ targetId: r.entityId, predicate: REL_PREDICATE_REFERENCES, spanText: r.link.spanText });
       replacements.push({ offset: r.link.offset, length: r.link.length, value: `[[entity:${r.entityId}]]` });
-    } else {
-      unresolvedLinks.push(r.link);
     }
   }
 
-  // Unresolved resolve: links → unqueued placeholders
-  if (unresolvedLinks.length > 0) {
-    const minted = await withTransaction(async (tx) => {
-      for (const q of setActorContext(tx, actor)) await q;
-      const result: Array<{ id: string; label: string; status: PlaceholderStatus }> = [];
+  // Deduplicate targets — if the same entity is linked multiple times,
+  // keep the last occurrence's spanText (last-write-wins).
+  const deduped = new Map<string, LinkTarget>();
+  for (const t of targets) {
+    deduped.set(`${t.targetId}:${t.predicate}`, t);
+  }
+  const dedupedTargets = [...deduped.values()];
 
-      for (const link of unresolvedLinks) {
-        const phId = generateUlid();
-        const phProps = { label: link.label, description: link.description ?? null, status: "placeholder" };
-
-        await tx`
-          INSERT INTO entities (
-            id, kind, type, ver, properties, owner_id,
-            edited_by, note, created_at, updated_at
-          ) VALUES (
-            ${phId}, 'entity', 'placeholder', 1, ${phProps}::jsonb, ${actor.id},
-            ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
-          )
-        `;
-
-        await tx`
-          INSERT INTO space_entities (space_id, entity_id, added_by, added_at)
-          VALUES (${spaceId}, ${phId}, ${actor.id}, ${now}::timestamptz)
-          ON CONFLICT (space_id, entity_id) DO NOTHING
-        `;
-
-        targets.push({ targetId: phId, predicate: REL_PREDICATE_REFERENCES, spanText: link.spanText });
-        result.push({ id: phId, label: link.label ?? "", status: "placeholder" });
-        replacements.push({ offset: link.offset, length: link.length, value: `[[entity:${phId}]]` });
-      }
-      return result;
-    });
-    placeholders.push(...minted);
+  if (autoMint) {
+    // All replacements (entity + resolve + mint) are in the array — apply them all
+    const resolvedContent = applyLinkReplacements(content, replacements);
+    return { resolvedContent, placeholders, targets: dedupedTargets, resolveWarnings };
   }
 
-  const resolvedContent = applyLinkReplacements(content, replacements);
+  // Deferred minting: return the raw replacements so the caller can combine
+  // them with mintResult.replacements and apply in one pass.
+  return {
+    resolvedContent: content, // not yet resolved — caller must apply replacements
+    placeholders,
+    targets: dedupedTargets,
+    resolveWarnings,
+    pendingMints,
+    _replacements: replacements,
+  };
+}
 
-  return { resolvedContent, placeholders, targets, resolveWarnings };
+// ── Placeholder minting ──────────────────────────────────────────
+
+export interface PendingMint {
+  link: ParsedLink;
+  status: PlaceholderStatus;
+}
+
+interface MintResult {
+  placeholders: Array<{ id: string; label: string; status: PlaceholderStatus }>;
+  placeholderLinks: Array<{ id: string; link: ParsedLink }>;
+  replacements: Array<{ offset: number; length: number; value: string }>;
+}
+
+/**
+ * Mint placeholder entities inside a caller-provided transaction.
+ * This lets the POST handler include minting in the same transaction
+ * as the wiki insert for atomicity.
+ */
+export async function mintPlaceholders(
+  tx: SqlClient,
+  params: {
+    actor: Actor;
+    spaceId: string;
+    depth: number;
+    mints: PendingMint[];
+  },
+): Promise<MintResult> {
+  const { actor, spaceId, depth, mints } = params;
+  const now = new Date().toISOString();
+  const placeholders: MintResult["placeholders"] = [];
+  const placeholderLinks: MintResult["placeholderLinks"] = [];
+  const replacements: MintResult["replacements"] = [];
+
+  for (const { link, status } of mints) {
+    const phId = generateUlid();
+    const phProps = { label: link.label, description: link.description ?? null, status };
+
+    await tx`
+      INSERT INTO entities (
+        id, kind, type, ver, properties, owner_id,
+        edited_by, note, created_at, updated_at
+      ) VALUES (
+        ${phId}, 'entity', 'placeholder', 1, ${phProps}::jsonb, ${actor.id},
+        ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
+      )
+    `;
+
+    await tx`
+      INSERT INTO space_entities (space_id, entity_id, added_by, added_at)
+      VALUES (${spaceId}, ${phId}, ${actor.id}, ${now}::timestamptz)
+      ON CONFLICT (space_id, entity_id) DO NOTHING
+    `;
+
+    if (status === "assigned") {
+      await tx`
+        INSERT INTO wiki_draft_queue (entity_id, depth, owner_agent, deadline, status, created_at)
+        VALUES (${phId}, ${depth + 1}, ${actor.id}, ${new Date(Date.now() + 3600_000).toISOString()}::timestamptz, 'pending', ${now}::timestamptz)
+      `;
+    }
+
+    placeholders.push({ id: phId, label: link.label ?? "", status });
+    placeholderLinks.push({ id: phId, link });
+    replacements.push({ offset: link.offset, length: link.length, value: `[[entity:${phId}]]` });
+  }
+
+  return { placeholders, placeholderLinks, replacements };
 }
 
 // ── Relationship management ────────────────────────────────────────
@@ -465,11 +518,10 @@ export function applyLinkReplacements(
  * Follow entity redirects to find the canonical visible entity ID.
  */
 export async function resolveVisibleEntityId(
+  sql: SqlClient,
   actor: Actor,
   id: string,
 ): Promise<string | null> {
-  const { createSql } = await import("./sql");
-  const sql = createSql();
   let current = id;
   const seen = new Set<string>();
 

--- a/packages/arkeon/src/server/lib/wiki-pipeline.ts
+++ b/packages/arkeon/src/server/lib/wiki-pipeline.ts
@@ -1,0 +1,493 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared wiki content pipeline — link parsing, resolution, placeholder
+ * minting, relationship management. Used by both POST /wiki (create) and
+ * PUT /wiki/{id} (update).
+ */
+
+import type { Actor } from "../types";
+import type { SqlClient } from "./sql";
+import { withTransaction } from "./sql";
+import { setActorContext } from "./actor-context";
+import { generateUlid } from "./ids";
+import { isLlmConfigured } from "./llm";
+import { ApiError } from "./errors";
+import { parseWikiLinks, WikiLinkParseError, type ParsedLink } from "./wiki-links";
+import { resolveLinks } from "./wiki-resolve";
+
+// ── Types ──────────────────────────────────────────────────────────
+
+type PlaceholderStatus = "placeholder" | "assigned";
+
+export interface WikiContentResult {
+  /** Content with all links replaced by [[entity:ULID]] */
+  resolvedContent: string;
+  /** Placeholders minted during this run */
+  placeholders: Array<{ id: string; label: string; status: PlaceholderStatus }>;
+  /** Relationship targets to create */
+  targets: LinkTarget[];
+  /** Warnings from resolve: links that fell back */
+  resolveWarnings: Array<{ label: string; reason: "llm_not_configured" | "no_match" }>;
+}
+
+export interface LinkTarget {
+  targetId: string;
+  predicate: string;
+  spanText: string;
+}
+
+export interface ExistingRelationship {
+  id: string;
+  targetId: string;
+  predicate: string;
+  spanText: string;
+}
+
+export interface RelationshipDiff {
+  toUpdate: Array<{ id: string; spanText: string }>;
+  toCreate: LinkTarget[];
+  toDelete: string[]; // relationship entity IDs
+}
+
+const REL_PREDICATE_REFERENCES = "references";
+
+// ── Content processing ─────────────────────────────────────────────
+
+/**
+ * Process wiki content: parse links, validate entity refs, resolve via
+ * LLM, mint placeholders, queue assign links. Returns the resolved
+ * content and all side-effect records.
+ */
+export async function processWikiContent(params: {
+  actor: Actor;
+  spaceId: string;
+  content: string;
+  depth: number;
+  maxDepth: number;
+}): Promise<WikiContentResult> {
+  const { actor, spaceId, content, depth, maxDepth } = params;
+
+  // Parse links
+  let links: ParsedLink[];
+  try {
+    links = parseWikiLinks(content, depth, maxDepth);
+  } catch (err) {
+    if (err instanceof WikiLinkParseError) {
+      throw new ApiError(400, "malformed_wiki_links", "Malformed wiki links", {
+        links: err.details,
+      });
+    }
+    throw err;
+  }
+
+  const replacements: Array<{ offset: number; length: number; value: string }> = [];
+
+  // Validate entity: links
+  const entityLinks = links.filter((l) => l.type === "entity");
+  const canonicalEntityIds = new Map<string, string>();
+  if (entityLinks.length > 0) {
+    for (const link of entityLinks) {
+      const canonicalId = await resolveVisibleEntityId(actor, link.id!);
+      if (!canonicalId) {
+        throw new ApiError(404, "not_found", `Entity ${link.id} not found or not visible`);
+      }
+      canonicalEntityIds.set(link.id!, canonicalId);
+      if (canonicalId !== link.id) {
+        replacements.push({ offset: link.offset, length: link.length, value: `[[entity:${canonicalId}]]` });
+      }
+    }
+  }
+
+  // Categorize links
+  const placeholderLinksIn = links.filter((l) => l.type === "placeholder");
+  const assignLinksIn = links.filter((l) => l.type === "assign");
+  const resolveLinksArr = links.filter((l) => l.type === "resolve");
+
+  // Resolve resolve: links
+  const resolveWarnings: Array<{ label: string; reason: "llm_not_configured" | "no_match" }> = [];
+  let resolved: Awaited<ReturnType<typeof resolveLinks>>;
+
+  if (resolveLinksArr.length > 0 && !isLlmConfigured()) {
+    resolved = resolveLinksArr.map((link) => ({ link, entityId: null, confidence: 0 }));
+    for (const link of resolveLinksArr) {
+      resolveWarnings.push({ label: link.label ?? "", reason: "llm_not_configured" });
+    }
+  } else {
+    try {
+      resolved = await resolveLinks(resolveLinksArr, actor, spaceId);
+    } catch (err) {
+      if ((err as Error).message.includes("LLM configuration missing")) {
+        resolved = resolveLinksArr.map((link) => ({ link, entityId: null, confidence: 0 }));
+        for (const link of resolveLinksArr) {
+          resolveWarnings.push({ label: link.label ?? "", reason: "llm_not_configured" });
+        }
+      } else {
+        throw err;
+      }
+    }
+    for (const r of resolved) {
+      if (!r.entityId && !resolveWarnings.some((w) => w.label === (r.link.label ?? ""))) {
+        resolveWarnings.push({ label: r.link.label ?? "", reason: "no_match" });
+      }
+    }
+  }
+
+  // Mint placeholders for placeholder: and assign: links
+  const placeholders: Array<{ id: string; label: string; status: PlaceholderStatus }> = [];
+  const placeholderLinks: Array<{ id: string; link: ParsedLink }> = [];
+  const now = new Date().toISOString();
+
+  const stage1Mints: Array<{ link: ParsedLink; status: PlaceholderStatus }> = [
+    ...placeholderLinksIn.map((link) => ({ link, status: "placeholder" as const })),
+    ...assignLinksIn.map((link) => ({ link, status: "assigned" as const })),
+  ];
+
+  if (stage1Mints.length > 0) {
+    await withTransaction(async (tx) => {
+      for (const q of setActorContext(tx, actor)) await q;
+
+      for (const { link, status } of stage1Mints) {
+        const phId = generateUlid();
+        const phProps = { label: link.label, description: link.description ?? null, status };
+
+        await tx`
+          INSERT INTO entities (
+            id, kind, type, ver, properties, owner_id,
+            edited_by, note, created_at, updated_at
+          ) VALUES (
+            ${phId}, 'entity', 'placeholder', 1, ${phProps}::jsonb, ${actor.id},
+            ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
+          )
+        `;
+
+        await tx`
+          INSERT INTO space_entities (space_id, entity_id, added_by, added_at)
+          VALUES (${spaceId}, ${phId}, ${actor.id}, ${now}::timestamptz)
+          ON CONFLICT (space_id, entity_id) DO NOTHING
+        `;
+
+        if (status === "assigned") {
+          await tx`
+            INSERT INTO wiki_draft_queue (entity_id, depth, owner_agent, deadline, status, created_at)
+            VALUES (${phId}, ${depth + 1}, ${actor.id}, ${new Date(Date.now() + 3600_000).toISOString()}::timestamptz, 'pending', ${now}::timestamptz)
+          `;
+        }
+
+        placeholders.push({ id: phId, label: link.label ?? "", status });
+        placeholderLinks.push({ id: phId, link });
+        replacements.push({ offset: link.offset, length: link.length, value: `[[entity:${phId}]]` });
+      }
+    });
+  }
+
+  // Build relationship targets
+  const targets: LinkTarget[] = [];
+
+  // Entity links
+  for (const link of entityLinks) {
+    targets.push({
+      targetId: canonicalEntityIds.get(link.id!) ?? link.id!,
+      predicate: REL_PREDICATE_REFERENCES,
+      spanText: link.spanText,
+    });
+  }
+
+  // Placeholder/assign links
+  for (const pl of placeholderLinks) {
+    targets.push({
+      targetId: pl.id,
+      predicate: REL_PREDICATE_REFERENCES,
+      spanText: pl.link.spanText,
+    });
+  }
+
+  // Resolved links
+  const unresolvedLinks: ParsedLink[] = [];
+  for (const r of resolved) {
+    if (r.entityId) {
+      targets.push({ targetId: r.entityId, predicate: REL_PREDICATE_REFERENCES, spanText: r.link.spanText });
+      replacements.push({ offset: r.link.offset, length: r.link.length, value: `[[entity:${r.entityId}]]` });
+    } else {
+      unresolvedLinks.push(r.link);
+    }
+  }
+
+  // Unresolved resolve: links → unqueued placeholders
+  if (unresolvedLinks.length > 0) {
+    const minted = await withTransaction(async (tx) => {
+      for (const q of setActorContext(tx, actor)) await q;
+      const result: Array<{ id: string; label: string; status: PlaceholderStatus }> = [];
+
+      for (const link of unresolvedLinks) {
+        const phId = generateUlid();
+        const phProps = { label: link.label, description: link.description ?? null, status: "placeholder" };
+
+        await tx`
+          INSERT INTO entities (
+            id, kind, type, ver, properties, owner_id,
+            edited_by, note, created_at, updated_at
+          ) VALUES (
+            ${phId}, 'entity', 'placeholder', 1, ${phProps}::jsonb, ${actor.id},
+            ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
+          )
+        `;
+
+        await tx`
+          INSERT INTO space_entities (space_id, entity_id, added_by, added_at)
+          VALUES (${spaceId}, ${phId}, ${actor.id}, ${now}::timestamptz)
+          ON CONFLICT (space_id, entity_id) DO NOTHING
+        `;
+
+        targets.push({ targetId: phId, predicate: REL_PREDICATE_REFERENCES, spanText: link.spanText });
+        result.push({ id: phId, label: link.label ?? "", status: "placeholder" });
+        replacements.push({ offset: link.offset, length: link.length, value: `[[entity:${phId}]]` });
+      }
+      return result;
+    });
+    placeholders.push(...minted);
+  }
+
+  const resolvedContent = applyLinkReplacements(content, replacements);
+
+  return { resolvedContent, placeholders, targets, resolveWarnings };
+}
+
+// ── Relationship management ────────────────────────────────────────
+
+/**
+ * Fetch existing "references" relationships from a wiki entity.
+ */
+export async function fetchWikiReferences(
+  actor: Actor,
+  wikiId: string,
+): Promise<ExistingRelationship[]> {
+  const rows = await withTransaction(async (tx) => {
+    for (const q of setActorContext(tx, actor)) await q;
+    return tx`
+      SELECT re.id, re.target_id, re.predicate, e.properties
+      FROM relationship_edges re
+      JOIN entities e ON e.id = re.id
+      WHERE re.source_id = ${wikiId} AND re.predicate = ${REL_PREDICATE_REFERENCES}
+    `;
+  });
+
+  return rows.map((row) => ({
+    id: String(row.id),
+    targetId: String(row.target_id),
+    predicate: String(row.predicate),
+    spanText: ((row.properties as Record<string, unknown>)?.span_text as string) ?? "",
+  }));
+}
+
+/**
+ * Diff existing relationships against new targets.
+ * - Kept (same target_id + predicate): update span_text
+ * - New (target not in existing): create
+ * - Removed (existing target not in new): delete
+ */
+export function diffWikiReferences(
+  existing: ExistingRelationship[],
+  newTargets: LinkTarget[],
+): RelationshipDiff {
+  const existingByTarget = new Map<string, ExistingRelationship>();
+  for (const rel of existing) {
+    existingByTarget.set(`${rel.targetId}:${rel.predicate}`, rel);
+  }
+
+  const newByTarget = new Set<string>();
+  const toUpdate: Array<{ id: string; spanText: string }> = [];
+  const toCreate: LinkTarget[] = [];
+
+  for (const target of newTargets) {
+    const key = `${target.targetId}:${target.predicate}`;
+    newByTarget.add(key);
+    const existingRel = existingByTarget.get(key);
+    if (existingRel) {
+      // Existing relationship — update span_text
+      toUpdate.push({ id: existingRel.id, spanText: target.spanText });
+    } else {
+      // New relationship
+      toCreate.push(target);
+    }
+  }
+
+  // Relationships no longer in the new set
+  const toDelete: string[] = [];
+  for (const rel of existing) {
+    const key = `${rel.targetId}:${rel.predicate}`;
+    if (!newByTarget.has(key)) {
+      toDelete.push(rel.id);
+    }
+  }
+
+  return { toUpdate, toCreate, toDelete };
+}
+
+/**
+ * Apply a relationship diff: update span_text on kept relationships,
+ * create new ones, delete removed ones.
+ */
+export async function applyRelationshipDiff(params: {
+  actor: Actor;
+  wikiId: string;
+  spaceId: string;
+  diff: RelationshipDiff;
+  now: string;
+}): Promise<{ created: number; updated: number; deleted: string[] }> {
+  const { actor, wikiId, spaceId, diff, now } = params;
+
+  return withTransaction(async (tx) => {
+    for (const q of setActorContext(tx, actor)) await q;
+
+    // Update existing relationships' span_text
+    for (const { id, spanText } of diff.toUpdate) {
+      const props = spanText ? { span_text: spanText } : {};
+      await tx`
+        UPDATE entities
+        SET properties = ${props}::jsonb,
+            updated_at = ${now}::timestamptz
+        WHERE id = ${id}
+      `;
+    }
+
+    // Create new relationships
+    for (const t of diff.toCreate) {
+      const relId = generateUlid();
+      const relProps = t.spanText ? { span_text: t.spanText } : {};
+
+      await tx`
+        INSERT INTO entities (
+          id, kind, type, ver, properties, owner_id,
+          edited_by, note, created_at, updated_at
+        ) VALUES (
+          ${relId}, 'relationship', 'relationship', 1, ${relProps}::jsonb,
+          ${actor.id},
+          ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
+        )
+      `;
+
+      await tx`
+        INSERT INTO relationship_edges (id, source_id, target_id, predicate)
+        VALUES (${relId}, ${wikiId}, ${t.targetId}, ${t.predicate})
+      `;
+
+      await tx`
+        INSERT INTO space_entities (space_id, entity_id, added_by, added_at)
+        VALUES (${spaceId}, ${relId}, ${actor.id}, ${now}::timestamptz)
+        ON CONFLICT (space_id, entity_id) DO NOTHING
+      `;
+    }
+
+    // Delete removed relationships (cascade handles edges + space_entities)
+    const deletedIds: string[] = [];
+    for (const id of diff.toDelete) {
+      await tx`DELETE FROM entities WHERE id = ${id}`;
+      deletedIds.push(id);
+    }
+
+    return { created: diff.toCreate.length, updated: diff.toUpdate.length, deleted: deletedIds };
+  });
+}
+
+/**
+ * Create all relationships for a newly created wiki (no diffing needed).
+ */
+export async function createWikiReferences(params: {
+  actor: Actor;
+  wikiId: string;
+  spaceId: string;
+  targets: LinkTarget[];
+  now: string;
+}): Promise<number> {
+  const { actor, wikiId, spaceId, targets, now } = params;
+  if (targets.length === 0) return 0;
+
+  return withTransaction(async (tx) => {
+    for (const q of setActorContext(tx, actor)) await q;
+    let count = 0;
+
+    for (const t of targets) {
+      const relId = generateUlid();
+      const relProps = t.spanText ? { span_text: t.spanText } : {};
+
+      await tx`
+        INSERT INTO entities (
+          id, kind, type, ver, properties, owner_id,
+          edited_by, note, created_at, updated_at
+        ) VALUES (
+          ${relId}, 'relationship', 'relationship', 1, ${relProps}::jsonb,
+          ${actor.id},
+          ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
+        )
+      `;
+
+      await tx`
+        INSERT INTO relationship_edges (id, source_id, target_id, predicate)
+        VALUES (${relId}, ${wikiId}, ${t.targetId}, ${t.predicate})
+      `;
+
+      await tx`
+        INSERT INTO space_entities (space_id, entity_id, added_by, added_at)
+        VALUES (${spaceId}, ${relId}, ${actor.id}, ${now}::timestamptz)
+        ON CONFLICT (space_id, entity_id) DO NOTHING
+      `;
+
+      count++;
+    }
+
+    return count;
+  });
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+/**
+ * Apply link replacements to content, processing from end to start
+ * so offsets remain valid.
+ */
+export function applyLinkReplacements(
+  content: string,
+  replacements: Array<{ offset: number; length: number; value: string }>,
+): string {
+  if (replacements.length === 0) return content;
+  let rewritten = content;
+  for (const replacement of [...replacements].sort((a, b) => b.offset - a.offset)) {
+    rewritten = rewritten.slice(0, replacement.offset) +
+      replacement.value +
+      rewritten.slice(replacement.offset + replacement.length);
+  }
+  return rewritten;
+}
+
+/**
+ * Follow entity redirects to find the canonical visible entity ID.
+ */
+export async function resolveVisibleEntityId(
+  actor: Actor,
+  id: string,
+): Promise<string | null> {
+  const { createSql } = await import("./sql");
+  const sql = createSql();
+  let current = id;
+  const seen = new Set<string>();
+
+  for (let i = 0; i < 10; i++) {
+    if (seen.has(current)) return null;
+    seen.add(current);
+
+    const found = await withTransaction(async (tx) => {
+      for (const q of setActorContext(tx, actor)) await q;
+      return tx`SELECT id FROM entities WHERE id = ${current} AND kind = 'entity' LIMIT 1`;
+    });
+    if (found.length > 0) return current;
+
+    const redirectRows = await sql`SELECT new_id FROM entity_redirects WHERE old_id = ${current} LIMIT 1`;
+    const redirect = redirectRows[0] as { new_id?: string } | undefined;
+    if (!redirect?.new_id) return null;
+    current = String(redirect.new_id);
+  }
+
+  return null;
+}

--- a/packages/arkeon/src/server/routes/entities.ts
+++ b/packages/arkeon/src/server/routes/entities.ts
@@ -550,6 +550,7 @@ wikisRouter.openapi(updateEntityRoute, async (c) => {
 
   let pipelineResult: Awaited<ReturnType<typeof processWikiContent>> | null = null;
   let mergeProperties = properties;
+  let pipelineSpaceId: string | null = null;
 
   if (hasContentUpdate) {
     // Fetch current entity to check if content actually changed and get space_id
@@ -563,15 +564,15 @@ wikisRouter.openapi(updateEntityRoute, async (c) => {
     if (currentContent !== newContent) {
       // Look up which space this wiki belongs to
       const spaceRows = await sql`SELECT space_id FROM space_entities WHERE entity_id = ${entityId} LIMIT 1`;
-      const spaceId = spaceRows[0]?.space_id as string | undefined;
-      if (!spaceId) {
+      pipelineSpaceId = (spaceRows[0]?.space_id as string) ?? null;
+      if (!pipelineSpaceId) {
         throw new ApiError(500, "internal_error", "Wiki has no space assignment");
       }
 
       // Run the wiki link pipeline on the new content
       pipelineResult = await processWikiContent({
         actor,
-        spaceId,
+        spaceId: pipelineSpaceId,
         content: newContent,
         depth: 0,
         maxDepth: 2,
@@ -668,16 +669,13 @@ wikisRouter.openapi(updateEntityRoute, async (c) => {
   backgroundTask(indexEntity(updated));
 
   // If content was processed through the pipeline, diff and apply relationship changes
-  if (pipelineResult) {
-    const spaceRows = await sql`SELECT space_id FROM space_entities WHERE entity_id = ${entityId} LIMIT 1`;
-    const spaceId = spaceRows[0]!.space_id as string;
-
+  if (pipelineResult && pipelineSpaceId) {
     const existingRefs = await fetchWikiReferences(actor, entityId);
     const diff = diffWikiReferences(existingRefs, pipelineResult.targets);
     const relResult = await applyRelationshipDiff({
       actor,
       wikiId: entityId,
-      spaceId,
+      spaceId: pipelineSpaceId,
       diff,
       now,
     });

--- a/packages/arkeon/src/server/routes/entities.ts
+++ b/packages/arkeon/src/server/routes/entities.ts
@@ -43,6 +43,12 @@ import {
 } from "../lib/schemas";
 import { setActorContext } from "../lib/actor-context";
 import { createSql } from "../lib/sql";
+import {
+  processWikiContent,
+  fetchWikiReferences,
+  diffWikiReferences,
+  applyRelationshipDiff,
+} from "../lib/wiki-pipeline";
 
 type VersionRow = {
   entity_id?: string;
@@ -147,7 +153,7 @@ const updateEntityRoute = createRoute({
   summary: "Update entity properties",
   "x-arke-auth": "required",
   "x-arke-related": ["GET /wiki/{id}", "GET /wiki/{id}/versions"],
-  "x-arke-rules": ["Only the owner or an admin may update", "Optimistic concurrency: must pass current ver to update", "Properties are shallow-merged: only provided keys are updated, omitted keys are preserved", "remove_properties deletes keys by name after the merge, so removals take precedence over additions"],
+  "x-arke-rules": ["Only the owner or an admin may update", "Optimistic concurrency: must pass current ver to update", "Properties are shallow-merged: only provided keys are updated, omitted keys are preserved", "remove_properties deletes keys by name after the merge, so removals take precedence over additions", "When properties.content is updated on a wiki, typed [[links]] are parsed and resolved — new placeholders are minted, relationships are created/updated/removed, and [[assign:...]] links are queued for background drafting"],
   request: {
     params: entityIdParams(),
     body: {
@@ -164,8 +170,26 @@ const updateEntityRoute = createRoute({
   },
   responses: {
     200: {
-      description: "Entity updated",
-      content: jsonContent(EntityResponse),
+      description: "Entity updated. When content contains wiki links that were processed, includes placeholders, relationships_created, and resolve_warnings.",
+      content: jsonContent(z.object({
+        entity: EntitySchema,
+        placeholders: z.array(
+          z.object({
+            id: EntityIdParam,
+            label: z.string(),
+            status: z.enum(["placeholder", "assigned"]),
+          }),
+        ).optional().describe("Placeholders minted from wiki links in updated content. Only present when content was processed through the wiki link pipeline."),
+        relationships_created: z.number().int().optional().describe("Number of new reference relationships created. Only present when content was processed."),
+        relationships_updated: z.number().int().optional().describe("Number of existing reference relationships updated (span_text changed). Only present when content was processed."),
+        relationships_removed: z.number().int().optional().describe("Number of reference relationships removed (target no longer in content). Only present when content was processed."),
+        resolve_warnings: z.array(
+          z.object({
+            label: z.string(),
+            reason: z.enum(["llm_not_configured", "no_match"]),
+          }),
+        ).optional().describe("Emitted when [[resolve:...]] links soft-degrade to placeholders."),
+      })),
     },
     ...errorResponses([400, 401, 403, 404, 409]),
   },
@@ -520,11 +544,53 @@ wikisRouter.openapi(updateEntityRoute, async (c) => {
   const sql = createSql();
   const now = new Date().toISOString();
 
+  // Detect if content is being updated — triggers the wiki link pipeline
+  const newContent = properties?.content;
+  const hasContentUpdate = typeof newContent === "string" && newContent.length > 0;
+
+  let pipelineResult: Awaited<ReturnType<typeof processWikiContent>> | null = null;
+  let mergeProperties = properties;
+
+  if (hasContentUpdate) {
+    // Fetch current entity to check if content actually changed and get space_id
+    const currentRows = await sql.transaction([
+      ...setActorContext(sql, actor),
+      sql`SELECT properties FROM entities WHERE id = ${entityId} AND type = 'wiki' LIMIT 1`,
+    ]);
+    const currentEntity = (currentRows[currentRows.length - 1] as Array<{ properties: Record<string, unknown> }>)[0];
+    const currentContent = currentEntity?.properties?.content;
+
+    if (currentContent !== newContent) {
+      // Look up which space this wiki belongs to
+      const spaceRows = await sql`SELECT space_id FROM space_entities WHERE entity_id = ${entityId} LIMIT 1`;
+      const spaceId = spaceRows[0]?.space_id as string | undefined;
+      if (!spaceId) {
+        throw new ApiError(500, "internal_error", "Wiki has no space assignment");
+      }
+
+      // Run the wiki link pipeline on the new content
+      pipelineResult = await processWikiContent({
+        actor,
+        spaceId,
+        content: newContent,
+        depth: 0,
+        maxDepth: 2,
+      });
+
+      // Rewrite the properties to use resolved content + store submitted_content
+      mergeProperties = {
+        ...properties,
+        submitted_content: newContent,
+        content: pipelineResult.resolvedContent,
+      };
+    }
+  }
+
   // Build the properties expression:
   //   merge only:  properties || $merge
   //   remove only: properties - $keys
   //   both:        (properties || $merge) - $keys  (removals win)
-  const hasMerge = properties && Object.keys(properties).length > 0;
+  const hasMerge = mergeProperties && Object.keys(mergeProperties).length > 0;
   const hasRemove = removeProperties.length > 0;
   let propsExpr: string;
   const params: unknown[] = [];
@@ -532,11 +598,11 @@ wikisRouter.openapi(updateEntityRoute, async (c) => {
 
   if (hasMerge && hasRemove) {
     propsExpr = `(properties || $${paramIdx}::jsonb) - $${paramIdx + 1}::text[]`;
-    params.push(JSON.stringify(properties), removeProperties);
+    params.push(JSON.stringify(mergeProperties), removeProperties);
     paramIdx += 2;
   } else if (hasMerge) {
     propsExpr = `properties || $${paramIdx}::jsonb`;
-    params.push(JSON.stringify(properties));
+    params.push(JSON.stringify(mergeProperties));
     paramIdx += 1;
   } else {
     propsExpr = `properties - $${paramIdx}::text[]`;
@@ -600,6 +666,38 @@ wikisRouter.openapi(updateEntityRoute, async (c) => {
     ]).then(() => undefined).catch(console.error),
   );
   backgroundTask(indexEntity(updated));
+
+  // If content was processed through the pipeline, diff and apply relationship changes
+  if (pipelineResult) {
+    const spaceRows = await sql`SELECT space_id FROM space_entities WHERE entity_id = ${entityId} LIMIT 1`;
+    const spaceId = spaceRows[0]!.space_id as string;
+
+    const existingRefs = await fetchWikiReferences(actor, entityId);
+    const diff = diffWikiReferences(existingRefs, pipelineResult.targets);
+    const relResult = await applyRelationshipDiff({
+      actor,
+      wikiId: entityId,
+      spaceId,
+      diff,
+      now,
+    });
+
+    // Remove deleted relationship entities from Meilisearch
+    if (relResult.deleted.length > 0) {
+      backgroundTask(removeEntities(relResult.deleted));
+    }
+
+    return c.json({
+      entity: updated,
+      placeholders: pipelineResult.placeholders,
+      relationships_created: relResult.created,
+      relationships_updated: relResult.updated,
+      relationships_removed: relResult.deleted.length,
+      ...(pipelineResult.resolveWarnings.length > 0
+        ? { resolve_warnings: pipelineResult.resolveWarnings }
+        : {}),
+    }, 200);
+  }
 
   return c.json({ entity: updated }, 200);
 });

--- a/packages/arkeon/src/server/routes/wiki.ts
+++ b/packages/arkeon/src/server/routes/wiki.ts
@@ -22,7 +22,12 @@ import { withTransaction } from "../lib/sql";
 import { setActorContext } from "../lib/actor-context";
 import { indexEntity } from "../lib/meilisearch";
 import { backgroundTask } from "../lib/background";
-import { processWikiContent, createWikiReferences } from "../lib/wiki-pipeline";
+import {
+  processWikiContent,
+  createWikiReferences,
+  mintPlaceholders,
+  applyLinkReplacements,
+} from "../lib/wiki-pipeline";
 import {
   EntityIdParam,
   EntitySchema,
@@ -46,6 +51,8 @@ const WIKI_CONTENT_DESCRIPTION = [
   "Every parsed link materializes as a `references` relationship from the published wiki to the target (or to a newly-minted placeholder). The wiki page itself is the canonical graph entity for its subject.",
   "",
   "Choosing between resolve / placeholder / assign: use `resolve` when the thing probably already exists and you want the server to find it; use `placeholder` when you want a stub but don't want anything auto-drafted; use `assign` to hand off actual drafting to a background worker.",
+  "",
+  "After processing, the stored entity has two content fields: `properties.content` (resolved — all links rewritten to `[[entity:ULID]]`) and `properties.submitted_content` (the original input with unresolved link syntax preserved). The same applies when updating content via PUT.",
   "",
   "Caveat: the parser scans every `[[...]]` pair in the content, including inside fenced code blocks. To discuss link syntax in prose, use alternative delimiters (e.g. `<<entity:id>>`). See GET /help/guide/wiki for a worked example.",
 ].join("\n");
@@ -222,13 +229,19 @@ wikiRouter.openapi(createWikiRoute, async (c) => {
   const wikiId = generateUlid();
 
   // --- Process content through the wiki link pipeline ---
-  const { resolvedContent, placeholders, targets, resolveWarnings } = await processWikiContent({
+  // Use mintInTransaction=false so we can mint placeholders atomically
+  // with the wiki insert (if the insert fails, placeholders roll back).
+  const pipelineResult = await processWikiContent({
     actor,
     spaceId: space_id,
     content,
     depth,
     maxDepth: MAX_DEPTH,
+    mintInTransaction: false,
   });
+  const { targets, resolveWarnings, pendingMints, _replacements } = pipelineResult;
+  let { placeholders } = pipelineResult;
+
   const wikiProperties = {
     ...extraProperties,
     label,
@@ -241,7 +254,10 @@ wikiRouter.openapi(createWikiRoute, async (c) => {
     status: "draft",
   };
 
-  // Persist wiki as draft (Stage 1)
+  // Collect all replacements — entity/resolve from pipeline + mint from below
+  const allReplacements = [...(_replacements ?? [])];
+
+  // Persist wiki as draft + mint placeholders atomically (Stage 1)
   await withTransaction(async (tx) => {
     for (const q of setActorContext(tx, actor)) await q;
 
@@ -293,7 +309,27 @@ wikiRouter.openapi(createWikiRoute, async (c) => {
       VALUES (${space_id}, ${wikiId}, ${actor.id}, ${now}::timestamptz)
       ON CONFLICT (space_id, entity_id) DO NOTHING
     `;
+
+    // Mint placeholders inside the same transaction — if the wiki insert
+    // fails (e.g. 409 duplicate), placeholders roll back with it.
+    if (pendingMints && pendingMints.length > 0) {
+      const mintResult = await mintPlaceholders(tx, {
+        actor, spaceId: space_id, depth, mints: pendingMints,
+      });
+      placeholders = mintResult.placeholders;
+      allReplacements.push(...mintResult.replacements);
+      for (const pl of mintResult.placeholderLinks) {
+        targets.push({
+          targetId: pl.id,
+          predicate: "references",
+          spanText: pl.link.spanText,
+        });
+      }
+    }
   });
+
+  // Apply all replacements in a single pass over original content
+  const resolvedContent = applyLinkReplacements(content, allReplacements);
 
   // Create relationships (Stage 2)
   const relationshipsCreated = await createWikiReferences({

--- a/packages/arkeon/src/server/routes/wiki.ts
+++ b/packages/arkeon/src/server/routes/wiki.ts
@@ -15,16 +15,14 @@ import { createRoute, z } from "@hono/zod-openapi";
 
 import { requireActor, parseJsonBody } from "../lib/http";
 import { fetchSpaceForActor, resolveDefaultSpace } from "../lib/spaces";
-import { isLlmConfigured } from "../lib/llm";
 import { ApiError } from "../lib/errors";
 import { generateUlid } from "../lib/ids";
 import { createRouter } from "../lib/openapi";
-import { createSql, withTransaction } from "../lib/sql";
+import { withTransaction } from "../lib/sql";
 import { setActorContext } from "../lib/actor-context";
 import { indexEntity } from "../lib/meilisearch";
 import { backgroundTask } from "../lib/background";
-import { parseWikiLinks, WikiLinkParseError, type ParsedLink } from "../lib/wiki-links";
-import { resolveLinks } from "../lib/wiki-resolve";
+import { processWikiContent, createWikiReferences } from "../lib/wiki-pipeline";
 import {
   EntityIdParam,
   EntitySchema,
@@ -33,7 +31,6 @@ import {
 } from "../lib/schemas";
 
 const MAX_DEPTH = 2;
-const REL_PREDICATE_REFERENCES = "references";
 
 const WIKI_CONTENT_DESCRIPTION = [
   "Markdown body. Typed [[links]] in the content are parsed and turned into relationships when the wiki is published.",
@@ -161,7 +158,6 @@ export const wikiRouter = createRouter();
 wikiRouter.openapi(createWikiRoute, async (c) => {
   const actor = requireActor(c);
   const body = await parseJsonBody<Record<string, unknown>>(c);
-  const sql = createSql();
   const now = new Date().toISOString();
 
   const content = body.content as string;
@@ -223,85 +219,16 @@ wikiRouter.openapi(createWikiRoute, async (c) => {
     throw new ApiError(404, "not_found", "Space not found");
   }
 
-  // --- Parse links ---
-  let links: ParsedLink[];
-  try {
-    links = parseWikiLinks(content, depth, MAX_DEPTH);
-  } catch (err) {
-    if (err instanceof WikiLinkParseError) {
-      throw new ApiError(400, "malformed_wiki_links", "Malformed wiki links", {
-        links: err.details,
-      });
-    }
-    throw err;
-  }
-  const replacements: Array<{ offset: number; length: number; value: string }> = [];
-
-  // --- Validate entity: links exist ---
-  const entityLinks = links.filter((l) => l.type === "entity");
-  const canonicalEntityIds = new Map<string, string>();
-  if (entityLinks.length > 0) {
-    for (const link of entityLinks) {
-      const canonicalId = await resolveVisibleEntityId(sql, actor, link.id!);
-      if (!canonicalId) {
-        throw new ApiError(404, "not_found", `Entity ${link.id} not found or not visible`);
-      }
-      canonicalEntityIds.set(link.id!, canonicalId);
-      if (canonicalId !== link.id) {
-        replacements.push({ offset: link.offset, length: link.length, value: `[[entity:${canonicalId}]]` });
-      }
-    }
-  }
-
-  // --- Stage 1: Mint placeholders and persist draft wiki ---
-
-  const placeholderLinksIn = links.filter((l) => l.type === "placeholder");
-  const assignLinksIn = links.filter((l) => l.type === "assign");
-  const resolveLinksArr = links.filter((l) => l.type === "resolve");
-
-  // Resolve before Stage 1 writes anything. resolve: links soft-degrade to
-  // placeholders on any failure mode — LLM missing, no match, or judge error —
-  // so the wiki publishes with warnings rather than failing the whole request.
-  type PlaceholderStatus = "placeholder" | "assigned";
-  const resolveWarnings: Array<{ label: string; reason: "llm_not_configured" | "no_match" }> = [];
-  let resolved: Awaited<ReturnType<typeof resolveLinks>>;
-
-  if (resolveLinksArr.length > 0 && !isLlmConfigured()) {
-    // Server has no LLM — resolve: can't actually match anything, even if
-    // Meilisearch would return candidates. Emit llm_not_configured for every
-    // resolve: link and skip the resolver entirely. Authors see the true
-    // reason rather than a misleading "no_match".
-    resolved = resolveLinksArr.map((link) => ({ link, entityId: null, confidence: 0 }));
-    for (const link of resolveLinksArr) {
-      resolveWarnings.push({ label: link.label ?? "", reason: "llm_not_configured" });
-    }
-  } else {
-    try {
-      resolved = await resolveLinks(resolveLinksArr, actor, space_id);
-    } catch (err) {
-      if ((err as Error).message.includes("LLM configuration missing")) {
-        // Defensive fallback: config races with our upfront check (e.g. the
-        // file was deleted between isLlmConfigured() and the LLM call).
-        resolved = resolveLinksArr.map((link) => ({ link, entityId: null, confidence: 0 }));
-        for (const link of resolveLinksArr) {
-          resolveWarnings.push({ label: link.label ?? "", reason: "llm_not_configured" });
-        }
-      } else {
-        throw err;
-      }
-    }
-    // For any resolve: link that ran against an LLM but didn't match.
-    for (const r of resolved) {
-      if (!r.entityId && !resolveWarnings.some((w) => w.label === (r.link.label ?? ""))) {
-        resolveWarnings.push({ label: r.link.label ?? "", reason: "no_match" });
-      }
-    }
-  }
-
-  const placeholders: Array<{ id: string; label: string; status: PlaceholderStatus }> = [];
-  const placeholderLinks: Array<{ id: string; link: ParsedLink }> = [];
-
   const wikiId = generateUlid();
+
+  // --- Process content through the wiki link pipeline ---
+  const { resolvedContent, placeholders, targets, resolveWarnings } = await processWikiContent({
+    actor,
+    spaceId: space_id,
+    content,
+    depth,
+    maxDepth: MAX_DEPTH,
+  });
   const wikiProperties = {
     ...extraProperties,
     label,
@@ -314,7 +241,7 @@ wikiRouter.openapi(createWikiRoute, async (c) => {
     status: "draft",
   };
 
-  // Build the atomic transaction for Stage 1
+  // Persist wiki as draft (Stage 1)
   await withTransaction(async (tx) => {
     for (const q of setActorContext(tx, actor)) await q;
 
@@ -344,14 +271,14 @@ wikiRouter.openapi(createWikiRoute, async (c) => {
     }
 
     // Create wiki entity
-    const [wiki] = await tx`
+    await tx`
       INSERT INTO entities (
         id, kind, type, ver, properties, owner_id,
         edited_by, note, created_at, updated_at
       ) VALUES (
         ${wikiId}, 'entity', 'wiki', 1, ${wikiProperties}::jsonb, ${actor.id},
         ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
-      ) RETURNING *
+      )
     `;
 
     // Version snapshot
@@ -366,175 +293,21 @@ wikiRouter.openapi(createWikiRoute, async (c) => {
       VALUES (${space_id}, ${wikiId}, ${actor.id}, ${now}::timestamptz)
       ON CONFLICT (space_id, entity_id) DO NOTHING
     `;
-
-    // Mint placeholder entities for placeholder: and assign: links.
-    // Only assign: links are enqueued for the background drafter.
-    const stage1Mints: Array<{ link: ParsedLink; status: PlaceholderStatus }> = [
-      ...placeholderLinksIn.map((link) => ({ link, status: "placeholder" as const })),
-      ...assignLinksIn.map((link) => ({ link, status: "assigned" as const })),
-    ];
-
-    for (const { link, status } of stage1Mints) {
-      const phId = generateUlid();
-      const phProps = { label: link.label, description: link.description ?? null, status };
-
-      await tx`
-        INSERT INTO entities (
-          id, kind, type, ver, properties, owner_id,
-          edited_by, note, created_at, updated_at
-        ) VALUES (
-          ${phId}, 'entity', 'placeholder', 1, ${phProps}::jsonb, ${actor.id},
-          ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
-        )
-      `;
-
-      await tx`
-        INSERT INTO space_entities (space_id, entity_id, added_by, added_at)
-        VALUES (${space_id}, ${phId}, ${actor.id}, ${now}::timestamptz)
-        ON CONFLICT (space_id, entity_id) DO NOTHING
-      `;
-
-      if (status === "assigned") {
-        await tx`
-          INSERT INTO wiki_draft_queue (entity_id, depth, owner_agent, deadline, status, created_at)
-          VALUES (${phId}, ${depth + 1}, ${actor.id}, ${new Date(Date.now() + 3600_000).toISOString()}::timestamptz, 'pending', ${now}::timestamptz)
-        `;
-      }
-
-      placeholders.push({ id: phId, label: link.label ?? "", status });
-      placeholderLinks.push({ id: phId, link });
-      replacements.push({ offset: link.offset, length: link.length, value: `[[entity:${phId}]]` });
-    }
-
-    return wiki;
   });
 
-  // --- Stage 2: Resolve links and create relationships ---
-
-  // Collect all links that need relationships:
-  //   - entity: links -> direct reference
-  //   - resolved resolve: links → matched entity
-  //   - unresolved resolve: links → mint placeholder (unqueued)
-  interface LinkTarget {
-    targetId: string;
-    predicate: string;
-    spanText: string;
-  }
-
-  const targets: LinkTarget[] = [];
-
-  // Entity links get "references" relationships
-  for (const link of entityLinks) {
-    targets.push({
-      targetId: canonicalEntityIds.get(link.id!) ?? link.id!,
-      predicate: REL_PREDICATE_REFERENCES,
-      spanText: link.spanText,
-    });
-  }
-
-  // placeholder: and assign: links get relationships to their newly minted placeholders.
-  for (const placeholderLink of placeholderLinks) {
-    targets.push({
-      targetId: placeholderLink.id,
-      predicate: REL_PREDICATE_REFERENCES,
-      spanText: placeholderLink.link.spanText,
-    });
-  }
-
-  // Resolved links
-  const unresolvedLinks: ParsedLink[] = [];
-  for (const r of resolved) {
-    if (r.entityId) {
-      targets.push({ targetId: r.entityId, predicate: REL_PREDICATE_REFERENCES, spanText: r.link.spanText });
-      replacements.push({ offset: r.link.offset, length: r.link.length, value: `[[entity:${r.entityId}]]` });
-    } else {
-      unresolvedLinks.push(r.link);
-    }
-  }
-
-  // Unresolved resolve: links soft-degrade to unqueued placeholders.
-  // The caller wrote `resolve:` (intent: find an existing match), so on
-  // miss we DON'T queue for auto-drafting — they'd have used `assign:` if
-  // they wanted that. Warnings are recorded above.
-  const unresolvedPlaceholders = await withTransaction(async (tx) => {
-    for (const q of setActorContext(tx, actor)) await q;
-    const minted: Array<{ id: string; label: string; status: PlaceholderStatus }> = [];
-
-    for (const link of unresolvedLinks) {
-      const phId = generateUlid();
-      const phProps = { label: link.label, description: link.description ?? null, status: "placeholder" };
-
-      await tx`
-        INSERT INTO entities (
-          id, kind, type, ver, properties, owner_id,
-          edited_by, note, created_at, updated_at
-        ) VALUES (
-          ${phId}, 'entity', 'placeholder', 1, ${phProps}::jsonb, ${actor.id},
-          ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
-        )
-      `;
-
-      await tx`
-        INSERT INTO space_entities (space_id, entity_id, added_by, added_at)
-        VALUES (${space_id}, ${phId}, ${actor.id}, ${now}::timestamptz)
-        ON CONFLICT (space_id, entity_id) DO NOTHING
-      `;
-
-      targets.push({ targetId: phId, predicate: REL_PREDICATE_REFERENCES, spanText: link.spanText });
-      minted.push({ id: phId, label: link.label ?? "", status: "placeholder" });
-      replacements.push({ offset: link.offset, length: link.length, value: `[[entity:${phId}]]` });
-    }
-    return minted;
+  // Create relationships (Stage 2)
+  const relationshipsCreated = await createWikiReferences({
+    actor,
+    wikiId,
+    spaceId: space_id,
+    targets,
+    now,
   });
 
-  placeholders.push(...unresolvedPlaceholders);
-
-  // Create all relationships in a single transaction
-  let relationshipsCreated = 0;
-  if (targets.length > 0) {
-    await withTransaction(async (tx) => {
-      for (const q of setActorContext(tx, actor)) await q;
-
-      for (const t of targets) {
-        const relId = generateUlid();
-        const relProps = t.spanText ? { span_text: t.spanText } : {};
-
-        // Insert relationship entity
-        await tx`
-          INSERT INTO entities (
-            id, kind, type, ver, properties, owner_id,
-            edited_by, note, created_at, updated_at
-          ) VALUES (
-            ${relId}, 'relationship', 'relationship', 1, ${relProps}::jsonb,
-            ${actor.id},
-            ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
-          )
-        `;
-
-        // Insert edge
-        await tx`
-          INSERT INTO relationship_edges (id, source_id, target_id, predicate)
-          VALUES (${relId}, ${wikiId}, ${t.targetId}, ${t.predicate})
-        `;
-
-        // Add relationship to space
-        await tx`
-          INSERT INTO space_entities (space_id, entity_id, added_by, added_at)
-          VALUES (${space_id}, ${relId}, ${actor.id}, ${now}::timestamptz)
-          ON CONFLICT (space_id, entity_id) DO NOTHING
-        `;
-
-        relationshipsCreated++;
-      }
-    });
-  }
-
-  // --- Promote wiki to published ---
-  const publishedContent = applyLinkReplacements(content, replacements);
+  // Promote wiki to published
+  const publishedProps = { ...wikiProperties, content: resolvedContent, status: "published" };
   const publishedWiki = await withTransaction(async (tx) => {
     for (const q of setActorContext(tx, actor)) await q;
-
-    const publishedProps = { ...wikiProperties, content: publishedContent, status: "published" };
 
     const [updated] = await tx`
       UPDATE entities
@@ -568,20 +341,6 @@ wikiRouter.openapi(createWikiRoute, async (c) => {
   );
 });
 
-function applyLinkReplacements(
-  content: string,
-  replacements: Array<{ offset: number; length: number; value: string }>,
-): string {
-  if (replacements.length === 0) return content;
-  let rewritten = content;
-  for (const replacement of [...replacements].sort((a, b) => b.offset - a.offset)) {
-    rewritten = rewritten.slice(0, replacement.offset) +
-      replacement.value +
-      rewritten.slice(replacement.offset + replacement.length);
-  }
-  return rewritten;
-}
-
 function wikiIdentityKeys(label: string, aliases: string[]): string[] {
   return [...new Set([label, ...aliases].map(normalizeWikiIdentity).filter(Boolean))].sort();
 }
@@ -614,31 +373,4 @@ function normalizeWikiIdentity(value: string): string {
     .trim()
     .replace(/\s+/g, " ")
     .toLowerCase();
-}
-
-async function resolveVisibleEntityId(
-  sql: ReturnType<typeof createSql>,
-  actor: ReturnType<typeof requireActor>,
-  id: string,
-): Promise<string | null> {
-  let current = id;
-  const seen = new Set<string>();
-
-  for (let i = 0; i < 10; i++) {
-    if (seen.has(current)) return null;
-    seen.add(current);
-
-    const found = await withTransaction(async (tx) => {
-      for (const q of setActorContext(tx, actor)) await q;
-      return tx`SELECT id FROM entities WHERE id = ${current} AND kind = 'entity' LIMIT 1`;
-    });
-    if (found.length > 0) return current;
-
-    const redirectRows = await sql`SELECT new_id FROM entity_redirects WHERE old_id = ${current} LIMIT 1`;
-    const redirect = redirectRows[0] as { new_id?: string } | undefined;
-    if (!redirect?.new_id) return null;
-    current = String(redirect.new_id);
-  }
-
-  return null;
 }

--- a/packages/arkeon/test/unit/wiki-pipeline.test.ts
+++ b/packages/arkeon/test/unit/wiki-pipeline.test.ts
@@ -144,10 +144,12 @@ describe("diffWikiReferences", () => {
     expect(diff.toDelete).toEqual(["rel-DELETE_ME"]);
   });
 
-  test("duplicate targets in new set are handled", () => {
-    // If the same target appears twice in new content (e.g., linked twice),
-    // both produce update entries for the same relationship. The last UPDATE
-    // wins at the DB level — harmless, just a redundant write.
+  test("duplicate targets in new set — processWikiContent deduplicates before diffing", () => {
+    // processWikiContent deduplicates targets by targetId:predicate before
+    // returning, so diffWikiReferences typically receives unique targets.
+    // But if duplicates do reach diffWikiReferences, both match the same
+    // existing relationship and produce two update entries (last-write-wins
+    // at DB level, harmless).
     const existing: ExistingRelationship[] = [
       makeExisting({ targetId: "E1", spanText: "original" }),
     ];
@@ -158,7 +160,6 @@ describe("diffWikiReferences", () => {
 
     const diff = diffWikiReferences(existing, targets);
 
-    // Both matches produce updates — last-write-wins at DB level
     expect(diff.toUpdate.length).toBe(2);
     expect(diff.toUpdate[0]!.id).toBe("rel-E1");
     expect(diff.toUpdate[1]!.id).toBe("rel-E1");

--- a/packages/arkeon/test/unit/wiki-pipeline.test.ts
+++ b/packages/arkeon/test/unit/wiki-pipeline.test.ts
@@ -1,0 +1,224 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test } from "vitest";
+
+import {
+  applyLinkReplacements,
+  diffWikiReferences,
+  type ExistingRelationship,
+  type LinkTarget,
+} from "../../src/server/lib/wiki-pipeline";
+
+describe("applyLinkReplacements", () => {
+  test("returns content unchanged when no replacements", () => {
+    const content = "Hello [[entity:ABC123]] world";
+    expect(applyLinkReplacements(content, [])).toBe(content);
+  });
+
+  test("replaces a single link", () => {
+    const content = '[[resolve:"Foo"|"Bar"]]';
+    const result = applyLinkReplacements(content, [
+      { offset: 0, length: content.length, value: "[[entity:01ABC]]" },
+    ]);
+    expect(result).toBe("[[entity:01ABC]]");
+  });
+
+  test("replaces multiple links preserving order", () => {
+    const content = 'See [[resolve:"A"|"x"]] and [[assign:"B"|"y"]] end';
+    const resolveOffset = content.indexOf("[[resolve:");
+    const resolveLen = '[[resolve:"A"|"x"]]'.length;
+    const assignOffset = content.indexOf("[[assign:");
+    const assignLen = '[[assign:"B"|"y"]]'.length;
+
+    const result = applyLinkReplacements(content, [
+      { offset: resolveOffset, length: resolveLen, value: "[[entity:ID1]]" },
+      { offset: assignOffset, length: assignLen, value: "[[entity:ID2]]" },
+    ]);
+
+    expect(result).toBe("See [[entity:ID1]] and [[entity:ID2]] end");
+  });
+
+  test("handles replacements of different lengths", () => {
+    const content = 'X [[resolve:"Short"]] Y [[assign:"Very Long Description"|"Extra"]] Z';
+    const r1Offset = content.indexOf("[[resolve:");
+    const r1Len = '[[resolve:"Short"]]'.length;
+    const r2Offset = content.indexOf("[[assign:");
+    const r2Len = '[[assign:"Very Long Description"|"Extra"]]'.length;
+
+    const result = applyLinkReplacements(content, [
+      { offset: r1Offset, length: r1Len, value: "[[entity:A]]" },
+      { offset: r2Offset, length: r2Len, value: "[[entity:B]]" },
+    ]);
+
+    expect(result).toBe("X [[entity:A]] Y [[entity:B]] Z");
+  });
+
+  test("processes replacements from end to start (offset-safe)", () => {
+    // Verify that earlier replacements don't corrupt later offsets
+    const content = "AB[[x:1]]CD[[y:2]]EF";
+    const result = applyLinkReplacements(content, [
+      { offset: 2, length: 7, value: "REPLACED1" },
+      { offset: 11, length: 7, value: "REPLACED2" },
+    ]);
+    expect(result).toBe("ABREPLACED1CDREPLACED2EF");
+  });
+});
+
+describe("diffWikiReferences", () => {
+  const makeExisting = (overrides: Partial<ExistingRelationship> & { targetId: string }): ExistingRelationship => ({
+    id: `rel-${overrides.targetId}`,
+    predicate: "references",
+    spanText: "",
+    ...overrides,
+  });
+
+  const makeTarget = (overrides: Partial<LinkTarget> & { targetId: string }): LinkTarget => ({
+    predicate: "references",
+    spanText: "",
+    ...overrides,
+  });
+
+  test("empty existing + empty new = no changes", () => {
+    const diff = diffWikiReferences([], []);
+    expect(diff.toUpdate).toEqual([]);
+    expect(diff.toCreate).toEqual([]);
+    expect(diff.toDelete).toEqual([]);
+  });
+
+  test("empty existing + new targets = all creates", () => {
+    const targets: LinkTarget[] = [
+      makeTarget({ targetId: "E1", spanText: "about E1" }),
+      makeTarget({ targetId: "E2", spanText: "about E2" }),
+    ];
+
+    const diff = diffWikiReferences([], targets);
+
+    expect(diff.toCreate).toEqual(targets);
+    expect(diff.toUpdate).toEqual([]);
+    expect(diff.toDelete).toEqual([]);
+  });
+
+  test("existing with no new targets = all deletes", () => {
+    const existing: ExistingRelationship[] = [
+      makeExisting({ targetId: "E1" }),
+      makeExisting({ targetId: "E2" }),
+    ];
+
+    const diff = diffWikiReferences(existing, []);
+
+    expect(diff.toDelete).toEqual(["rel-E1", "rel-E2"]);
+    expect(diff.toCreate).toEqual([]);
+    expect(diff.toUpdate).toEqual([]);
+  });
+
+  test("same target = update span_text", () => {
+    const existing: ExistingRelationship[] = [
+      makeExisting({ targetId: "E1", spanText: "old context" }),
+    ];
+    const targets: LinkTarget[] = [
+      makeTarget({ targetId: "E1", spanText: "new context" }),
+    ];
+
+    const diff = diffWikiReferences(existing, targets);
+
+    expect(diff.toUpdate).toEqual([{ id: "rel-E1", spanText: "new context" }]);
+    expect(diff.toCreate).toEqual([]);
+    expect(diff.toDelete).toEqual([]);
+  });
+
+  test("mixed: keep + create + delete", () => {
+    const existing: ExistingRelationship[] = [
+      makeExisting({ targetId: "KEEP", spanText: "old" }),
+      makeExisting({ targetId: "DELETE_ME", spanText: "will go" }),
+    ];
+    const targets: LinkTarget[] = [
+      makeTarget({ targetId: "KEEP", spanText: "updated" }),
+      makeTarget({ targetId: "NEW_ONE", spanText: "fresh" }),
+    ];
+
+    const diff = diffWikiReferences(existing, targets);
+
+    expect(diff.toUpdate).toEqual([{ id: "rel-KEEP", spanText: "updated" }]);
+    expect(diff.toCreate).toEqual([makeTarget({ targetId: "NEW_ONE", spanText: "fresh" })]);
+    expect(diff.toDelete).toEqual(["rel-DELETE_ME"]);
+  });
+
+  test("duplicate targets in new set are handled", () => {
+    // If the same target appears twice in new content (e.g., linked twice),
+    // both produce update entries for the same relationship. The last UPDATE
+    // wins at the DB level — harmless, just a redundant write.
+    const existing: ExistingRelationship[] = [
+      makeExisting({ targetId: "E1", spanText: "original" }),
+    ];
+    const targets: LinkTarget[] = [
+      makeTarget({ targetId: "E1", spanText: "first mention" }),
+      makeTarget({ targetId: "E1", spanText: "second mention" }),
+    ];
+
+    const diff = diffWikiReferences(existing, targets);
+
+    // Both matches produce updates — last-write-wins at DB level
+    expect(diff.toUpdate.length).toBe(2);
+    expect(diff.toUpdate[0]!.id).toBe("rel-E1");
+    expect(diff.toUpdate[1]!.id).toBe("rel-E1");
+    expect(diff.toDelete).toEqual([]);
+    expect(diff.toCreate).toEqual([]);
+  });
+
+  test("different predicates are treated as different relationships", () => {
+    const existing: ExistingRelationship[] = [
+      makeExisting({ targetId: "E1", predicate: "references" }),
+    ];
+    const targets: LinkTarget[] = [
+      // Same target but different predicate = new relationship
+      makeTarget({ targetId: "E1", predicate: "derived_from" }),
+    ];
+
+    const diff = diffWikiReferences(existing, targets);
+
+    // The existing "references" relationship to E1 should be deleted
+    // The new "derived_from" relationship to E1 should be created
+    expect(diff.toDelete).toEqual(["rel-E1"]);
+    expect(diff.toCreate).toEqual([makeTarget({ targetId: "E1", predicate: "derived_from" })]);
+    expect(diff.toUpdate).toEqual([]);
+  });
+
+  test("large set of changes", () => {
+    const existing: ExistingRelationship[] = Array.from({ length: 10 }, (_, i) =>
+      makeExisting({ targetId: `E${i}`, id: `rel-${i}`, spanText: `old-${i}` }),
+    );
+
+    // Keep first 5, drop last 5, add 3 new
+    const targets: LinkTarget[] = [
+      ...Array.from({ length: 5 }, (_, i) =>
+        makeTarget({ targetId: `E${i}`, spanText: `new-${i}` }),
+      ),
+      ...Array.from({ length: 3 }, (_, i) =>
+        makeTarget({ targetId: `NEW${i}`, spanText: `fresh-${i}` }),
+      ),
+    ];
+
+    const diff = diffWikiReferences(existing, targets);
+
+    expect(diff.toUpdate).toHaveLength(5);
+    expect(diff.toCreate).toHaveLength(3);
+    expect(diff.toDelete).toHaveLength(5);
+
+    // Verify update IDs match the kept ones
+    for (let i = 0; i < 5; i++) {
+      expect(diff.toUpdate[i]!.id).toBe(`rel-${i}`);
+      expect(diff.toUpdate[i]!.spanText).toBe(`new-${i}`);
+    }
+
+    // Verify delete IDs match the dropped ones
+    for (let i = 5; i < 10; i++) {
+      expect(diff.toDelete).toContain(`rel-${i}`);
+    }
+
+    // Verify create targets
+    for (let i = 0; i < 3; i++) {
+      expect(diff.toCreate[i]!.targetId).toBe(`NEW${i}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Updating a wiki's `content` via `PUT /wiki/{id}` now triggers the full link pipeline: `[[assign:...]]`, `[[resolve:...]]`, `[[placeholder:...]]`, and `[[entity:...]]` links are parsed, resolved, and turned into relationships — just like `POST /wiki`
- Extracts shared pipeline logic into `lib/wiki-pipeline.ts` (used by both POST and PUT), eliminating ~200 lines of duplication from the POST handler
- Relationships are **diffed** on update: existing ones get span_text updated, new targets get relationships created, removed targets get relationships deleted

## Test plan

- [x] Typecheck passes (`npm run typecheck -w packages/arkeon`)
- [x] All 102 unit tests pass (13 new tests for `applyLinkReplacements` and `diffWikiReferences`)
- [ ] Manual smoke test: POST a wiki, PUT to update content with new `[[assign:...]]` links, verify placeholders minted and relationships created
- [ ] Verify POST /wiki still works identically (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)