### PR TITLE
feat: workers.yaml config system for LLM workers

### DIFF
--- a/docs/dev/WIKI_PIPELINE.md
+++ b/docs/dev/WIKI_PIPELINE.md
@@ -124,29 +124,65 @@ duplicates that deterministic label/alias checks missed. High-confidence cases
 can be routed to merge/review; uncertain cases should remain separate because
 false merges are worse than duplicate pages.
 
-## LLM Configuration
+## Worker Configuration
 
-All LLM-using steps share `server/lib/llm.ts`.
+Workers are configured via `~/.arkeon-wiki/workers.yaml` (override path with
+`ARKEON_WORKERS_CONFIG`). Each worker can have its own LLM provider/model,
+custom prompt, and operational settings. The file is optional — everything
+works with env vars or `llm.json` alone.
 
-Config file: `~/.arkeon-wiki/llm.json` (override with `WIKI_LLM_CONFIG_PATH`)
+```yaml
+llm:
+  provider: openai
+  base_url: https://api.openai.com/v1
+  api_key: sk-...
+  model: gpt-5.4-nano
 
-```json
-{
-  "default": {
-    "provider": "openai",
-    "base_url": "https://api.openai.com/v1",
-    "api_key": "sk-...",
-    "model": "gpt-5.4-nano"
-  },
-  "draft": { "model": "gpt-5.4-nano", "max_tokens": 8000 },
-  "dedup": { "model": "gpt-5.4-nano", "max_tokens": 16000 }
-}
+workers:
+  extractor:
+    enabled: true
+    prompt_mode: append        # replace | prepend | append
+    prompt: null               # custom text merged with built-in prompt
+    llm:
+      model: gpt-5.4-nano
+    steps:
+      resolve: { model: gpt-5.4-nano, max_tokens: 256 }
+      exists:  { model: gpt-5.4-nano, max_tokens: 512 }
+
+  drafter:
+    enabled: true
+    poll_interval: 10s
+    batch_size: 5
+    max_depth: 2
+    llm: { model: gpt-4o, max_tokens: 8000 }
 ```
 
-Resolution order:
+### Workers
 
-1. Step-specific model env var, such as `WIKI_RESOLVE_MODEL`.
-2. Step block in `llm.json`.
-3. `default` block in `llm.json`.
-4. `OPENAI_API_KEY` / `OPENAI_BASE_URL`.
-5. Hardcoded per-step defaults.
+| Worker | Type | Description |
+|---|---|---|
+| **extractor** | sync | Resolves `[[resolve:...]]` links during `POST /wiki` via Meilisearch + LLM judge |
+| **drafter** | background | Polls `wiki_draft_queue`, drafts wiki content for `[[assign:...]]` placeholders |
+
+Future workers (consolidator, cross-space connector) will be added to this
+file when implemented.
+
+### Prompt customization
+
+Each worker accepts `prompt` + `prompt_mode`:
+
+- **replace**: fully replaces the built-in system prompt
+- **prepend**: user text goes before the built-in prompt
+- **append**: user text goes after the built-in prompt (most common)
+- `prompt: null` or omitted: use built-in unchanged
+
+### LLM resolution order
+
+1. Per-step env var (`WIKI_RESOLVE_MODEL`, etc.) — model only
+2. `workers.yaml` step config (extractor only)
+3. `workers.yaml` worker-level `llm` block
+4. `workers.yaml` top-level `llm` block
+5. `llm.json` step block (legacy fallback)
+6. `llm.json` `"default"` block (legacy fallback)
+7. `OPENAI_API_KEY` / `OPENAI_BASE_URL`
+8. Hardcoded per-step defaults

--- a/packages/arkeon/package.json
+++ b/packages/arkeon/package.json
@@ -42,6 +42,7 @@
     "dotenv": "^17.3.1",
     "embedded-postgres": "18.3.0-beta.16",
     "hono": "^4.12.9",
+    "js-yaml": "^4.1.1",
     "meilisearch": "^0.56.0",
     "openai": "^4.80.0",
     "postgres": "^3.4.8",
@@ -50,7 +51,6 @@
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.6.0",
-    "js-yaml": "^4.1.1",
     "tsup": "^8.5.0",
     "tsx": "^4.20.5",
     "typescript": "^5.9.3",

--- a/packages/arkeon/src/server/lib/entity-resolve.ts
+++ b/packages/arkeon/src/server/lib/entity-resolve.ts
@@ -41,6 +41,7 @@ import { withTransaction } from "./sql";
 import { setActorContext } from "./actor-context";
 import { getLlmClient, type LlmStep } from "./llm";
 import { buildCandidateQueries, strictNormalizeLabel } from "./label-match";
+import { getWorkerPromptConfig, buildPrompt } from "./worker-config";
 import type { Actor } from "../types";
 
 export interface ResolutionSubject {
@@ -248,6 +249,10 @@ async function llmJudge(
 ): Promise<EntityMatch[]> {
   const { client, model, maxTokens } = getLlmClient(llmStep);
 
+  // Apply user prompt customization from workers.yaml if configured
+  const promptConfig = getWorkerPromptConfig(llmStep);
+  const systemPrompt = promptConfig ? buildPrompt(JUDGE_PROMPT, promptConfig) : JUDGE_PROMPT;
+
   const input = {
     target: {
       label: subject.label,
@@ -271,7 +276,7 @@ async function llmJudge(
     const response = await client.chat.completions.create({
       model,
       messages: [
-        { role: "system", content: JUDGE_PROMPT },
+        { role: "system", content: systemPrompt },
         { role: "user", content: JSON.stringify(input) },
       ],
       response_format: { type: "json_object" },

--- a/packages/arkeon/src/server/lib/llm.ts
+++ b/packages/arkeon/src/server/lib/llm.ts
@@ -9,30 +9,22 @@
  *
  *   1. Per-step env vars: WIKI_RESOLVE_MODEL, WIKI_EXISTS_MODEL,
  *      WIKI_DRAFT_MODEL, WIKI_DEDUP_MODEL (model only)
- *   2. Step block in $ARKEON_WIKI_HOME/llm.json (or WIKI_LLM_CONFIG_PATH)
- *   3. Default block in the same file
- *   4. Base env vars: OPENAI_API_KEY, OPENAI_BASE_URL (for api_key + base_url)
- *   5. Hardcoded defaults per step (cheap models for resolve/exists,
+ *   2. workers.yaml step/worker/global LLM config
+ *   3. Step block in $ARKEON_WIKI_HOME/llm.json (or WIKI_LLM_CONFIG_PATH)
+ *   4. Default block in the same file
+ *   5. Base env vars: OPENAI_API_KEY, OPENAI_BASE_URL (for api_key + base_url)
+ *   6. Hardcoded defaults per step (cheap models for resolve/exists,
  *      stronger models for draft/dedup)
  *
- * File shape:
- *
- *   {
- *     "default": {
- *       "provider": "openai",
- *       "base_url": "https://api.openai.com/v1",
- *       "api_key": "sk-...",
- *       "model": "gpt-5.4-nano"
- *     },
- *     "draft": { "model": "gpt-4o", "max_tokens": 8000 },
- *     "dedup": { "model": "gpt-4o", "max_tokens": 16000 }
- *   }
+ * workers.yaml is the primary config surface and subsumes llm.json.
+ * llm.json continues to work as a lower-priority fallback.
  */
 
 import OpenAI from "openai";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { getWorkerLlmConfig } from "./worker-config.js";
 
 export type LlmStep = "resolve" | "exists" | "draft" | "dedup";
 
@@ -146,26 +138,32 @@ const _clientCache = new Map<string, ResolvedLlm>();
  * Throws if no api_key can be resolved from any source.
  */
 export function getLlmClient(step: LlmStep): ResolvedLlm {
+  // workers.yaml config (step > worker > global)
+  const workerLlm = getWorkerLlmConfig(step) ?? {};
+
+  // llm.json fallback
   const file = loadConfigFile();
   const fileDefault = file?.default ?? {};
   const fileStep = file?.[step] ?? {};
 
-  // Step-specific model env var wins. No per-step base_url/api_key env vars —
-  // if you need different providers per step, use the config file.
+  // Step-specific model env var wins over everything except explicit
+  // workers.yaml settings. No per-step base_url/api_key env vars —
+  // if you need different providers per step, use workers.yaml.
   const envStepModel = process.env[`WIKI_${step.toUpperCase()}_MODEL`];
   const envApiKey = process.env.OPENAI_API_KEY;
   const envBaseUrl = process.env.OPENAI_BASE_URL;
 
-  const apiKey = fileStep.api_key ?? fileDefault.api_key ?? envApiKey;
-  const baseUrl = fileStep.base_url ?? fileDefault.base_url ?? envBaseUrl;
-  const model = envStepModel ?? fileStep.model ?? fileDefault.model ?? DEFAULT_MODEL[step];
-  const maxTokens = fileStep.max_tokens ?? fileDefault.max_tokens ?? DEFAULT_MAX_TOKENS[step];
+  // Resolution chain: env step model > workers.yaml > llm.json step > llm.json default > env > hardcoded
+  const apiKey = workerLlm.api_key ?? fileStep.api_key ?? fileDefault.api_key ?? envApiKey;
+  const baseUrl = workerLlm.base_url ?? fileStep.base_url ?? fileDefault.base_url ?? envBaseUrl;
+  const model = envStepModel ?? workerLlm.model ?? fileStep.model ?? fileDefault.model ?? DEFAULT_MODEL[step];
+  const maxTokens = workerLlm.max_tokens ?? fileStep.max_tokens ?? fileDefault.max_tokens ?? DEFAULT_MAX_TOKENS[step];
 
   if (!apiKey) {
     throw new Error(
       `LLM configuration missing for step "${step}". Set OPENAI_API_KEY in ` +
-      `the environment, write ${configPath()} with a default.api_key, or run ` +
-      `\`arkeon init --llm-provider ... --llm-base-url ... --llm-api-key ... --llm-model ...\`.`,
+      `the environment, write ${configPath()} with a default.api_key, or ` +
+      `configure it in workers.yaml.`,
     );
   }
 
@@ -188,6 +186,11 @@ export function getLlmClient(step: LlmStep): ResolvedLlm {
  * wiki with [[resolve:...]] links) rather than 500 deep in the pipeline.
  */
 export function isLlmConfigured(): boolean {
+  // Check workers.yaml first
+  const workerLlm = getWorkerLlmConfig("resolve");
+  if (workerLlm?.api_key) return true;
+
+  // Fall back to llm.json + env
   const file = loadConfigFile();
   const key =
     file?.default?.api_key ??

--- a/packages/arkeon/src/server/lib/worker-config.ts
+++ b/packages/arkeon/src/server/lib/worker-config.ts
@@ -148,6 +148,91 @@ const WORKER_DEFAULTS: Record<WorkerName, {
   },
 };
 
+// ── Validation ─────────────────────────────────────────────────────
+
+const VALID_PROMPT_MODES = new Set(["replace", "prepend", "append"]);
+
+function assertType(value: unknown, expected: string, path: string): void {
+  if (expected === "string" && typeof value !== "string") {
+    throw new Error(`[worker-config] ${path} must be a string, got ${typeof value}`);
+  }
+  if (expected === "number") {
+    if (typeof value !== "number" || Number.isNaN(value)) {
+      throw new Error(`[worker-config] ${path} must be a number, got ${JSON.stringify(value)}`);
+    }
+  }
+  if (expected === "boolean" && typeof value !== "boolean") {
+    throw new Error(`[worker-config] ${path} must be a boolean, got ${typeof value}`);
+  }
+}
+
+function validateLlmConfig(obj: Record<string, unknown>, prefix: string): void {
+  if (obj.provider !== undefined) assertType(obj.provider, "string", `${prefix}.provider`);
+  if (obj.base_url !== undefined) assertType(obj.base_url, "string", `${prefix}.base_url`);
+  if (obj.api_key !== undefined) assertType(obj.api_key, "string", `${prefix}.api_key`);
+  if (obj.model !== undefined) assertType(obj.model, "string", `${prefix}.model`);
+  if (obj.max_tokens !== undefined) assertType(obj.max_tokens, "number", `${prefix}.max_tokens`);
+}
+
+function validatePromptConfig(obj: Record<string, unknown>, prefix: string): void {
+  if (obj.prompt_mode !== undefined) {
+    assertType(obj.prompt_mode, "string", `${prefix}.prompt_mode`);
+    if (!VALID_PROMPT_MODES.has(obj.prompt_mode as string)) {
+      throw new Error(
+        `[worker-config] ${prefix}.prompt_mode must be one of: replace, prepend, append — got "${obj.prompt_mode}"`,
+      );
+    }
+  }
+  if (obj.prompt !== undefined && obj.prompt !== null) {
+    assertType(obj.prompt, "string", `${prefix}.prompt`);
+  }
+}
+
+function validateWorkerBlock(obj: unknown, prefix: string): void {
+  if (obj === undefined || obj === null) return;
+  if (typeof obj !== "object") {
+    throw new Error(`[worker-config] ${prefix} must be a mapping, got ${typeof obj}`);
+  }
+  const w = obj as Record<string, unknown>;
+  if (w.enabled !== undefined) assertType(w.enabled, "boolean", `${prefix}.enabled`);
+  if (w.poll_interval !== undefined) assertType(w.poll_interval, "string", `${prefix}.poll_interval`);
+  if (w.batch_size !== undefined) assertType(w.batch_size, "number", `${prefix}.batch_size`);
+  if (w.max_depth !== undefined) assertType(w.max_depth, "number", `${prefix}.max_depth`);
+  if (w.similarity_threshold !== undefined) assertType(w.similarity_threshold, "number", `${prefix}.similarity_threshold`);
+  if (w.llm !== undefined) {
+    if (typeof w.llm !== "object" || w.llm === null) {
+      throw new Error(`[worker-config] ${prefix}.llm must be a mapping`);
+    }
+    validateLlmConfig(w.llm as Record<string, unknown>, `${prefix}.llm`);
+  }
+  validatePromptConfig(w, prefix);
+}
+
+function validateWorkersYaml(raw: Record<string, unknown> | null, filePath: string): WorkersYaml | null {
+  if (!raw) return null;
+
+  if (raw.llm !== undefined) {
+    if (typeof raw.llm !== "object" || raw.llm === null) {
+      throw new Error(`[worker-config] ${filePath}: llm must be a mapping`);
+    }
+    validateLlmConfig(raw.llm as Record<string, unknown>, "llm");
+  }
+
+  if (raw.workers !== undefined) {
+    if (typeof raw.workers !== "object" || raw.workers === null) {
+      throw new Error(`[worker-config] ${filePath}: workers must be a mapping`);
+    }
+    const workers = raw.workers as Record<string, unknown>;
+    for (const name of ["extractor", "drafter", "consolidator", "connector"]) {
+      if (workers[name] !== undefined) {
+        validateWorkerBlock(workers[name], `workers.${name}`);
+      }
+    }
+  }
+
+  return raw as unknown as WorkersYaml;
+}
+
 // ── YAML loading (mtime-cached) ────────────────────────────────────
 
 function arkeonHome(): string {
@@ -186,16 +271,21 @@ export function loadWorkersYaml(): WorkersYaml | null {
     return _yamlCache.value;
   }
 
+  const raw = readFileSync(path, "utf-8");
+  let parsed: unknown;
   try {
-    const raw = readFileSync(path, "utf-8");
-    const parsed = yaml.load(raw) as WorkersYaml;
-    _yamlCache = { value: parsed, path, mtimeMs: stat.mtimeMs, size: stat.size };
-    return parsed;
+    parsed = yaml.load(raw);
   } catch (err) {
-    console.warn(`[worker-config] failed to parse ${path}:`, (err as Error).message);
-    _yamlCache = { value: null, path, mtimeMs: stat.mtimeMs, size: stat.size };
-    return null;
+    throw new Error(`[worker-config] invalid YAML in ${path}: ${(err as Error).message}`);
   }
+
+  if (parsed !== null && typeof parsed !== "object") {
+    throw new Error(`[worker-config] ${path} must be a YAML mapping, got ${typeof parsed}`);
+  }
+
+  const validated = validateWorkersYaml(parsed as Record<string, unknown> | null, path);
+  _yamlCache = { value: validated, path, mtimeMs: stat.mtimeMs, size: stat.size };
+  return validated;
 }
 
 /** For tests: forget cached YAML. */
@@ -255,7 +345,7 @@ export function resolveWorkerConfig(name: WorkerName, yamlConfig?: WorkersYaml |
 
   // Prompt
   const prompt: ResolvedWorkerConfig["prompt"] = {
-    mode: workerCfg?.prompt_mode ?? "replace",
+    mode: workerCfg?.prompt_mode ?? "append",
     text: workerCfg?.prompt ?? null,
   };
 
@@ -362,13 +452,13 @@ export function getWorkerPromptConfig(step: string): ResolvedWorkerConfig["promp
     const extCfg = workerCfg as ExtractorConfig;
     const stepCfg = extCfg.steps?.[step as "resolve" | "exists"];
     if (stepCfg?.prompt) {
-      return { mode: stepCfg.prompt_mode ?? "replace", text: stepCfg.prompt };
+      return { mode: stepCfg.prompt_mode ?? "append", text: stepCfg.prompt };
     }
   }
 
   // Worker-level prompt
   if (workerCfg.prompt) {
-    return { mode: workerCfg.prompt_mode ?? "replace", text: workerCfg.prompt };
+    return { mode: workerCfg.prompt_mode ?? "append", text: workerCfg.prompt };
   }
 
   return null;

--- a/packages/arkeon/src/server/lib/worker-config.ts
+++ b/packages/arkeon/src/server/lib/worker-config.ts
@@ -1,0 +1,375 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Worker configuration loader.
+ *
+ * Reads `$ARKEON_WIKI_HOME/workers.yaml` (default `~/.arkeon-wiki/workers.yaml`)
+ * and exposes resolved config for each worker. workers.yaml subsumes
+ * llm.json — the top-level `llm:` block replaces llm.json's `"default"`.
+ * llm.json continues to work as a lower-priority fallback for existing
+ * setups.
+ *
+ * File shape:
+ *
+ *   llm:
+ *     provider: openai
+ *     base_url: https://api.openai.com/v1
+ *     api_key: sk-...
+ *     model: gpt-5.4-nano
+ *     max_tokens: 4096
+ *
+ *   workers:
+ *     extractor:
+ *       enabled: true
+ *       prompt_mode: append
+ *       prompt: "Extra domain rules..."
+ *       llm:
+ *         model: gpt-5.4-nano
+ *       steps:
+ *         resolve: { model: gpt-5.4-nano, max_tokens: 256 }
+ *         exists:  { model: gpt-5.4-nano, max_tokens: 512 }
+ *     drafter:
+ *       enabled: true
+ *       poll_interval: 10s
+ *       batch_size: 5
+ *       max_depth: 2
+ *       llm: { model: gpt-4o, max_tokens: 8000 }
+ *     consolidator:
+ *       enabled: false
+ *       ...
+ *     connector:
+ *       enabled: false
+ *       ...
+ */
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import yaml from "js-yaml";
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export interface LlmConfig {
+  provider?: string;
+  base_url?: string;
+  api_key?: string;
+  model?: string;
+  max_tokens?: number;
+}
+
+export type PromptMode = "replace" | "prepend" | "append";
+
+export interface PromptConfig {
+  prompt_mode?: PromptMode;
+  prompt?: string | null;
+}
+
+export interface WorkerConfigBase extends PromptConfig {
+  enabled?: boolean;
+  llm?: LlmConfig;
+}
+
+export interface BackgroundWorkerConfig extends WorkerConfigBase {
+  poll_interval?: string;
+  batch_size?: number;
+}
+
+export interface StepConfig extends PromptConfig {
+  model?: string;
+  max_tokens?: number;
+}
+
+export interface ExtractorConfig extends WorkerConfigBase {
+  steps?: {
+    resolve?: StepConfig;
+    exists?: StepConfig;
+  };
+}
+
+export interface DrafterConfig extends BackgroundWorkerConfig {
+  max_depth?: number;
+}
+
+// Future worker configs — uncomment when implemented:
+// export interface ConsolidatorConfig extends BackgroundWorkerConfig {
+//   similarity_threshold?: number;
+// }
+// export interface ConnectorConfig extends BackgroundWorkerConfig {}
+
+export interface WorkersYaml {
+  llm?: LlmConfig;
+  workers?: {
+    extractor?: ExtractorConfig;
+    drafter?: DrafterConfig;
+    // Future workers — uncomment when implemented:
+    // consolidator?: ConsolidatorConfig;
+    // connector?: ConnectorConfig;
+  };
+}
+
+export type WorkerName = "extractor" | "drafter";
+
+export interface ResolvedWorkerConfig {
+  name: WorkerName;
+  enabled: boolean;
+  pollIntervalMs: number;
+  batchSize: number;
+  llm: LlmConfig & { model: string; max_tokens: number };
+  prompt: { mode: PromptMode; text: string | null };
+  extra: Record<string, unknown>;
+}
+
+// ── Defaults ───────────────────────────────────────────────────────
+
+const WORKER_DEFAULTS: Record<WorkerName, {
+  enabled: boolean;
+  pollIntervalMs: number;
+  batchSize: number;
+  model: string;
+  maxTokens: number;
+  extra: Record<string, unknown>;
+}> = {
+  extractor: {
+    enabled: true,
+    pollIntervalMs: 0, // sync — not a poller
+    batchSize: 0,
+    model: "gpt-5.4-nano",
+    maxTokens: 256,
+    extra: {},
+  },
+  drafter: {
+    enabled: true,
+    pollIntervalMs: 10_000,
+    batchSize: 5,
+    model: "gpt-5.4-nano",
+    maxTokens: 8000,
+    extra: { max_depth: 2 },
+  },
+};
+
+// ── YAML loading (mtime-cached) ────────────────────────────────────
+
+function arkeonHome(): string {
+  return process.env.ARKEON_WIKI_HOME ?? join(homedir(), ".arkeon-wiki");
+}
+
+function workersYamlPath(): string {
+  return process.env.ARKEON_WORKERS_CONFIG ?? join(arkeonHome(), "workers.yaml");
+}
+
+let _yamlCache: {
+  value: WorkersYaml | null;
+  path: string;
+  mtimeMs: number | null;
+  size: number | null;
+} | null = null;
+
+export function loadWorkersYaml(): WorkersYaml | null {
+  const path = workersYamlPath();
+
+  if (!existsSync(path)) {
+    if (_yamlCache && _yamlCache.path === path && _yamlCache.mtimeMs === null) {
+      return _yamlCache.value;
+    }
+    _yamlCache = { value: null, path, mtimeMs: null, size: null };
+    return null;
+  }
+
+  const stat = statSync(path);
+  if (
+    _yamlCache &&
+    _yamlCache.path === path &&
+    _yamlCache.mtimeMs === stat.mtimeMs &&
+    _yamlCache.size === stat.size
+  ) {
+    return _yamlCache.value;
+  }
+
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = yaml.load(raw) as WorkersYaml;
+    _yamlCache = { value: parsed, path, mtimeMs: stat.mtimeMs, size: stat.size };
+    return parsed;
+  } catch (err) {
+    console.warn(`[worker-config] failed to parse ${path}:`, (err as Error).message);
+    _yamlCache = { value: null, path, mtimeMs: stat.mtimeMs, size: stat.size };
+    return null;
+  }
+}
+
+/** For tests: forget cached YAML. */
+export function resetWorkerConfigCache(): void {
+  _yamlCache = null;
+}
+
+// ── Duration parsing ───────────────────────────────────────────────
+
+const DURATION_MULTIPLIERS: Record<string, number> = {
+  ms: 1,
+  s: 1000,
+  m: 60_000,
+  h: 3_600_000,
+};
+
+export function parseDuration(s: string): number {
+  const match = s.match(/^(\d+(?:\.\d+)?)\s*(ms|s|m|h)$/);
+  if (!match) throw new Error(`Invalid duration: "${s}"`);
+  const [, n, unit] = match;
+  return Math.round(parseFloat(n!) * DURATION_MULTIPLIERS[unit!]!);
+}
+
+// ── Config resolution ──────────────────────────────────────────────
+
+/**
+ * Resolve the full config for a worker by merging:
+ *   workers.yaml worker block > workers.yaml global llm > hardcoded defaults
+ */
+export function resolveWorkerConfig(name: WorkerName, yamlConfig?: WorkersYaml | null): ResolvedWorkerConfig {
+  const cfg = yamlConfig ?? loadWorkersYaml();
+  const defaults = WORKER_DEFAULTS[name];
+  const workerCfg = cfg?.workers?.[name] as WorkerConfigBase & BackgroundWorkerConfig & Record<string, unknown> | undefined;
+  const globalLlm = cfg?.llm ?? {};
+
+  // Enabled
+  const enabled = workerCfg?.enabled ?? defaults.enabled;
+
+  // Poll interval
+  let pollIntervalMs = defaults.pollIntervalMs;
+  if (workerCfg?.poll_interval) {
+    pollIntervalMs = parseDuration(workerCfg.poll_interval);
+  }
+
+  // Batch size
+  const batchSize = workerCfg?.batch_size ?? defaults.batchSize;
+
+  // LLM: worker llm > global llm > defaults
+  const workerLlm = workerCfg?.llm ?? {};
+  const llm: ResolvedWorkerConfig["llm"] = {
+    provider: workerLlm.provider ?? globalLlm.provider,
+    base_url: workerLlm.base_url ?? globalLlm.base_url,
+    api_key: workerLlm.api_key ?? globalLlm.api_key,
+    model: workerLlm.model ?? globalLlm.model ?? defaults.model,
+    max_tokens: workerLlm.max_tokens ?? globalLlm.max_tokens ?? defaults.maxTokens,
+  };
+
+  // Prompt
+  const prompt: ResolvedWorkerConfig["prompt"] = {
+    mode: workerCfg?.prompt_mode ?? "replace",
+    text: workerCfg?.prompt ?? null,
+  };
+
+  // Extra (worker-specific settings)
+  const extra: Record<string, unknown> = { ...defaults.extra };
+  if (name === "drafter" && (workerCfg as DrafterConfig)?.max_depth !== undefined) {
+    extra.max_depth = (workerCfg as DrafterConfig).max_depth;
+  }
+
+  return { name, enabled, pollIntervalMs, batchSize, llm, prompt, extra };
+}
+
+// ── Prompt building ────────────────────────────────────────────────
+
+/**
+ * Merge a built-in prompt with user-configured prompt text according
+ * to the prompt mode.
+ *
+ * - replace: user text fully replaces built-in (if user text is set)
+ * - prepend: user text goes before built-in
+ * - append:  user text goes after built-in
+ * - null/undefined user text: always returns built-in unchanged
+ */
+export function buildPrompt(builtIn: string, config: ResolvedWorkerConfig["prompt"]): string {
+  if (!config.text) return builtIn;
+  switch (config.mode) {
+    case "prepend": return `${config.text}\n\n${builtIn}`;
+    case "append": return `${builtIn}\n\n${config.text}`;
+    case "replace": return config.text;
+  }
+}
+
+// ── LLM config for llm.ts integration ──────────────────────────────
+
+/** Map LLM step names to their parent worker. */
+const STEP_TO_WORKER: Record<string, WorkerName> = {
+  resolve: "extractor",
+  exists: "extractor",
+  draft: "drafter",
+  // Future: dedup → consolidator, connect → connector
+};
+
+/**
+ * Get the LLM config for a given pipeline step from workers.yaml.
+ * Returns partial config — the caller (llm.ts) merges this with
+ * its own fallback chain (llm.json > env > hardcoded).
+ *
+ * For the extractor, also checks `workers.extractor.steps.<step>`
+ * for step-level overrides.
+ */
+export function getWorkerLlmConfig(step: string): Partial<LlmConfig> | null {
+  const workerName = STEP_TO_WORKER[step];
+  if (!workerName) return null;
+
+  const cfg = loadWorkersYaml();
+  if (!cfg) return null;
+
+  const globalLlm = cfg.llm ?? {};
+  const workerCfg = cfg.workers?.[workerName] as WorkerConfigBase & Record<string, unknown> | undefined;
+  const workerLlm = workerCfg?.llm ?? {};
+
+  // For extractor, check step-level config
+  let stepLlm: Partial<LlmConfig> = {};
+  if (workerName === "extractor") {
+    const extCfg = workerCfg as ExtractorConfig | undefined;
+    const stepCfg = extCfg?.steps?.[step as "resolve" | "exists"];
+    if (stepCfg) {
+      stepLlm = {
+        model: stepCfg.model,
+        max_tokens: stepCfg.max_tokens,
+      };
+    }
+  }
+
+  // Merge: step > worker > global (only non-undefined values)
+  const merged: Partial<LlmConfig> = {};
+  for (const key of ["provider", "base_url", "api_key", "model", "max_tokens"] as const) {
+    const val = stepLlm[key] ?? workerLlm[key] ?? globalLlm[key];
+    if (val !== undefined) {
+      (merged as Record<string, unknown>)[key] = val;
+    }
+  }
+
+  return Object.keys(merged).length > 0 ? merged : null;
+}
+
+/**
+ * Get the prompt config for a given pipeline step from workers.yaml.
+ * For extractor steps, checks step-level prompt config first, then
+ * falls back to the extractor worker-level prompt config.
+ */
+export function getWorkerPromptConfig(step: string): ResolvedWorkerConfig["prompt"] | null {
+  const workerName = STEP_TO_WORKER[step];
+  if (!workerName) return null;
+
+  const cfg = loadWorkersYaml();
+  if (!cfg) return null;
+
+  const workerCfg = cfg.workers?.[workerName] as WorkerConfigBase & Record<string, unknown> | undefined;
+  if (!workerCfg) return null;
+
+  // For extractor, check step-level prompt first
+  if (workerName === "extractor") {
+    const extCfg = workerCfg as ExtractorConfig;
+    const stepCfg = extCfg.steps?.[step as "resolve" | "exists"];
+    if (stepCfg?.prompt) {
+      return { mode: stepCfg.prompt_mode ?? "replace", text: stepCfg.prompt };
+    }
+  }
+
+  // Worker-level prompt
+  if (workerCfg.prompt) {
+    return { mode: workerCfg.prompt_mode ?? "replace", text: workerCfg.prompt };
+  }
+
+  return null;
+}

--- a/packages/arkeon/src/server/lib/worker-registry.ts
+++ b/packages/arkeon/src/server/lib/worker-registry.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Worker registry — loads workers.yaml, instantiates background workers,
+ * manages their lifecycle.
+ *
+ * The extractor is not registered here — it runs synchronously in the
+ * request path and reads its config via worker-config.ts directly.
+ */
+
+import { loadWorkersYaml, resolveWorkerConfig, type WorkerName } from "./worker-config.js";
+import { ArkeonWorker } from "./worker.js";
+import { DraftWorker } from "./workers/draft-worker.js";
+
+// Future workers — uncomment when implemented:
+// import { ConsolidatorWorker } from "./workers/consolidator-worker.js";
+// import { ConnectorWorker } from "./workers/connector-worker.js";
+
+const workers: ArkeonWorker[] = [];
+
+interface WorkerDef {
+  name: WorkerName;
+  Ctor: new (config: ReturnType<typeof resolveWorkerConfig>) => ArkeonWorker;
+}
+
+const WORKER_DEFS: WorkerDef[] = [
+  { name: "drafter", Ctor: DraftWorker },
+  // { name: "consolidator", Ctor: ConsolidatorWorker },
+  // { name: "connector", Ctor: ConnectorWorker },
+];
+
+export async function startWorkers(): Promise<void> {
+  const yamlConfig = loadWorkersYaml();
+
+  for (const { name, Ctor } of WORKER_DEFS) {
+    const config = resolveWorkerConfig(name, yamlConfig);
+    const worker = new Ctor(config);
+    await worker.init();
+    worker.start();
+    workers.push(worker);
+  }
+}
+
+export function stopWorkers(): void {
+  for (const w of workers) w.stop();
+  workers.length = 0;
+}

--- a/packages/arkeon/src/server/lib/worker.ts
+++ b/packages/arkeon/src/server/lib/worker.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Abstract base class for Arkeon background workers.
+ *
+ * Provides a poll loop with skip-if-running guard, lifecycle hooks,
+ * and prompt building. Synchronous workers (extractor) do not extend
+ * this — they read config via worker-config.ts directly.
+ *
+ * Pattern mirrors retention.ts: setInterval with unref so the loop
+ * does not keep Node alive on its own.
+ */
+
+import type { ResolvedWorkerConfig } from "./worker-config.js";
+import { buildPrompt } from "./worker-config.js";
+
+export abstract class ArkeonWorker {
+  readonly name: string;
+  protected config: ResolvedWorkerConfig;
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+
+  constructor(name: string, config: ResolvedWorkerConfig) {
+    this.name = name;
+    this.config = config;
+  }
+
+  /** Called once at startup. Override for setup work. */
+  async init(): Promise<void> {}
+
+  /** Background workers implement this to poll for and process work. */
+  protected abstract poll(): Promise<void>;
+
+  /** Start the poll loop. No-op if disabled or pollIntervalMs <= 0. */
+  start(): void {
+    if (!this.config.enabled) {
+      console.log(`[worker:${this.name}] disabled — skipping`);
+      return;
+    }
+    if (this.config.pollIntervalMs <= 0) return;
+
+    console.log(
+      `[worker:${this.name}] started — polling every ${this.config.pollIntervalMs}ms`,
+    );
+
+    // Immediate first tick, then settle into cadence.
+    void this.tick();
+    this.timer = setInterval(() => void this.tick(), this.config.pollIntervalMs);
+    this.timer.unref?.();
+  }
+
+  private async tick(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+    try {
+      await this.poll();
+    } catch (err) {
+      console.error(`[worker:${this.name}]`, err);
+    } finally {
+      this.running = false;
+    }
+  }
+
+  /** Stop the poll loop. */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * Build a system prompt by merging the built-in default with the
+   * user's configured prompt text according to prompt_mode.
+   */
+  protected resolvePrompt(builtIn: string): string {
+    return buildPrompt(builtIn, this.config.prompt);
+  }
+}

--- a/packages/arkeon/src/server/lib/workers/draft-worker.ts
+++ b/packages/arkeon/src/server/lib/workers/draft-worker.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Draft worker — polls wiki_draft_queue for pending placeholder entities
+ * and drafts wiki content for them via LLM.
+ *
+ * Phase 2 stub: the poll loop is wired up and will dequeue items, but
+ * the actual LLM drafting logic is not yet implemented.
+ */
+
+import { ArkeonWorker } from "../worker.js";
+import type { ResolvedWorkerConfig } from "../worker-config.js";
+import { withTransaction } from "../sql.js";
+
+export class DraftWorker extends ArkeonWorker {
+  constructor(config: ResolvedWorkerConfig) {
+    super("drafter", config);
+  }
+
+  protected async poll(): Promise<void> {
+    const batchSize = this.config.batchSize;
+    const maxDepth = (this.config.extra.max_depth as number) ?? 2;
+
+    // Claim a batch of pending items using advisory lock to prevent
+    // concurrent workers from grabbing the same rows.
+    const items = await withTransaction(async (tx) => {
+      // Try advisory lock — skip this tick if another worker holds it
+      const lockResult = await tx`SELECT pg_try_advisory_xact_lock(8675309) AS locked`;
+      if (!lockResult[0]?.locked) return [];
+
+      return tx`
+        UPDATE wiki_draft_queue
+        SET status = 'processing', attempts = attempts + 1
+        WHERE entity_id IN (
+          SELECT entity_id FROM wiki_draft_queue
+          WHERE status = 'pending'
+            AND depth <= ${maxDepth}
+          ORDER BY created_at ASC
+          LIMIT ${batchSize}
+          FOR UPDATE SKIP LOCKED
+        )
+        RETURNING entity_id, depth, owner_agent
+      `;
+    });
+
+    if (items.length === 0) return;
+
+    console.log(`[worker:drafter] dequeued ${items.length} item(s)`);
+
+    for (const item of items) {
+      const entityId = String(item.entity_id);
+      const depth = Number(item.depth);
+
+      try {
+        await this.draftEntity(entityId, depth, String(item.owner_agent));
+      } catch (err) {
+        console.error(`[worker:drafter] failed to draft ${entityId}:`, (err as Error).message);
+        await withTransaction(async (tx) => {
+          await tx`
+            UPDATE wiki_draft_queue
+            SET status = CASE WHEN attempts >= max_attempts THEN 'failed' ELSE 'pending' END,
+                error = ${(err as Error).message}
+            WHERE entity_id = ${entityId}
+          `;
+        });
+      }
+    }
+  }
+
+  private async draftEntity(entityId: string, depth: number, _ownerAgent: string): Promise<void> {
+    // Fetch the placeholder entity to get its label + description
+    const rows = await withTransaction(async (tx) => {
+      return tx`
+        SELECT properties FROM entities
+        WHERE id = ${entityId} AND kind = 'entity' AND type = 'placeholder'
+      `;
+    });
+
+    if (rows.length === 0) {
+      // Entity no longer exists or is no longer a placeholder — mark undraftable
+      await withTransaction(async (tx) => {
+        await tx`
+          UPDATE wiki_draft_queue SET status = 'undraftable'
+          WHERE entity_id = ${entityId}
+        `;
+      });
+      return;
+    }
+
+    const props = rows[0]!.properties as Record<string, unknown>;
+    const _label = String(props.label ?? "");
+    const _description = String(props.description ?? "");
+
+    // TODO(phase-2): Implement actual LLM drafting
+    // 1. Build prompt using this.resolvePrompt(DRAFT_PROMPT) with entity context
+    // 2. Call LLM to generate wiki content
+    // 3. POST /wiki with depth+1 to create the wiki (triggers the full pipeline)
+    // 4. Mark queue item as 'complete'
+    //
+    // For now, mark as undraftable so items don't spin forever.
+    await withTransaction(async (tx) => {
+      await tx`
+        UPDATE wiki_draft_queue SET status = 'undraftable',
+          error = 'draft worker not yet implemented'
+        WHERE entity_id = ${entityId}
+      `;
+    });
+  }
+}

--- a/packages/arkeon/src/server/server.ts
+++ b/packages/arkeon/src/server/server.ts
@@ -24,6 +24,7 @@ import { createApp, openApiConfig } from "./app.js";
 import { ensureBootstrap } from "./lib/bootstrap.js";
 import { ensureMeiliIndex, isMeilisearchConfigured } from "./lib/meilisearch.js";
 import { startRetention, stopRetention } from "./lib/retention.js";
+import { startWorkers, stopWorkers } from "./lib/worker-registry.js";
 
 export interface ArkeonApiConfig {
   /** TCP port to bind. Default: process.env.PORT ?? 8000 */
@@ -113,11 +114,7 @@ export async function startApi(config: ArkeonApiConfig = {}): Promise<ArkeonApi>
   });
 
   startRetention();
-
-  // TODO(phase-2): Start wiki background processors here:
-  //   - Draft worker: polls wiki_draft_queue, calls POST /wiki with depth+1
-  //   - Dedup poller: watches published wikis, finds duplicate labels/aliases, dispatches edits
-  // Pattern: use setInterval like retention.ts, or a dedicated poller
+  await startWorkers();
 
   const address = server.address() as AddressInfo;
 
@@ -126,6 +123,7 @@ export async function startApi(config: ArkeonApiConfig = {}): Promise<ArkeonApi>
       opts.drainTimeoutMs ?? (Number(process.env.DRAIN_TIMEOUT_MS) || 320_000);
 
     const drainPromise = (async () => {
+      stopWorkers();
       stopRetention();
       await new Promise<void>((resolve, reject) =>
         server.close((err) => (err ? reject(err) : resolve())),

--- a/packages/arkeon/test/unit/worker-config.test.ts
+++ b/packages/arkeon/test/unit/worker-config.test.ts
@@ -157,17 +157,17 @@ describe("loadWorkersYaml", () => {
   let prevConfig: string | undefined;
 
   beforeEach(() => {
-    prevHome = process.env.ARKEON_HOME;
+    prevHome = process.env.ARKEON_WIKI_HOME;
     prevConfig = process.env.ARKEON_WORKERS_CONFIG;
     scratch = mkdtempSync(join(tmpdir(), "arkeon-worker-cfg-"));
-    process.env.ARKEON_HOME = scratch;
+    process.env.ARKEON_WIKI_HOME = scratch;
     delete process.env.ARKEON_WORKERS_CONFIG;
     resetWorkerConfigCache();
   });
 
   afterEach(() => {
-    if (prevHome !== undefined) process.env.ARKEON_HOME = prevHome;
-    else delete process.env.ARKEON_HOME;
+    if (prevHome !== undefined) process.env.ARKEON_WIKI_HOME = prevHome;
+    else delete process.env.ARKEON_WIKI_HOME;
     if (prevConfig !== undefined) process.env.ARKEON_WORKERS_CONFIG = prevConfig;
     else delete process.env.ARKEON_WORKERS_CONFIG;
     rmSync(scratch, { recursive: true, force: true });
@@ -233,15 +233,15 @@ describe("getWorkerLlmConfig", () => {
   let prevHome: string | undefined;
 
   beforeEach(() => {
-    prevHome = process.env.ARKEON_HOME;
+    prevHome = process.env.ARKEON_WIKI_HOME;
     scratch = mkdtempSync(join(tmpdir(), "arkeon-wlc-"));
-    process.env.ARKEON_HOME = scratch;
+    process.env.ARKEON_WIKI_HOME = scratch;
     resetWorkerConfigCache();
   });
 
   afterEach(() => {
-    if (prevHome !== undefined) process.env.ARKEON_HOME = prevHome;
-    else delete process.env.ARKEON_HOME;
+    if (prevHome !== undefined) process.env.ARKEON_WIKI_HOME = prevHome;
+    else delete process.env.ARKEON_WIKI_HOME;
     rmSync(scratch, { recursive: true, force: true });
     resetWorkerConfigCache();
   });
@@ -291,15 +291,15 @@ describe("getWorkerPromptConfig", () => {
   let prevHome: string | undefined;
 
   beforeEach(() => {
-    prevHome = process.env.ARKEON_HOME;
+    prevHome = process.env.ARKEON_WIKI_HOME;
     scratch = mkdtempSync(join(tmpdir(), "arkeon-wpc-"));
-    process.env.ARKEON_HOME = scratch;
+    process.env.ARKEON_WIKI_HOME = scratch;
     resetWorkerConfigCache();
   });
 
   afterEach(() => {
-    if (prevHome !== undefined) process.env.ARKEON_HOME = prevHome;
-    else delete process.env.ARKEON_HOME;
+    if (prevHome !== undefined) process.env.ARKEON_WIKI_HOME = prevHome;
+    else delete process.env.ARKEON_WIKI_HOME;
     rmSync(scratch, { recursive: true, force: true });
     resetWorkerConfigCache();
   });

--- a/packages/arkeon/test/unit/worker-config.test.ts
+++ b/packages/arkeon/test/unit/worker-config.test.ts
@@ -1,0 +1,330 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  parseDuration,
+  buildPrompt,
+  resolveWorkerConfig,
+  loadWorkersYaml,
+  resetWorkerConfigCache,
+  getWorkerLlmConfig,
+  getWorkerPromptConfig,
+} from "../../src/server/lib/worker-config.js";
+
+// ── parseDuration ──────────────────────────────────────────────────
+
+describe("parseDuration", () => {
+  test("parses milliseconds", () => {
+    expect(parseDuration("500ms")).toBe(500);
+  });
+
+  test("parses seconds", () => {
+    expect(parseDuration("10s")).toBe(10_000);
+  });
+
+  test("parses minutes", () => {
+    expect(parseDuration("5m")).toBe(300_000);
+  });
+
+  test("parses hours", () => {
+    expect(parseDuration("2h")).toBe(7_200_000);
+  });
+
+  test("parses fractional values", () => {
+    expect(parseDuration("1.5s")).toBe(1500);
+    expect(parseDuration("0.5m")).toBe(30_000);
+  });
+
+  test("throws on invalid format", () => {
+    expect(() => parseDuration("five")).toThrow('Invalid duration: "five"');
+    expect(() => parseDuration("10")).toThrow('Invalid duration: "10"');
+    expect(() => parseDuration("10d")).toThrow('Invalid duration: "10d"');
+    expect(() => parseDuration("")).toThrow('Invalid duration: ""');
+  });
+});
+
+// ── buildPrompt ────────────────────────────────────────────────────
+
+describe("buildPrompt", () => {
+  const BUILTIN = "You are a judge.";
+
+  test("returns built-in when text is null", () => {
+    expect(buildPrompt(BUILTIN, { mode: "append", text: null })).toBe(BUILTIN);
+  });
+
+  test("returns built-in when text is empty string", () => {
+    expect(buildPrompt(BUILTIN, { mode: "append", text: "" })).toBe(BUILTIN);
+  });
+
+  test("append mode adds text after built-in", () => {
+    const result = buildPrompt(BUILTIN, { mode: "append", text: "Extra rule." });
+    expect(result).toBe("You are a judge.\n\nExtra rule.");
+  });
+
+  test("prepend mode adds text before built-in", () => {
+    const result = buildPrompt(BUILTIN, { mode: "prepend", text: "Important:" });
+    expect(result).toBe("Important:\n\nYou are a judge.");
+  });
+
+  test("replace mode fully replaces built-in", () => {
+    const result = buildPrompt(BUILTIN, { mode: "replace", text: "Custom prompt." });
+    expect(result).toBe("Custom prompt.");
+  });
+});
+
+// ── resolveWorkerConfig ────────────────────────────────────────────
+
+describe("resolveWorkerConfig", () => {
+  test("returns hardcoded defaults when no yaml is provided", () => {
+    const cfg = resolveWorkerConfig("drafter", null);
+    expect(cfg.name).toBe("drafter");
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.pollIntervalMs).toBe(10_000);
+    expect(cfg.batchSize).toBe(5);
+    expect(cfg.llm.model).toBe("gpt-5.4-nano");
+    expect(cfg.llm.max_tokens).toBe(8000);
+    expect(cfg.extra.max_depth).toBe(2);
+  });
+
+  test("extractor defaults are sync (pollIntervalMs = 0)", () => {
+    const cfg = resolveWorkerConfig("extractor", null);
+    expect(cfg.pollIntervalMs).toBe(0);
+    expect(cfg.enabled).toBe(true);
+  });
+
+  test("prompt_mode defaults to append", () => {
+    const cfg = resolveWorkerConfig("drafter", null);
+    expect(cfg.prompt.mode).toBe("append");
+    expect(cfg.prompt.text).toBeNull();
+  });
+
+  test("yaml worker block overrides defaults", () => {
+    const cfg = resolveWorkerConfig("drafter", {
+      workers: {
+        drafter: {
+          enabled: false,
+          poll_interval: "30s",
+          batch_size: 10,
+          max_depth: 5,
+          llm: { model: "gpt-4o", max_tokens: 16000 },
+          prompt_mode: "replace",
+          prompt: "Custom drafter prompt.",
+        },
+      },
+    });
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.pollIntervalMs).toBe(30_000);
+    expect(cfg.batchSize).toBe(10);
+    expect(cfg.extra.max_depth).toBe(5);
+    expect(cfg.llm.model).toBe("gpt-4o");
+    expect(cfg.llm.max_tokens).toBe(16000);
+    expect(cfg.prompt.mode).toBe("replace");
+    expect(cfg.prompt.text).toBe("Custom drafter prompt.");
+  });
+
+  test("global llm block applies when worker llm is absent", () => {
+    const cfg = resolveWorkerConfig("drafter", {
+      llm: { api_key: "sk-global", model: "gpt-4o-mini" },
+    });
+    expect(cfg.llm.api_key).toBe("sk-global");
+    expect(cfg.llm.model).toBe("gpt-4o-mini");
+  });
+
+  test("worker llm overrides global llm", () => {
+    const cfg = resolveWorkerConfig("drafter", {
+      llm: { api_key: "sk-global", model: "gpt-4o-mini" },
+      workers: {
+        drafter: {
+          llm: { model: "gpt-4o", api_key: "sk-drafter" },
+        },
+      },
+    });
+    expect(cfg.llm.api_key).toBe("sk-drafter");
+    expect(cfg.llm.model).toBe("gpt-4o");
+  });
+});
+
+// ── YAML loading + validation ──────────────────────────────────────
+
+describe("loadWorkersYaml", () => {
+  let scratch: string;
+  let prevHome: string | undefined;
+  let prevConfig: string | undefined;
+
+  beforeEach(() => {
+    prevHome = process.env.ARKEON_HOME;
+    prevConfig = process.env.ARKEON_WORKERS_CONFIG;
+    scratch = mkdtempSync(join(tmpdir(), "arkeon-worker-cfg-"));
+    process.env.ARKEON_HOME = scratch;
+    delete process.env.ARKEON_WORKERS_CONFIG;
+    resetWorkerConfigCache();
+  });
+
+  afterEach(() => {
+    if (prevHome !== undefined) process.env.ARKEON_HOME = prevHome;
+    else delete process.env.ARKEON_HOME;
+    if (prevConfig !== undefined) process.env.ARKEON_WORKERS_CONFIG = prevConfig;
+    else delete process.env.ARKEON_WORKERS_CONFIG;
+    rmSync(scratch, { recursive: true, force: true });
+    resetWorkerConfigCache();
+  });
+
+  test("returns null when file does not exist", () => {
+    expect(loadWorkersYaml()).toBeNull();
+  });
+
+  test("loads a valid workers.yaml", () => {
+    writeFileSync(
+      join(scratch, "workers.yaml"),
+      "llm:\n  api_key: sk-test\n  model: gpt-4o\n",
+    );
+    const cfg = loadWorkersYaml();
+    expect(cfg?.llm?.api_key).toBe("sk-test");
+    expect(cfg?.llm?.model).toBe("gpt-4o");
+  });
+
+  test("throws on malformed YAML syntax", () => {
+    writeFileSync(join(scratch, "workers.yaml"), "{{not yaml");
+    expect(() => loadWorkersYaml()).toThrow(/invalid YAML/);
+  });
+
+  test("throws when batch_size is not a number", () => {
+    writeFileSync(
+      join(scratch, "workers.yaml"),
+      "workers:\n  drafter:\n    batch_size: five\n",
+    );
+    expect(() => loadWorkersYaml()).toThrow(/batch_size must be a number/);
+  });
+
+  test("throws when enabled is not a boolean", () => {
+    writeFileSync(
+      join(scratch, "workers.yaml"),
+      "workers:\n  extractor:\n    enabled: yes_please\n",
+    );
+    expect(() => loadWorkersYaml()).toThrow(/enabled must be a boolean/);
+  });
+
+  test("throws when prompt_mode is invalid", () => {
+    writeFileSync(
+      join(scratch, "workers.yaml"),
+      "workers:\n  drafter:\n    prompt_mode: merge\n",
+    );
+    expect(() => loadWorkersYaml()).toThrow(/prompt_mode must be one of/);
+  });
+
+  test("throws when llm.max_tokens is not a number", () => {
+    writeFileSync(
+      join(scratch, "workers.yaml"),
+      "llm:\n  max_tokens: lots\n",
+    );
+    expect(() => loadWorkersYaml()).toThrow(/max_tokens must be a number/);
+  });
+});
+
+// ── getWorkerLlmConfig ─────────────────────────────────────────────
+
+describe("getWorkerLlmConfig", () => {
+  let scratch: string;
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    prevHome = process.env.ARKEON_HOME;
+    scratch = mkdtempSync(join(tmpdir(), "arkeon-wlc-"));
+    process.env.ARKEON_HOME = scratch;
+    resetWorkerConfigCache();
+  });
+
+  afterEach(() => {
+    if (prevHome !== undefined) process.env.ARKEON_HOME = prevHome;
+    else delete process.env.ARKEON_HOME;
+    rmSync(scratch, { recursive: true, force: true });
+    resetWorkerConfigCache();
+  });
+
+  test("returns null for unknown step", () => {
+    expect(getWorkerLlmConfig("unknown")).toBeNull();
+  });
+
+  test("returns null when no workers.yaml exists", () => {
+    expect(getWorkerLlmConfig("resolve")).toBeNull();
+  });
+
+  test("returns global llm config for known step", () => {
+    writeFileSync(
+      join(scratch, "workers.yaml"),
+      "llm:\n  api_key: sk-g\n  model: gpt-4o\n",
+    );
+    const cfg = getWorkerLlmConfig("resolve");
+    expect(cfg?.api_key).toBe("sk-g");
+    expect(cfg?.model).toBe("gpt-4o");
+  });
+
+  test("extractor step config overrides worker config", () => {
+    writeFileSync(
+      join(scratch, "workers.yaml"),
+      [
+        "workers:",
+        "  extractor:",
+        "    llm:",
+        "      model: gpt-4o",
+        "    steps:",
+        "      resolve:",
+        "        model: gpt-5.4-nano",
+        "        max_tokens: 128",
+      ].join("\n"),
+    );
+    const cfg = getWorkerLlmConfig("resolve");
+    expect(cfg?.model).toBe("gpt-5.4-nano");
+    expect(cfg?.max_tokens).toBe(128);
+  });
+});
+
+// ── getWorkerPromptConfig ──────────────────────────────────────────
+
+describe("getWorkerPromptConfig", () => {
+  let scratch: string;
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    prevHome = process.env.ARKEON_HOME;
+    scratch = mkdtempSync(join(tmpdir(), "arkeon-wpc-"));
+    process.env.ARKEON_HOME = scratch;
+    resetWorkerConfigCache();
+  });
+
+  afterEach(() => {
+    if (prevHome !== undefined) process.env.ARKEON_HOME = prevHome;
+    else delete process.env.ARKEON_HOME;
+    rmSync(scratch, { recursive: true, force: true });
+    resetWorkerConfigCache();
+  });
+
+  test("returns null when no workers.yaml", () => {
+    expect(getWorkerPromptConfig("resolve")).toBeNull();
+  });
+
+  test("returns worker-level prompt config", () => {
+    writeFileSync(
+      join(scratch, "workers.yaml"),
+      "workers:\n  drafter:\n    prompt: Custom draft rules.\n    prompt_mode: replace\n",
+    );
+    const cfg = getWorkerPromptConfig("draft");
+    expect(cfg?.text).toBe("Custom draft rules.");
+    expect(cfg?.mode).toBe("replace");
+  });
+
+  test("defaults prompt_mode to append", () => {
+    writeFileSync(
+      join(scratch, "workers.yaml"),
+      "workers:\n  extractor:\n    prompt: Extra rules.\n",
+    );
+    const cfg = getWorkerPromptConfig("resolve");
+    expect(cfg?.mode).toBe("append");
+    expect(cfg?.text).toBe("Extra rules.");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `~/.arkeon/workers.yaml` as the single config surface for all wiki pipeline workers (model, API key, custom prompts, polling intervals, enable/disable)
- Subsumes `llm.json` — workers.yaml takes precedence, llm.json remains as backward-compatible fallback
- Prompt customization via `prompt_mode` (replace/prepend/append) lets users extend or override built-in system prompts per worker
- Wires up draft worker with advisory-lock-based queue polling (LLM drafting logic is a stub for now)
- Updates `docs/dev/WIKI_PIPELINE.md` with full worker config reference

### New files
- `worker-config.ts` — YAML loader, types, config resolution, duration parsing, prompt building
- `worker.ts` — `ArkeonWorker` base class with poll loop lifecycle
- `worker-registry.ts` — `startWorkers()`/`stopWorkers()` wired into server startup/shutdown
- `workers/draft-worker.ts` — polls `wiki_draft_queue`, claims batches with `pg_try_advisory_xact_lock`

### Modified files
- `llm.ts` — resolution chain checks workers.yaml before llm.json
- `entity-resolve.ts` — `JUDGE_PROMPT` flows through `buildPrompt()` for user customization
- `server.ts` — replaces Phase 2 TODO with worker lifecycle calls
- `package.json` — moves `js-yaml` from devDeps to deps

## Test plan
- [x] `npm run typecheck` passes
- [x] All 102 unit tests pass
- [ ] Manual: create `~/.arkeon/workers.yaml` with `prompt_mode: append`, verify prompt is combined
- [ ] Manual: verify system works with no workers.yaml (env/llm.json fallback)
- [ ] Manual: `arkeon-wiki start` logs worker startup status

🤖 Generated with [Claude Code](https://claude.com/claude-code)