### PR TITLE
fix: smoke test bugs (P0-P2) + comprehensive doc audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ arkeon <resource> <action> [args]
 arkeon entities create --type concept --properties '{"label":"distributed systems"}'
 arkeon relationships list --source-id <id>
 arkeon spaces list
+
+# Manage auth profiles (for multi-actor workflows)
+arkeon auth profiles           # list profiles for this instance
+arkeon auth use <name>         # switch active profile
+arkeon auth add <name>         # create new actor + profile (admin)
 ```
 
 ## Reference
@@ -113,6 +118,7 @@ When the stack is running, the API is also self-documenting:
 ## Configuration
 
 All state lives in `~/.arkeon-wiki/` by default (override with `ARKEON_WIKI_HOME`).
+Configure LLM workers for link resolution and auto-drafting via `~/.arkeon-wiki/workers.yaml`. See [Advanced Configuration](docs/ADVANCED.md) for the full schema.
 For external Postgres/Meilisearch and other configuration options, see
 the [quickstart](docs/user/QUICKSTART.md).
 
@@ -155,7 +161,6 @@ npm test -w packages/arkeon            # Unit tests
 | [Classification](docs/dev/CLASSIFICATION.md) | 5-tier read/write access control |
 | [Filtering](docs/dev/FILTERING.md) | Query syntax for list endpoints |
 | [Entity refs](docs/dev/ENTITY_REFS.md) | Entity reference conventions |
-| [Ingest ops](docs/dev/INGEST_OPS.md) | Bulk ingestion via POST /ops |
 | [Files](docs/dev/FILES.md) | Binary content storage (S3/local) |
 | [Error contract](docs/dev/ERROR_CONTRACT.md) | JSON error response shape |
 | [SDK](docs/dev/SDK.md) | TypeScript SDK usage |

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -9,9 +9,10 @@ opt-in and not required for core usage.
 
 ## Worker configuration (`workers.yaml`)
 
-Workers are background processes that enrich your knowledge graph: the
-**extractor** resolves placeholder links into entities, the **drafter**
-writes wiki content for stub entities, and the **consolidator** deduplicates.
+Workers are background processes that enrich your knowledge graph. Currently
+implemented: the **extractor** resolves placeholder links into entities, and
+the **drafter** writes wiki content for stub entities. Additional workers
+(consolidator, connector) are planned but not yet available.
 
 Configure them via `~/.arkeon-wiki/workers.yaml` (override path with
 `ARKEON_WORKERS_CONFIG`). If the file doesn't exist, built-in defaults
@@ -57,8 +58,7 @@ workers:
       model: gpt-4o
       max_tokens: 8000
 
-  consolidator:
-    enabled: false            # disabled by default
+  # consolidator and connector are planned but not yet implemented
 ```
 
 ### Prompt customization modes

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -7,6 +7,77 @@ opt-in and not required for core usage.
 
 ---
 
+## Worker configuration (`workers.yaml`)
+
+Workers are background processes that enrich your knowledge graph: the
+**extractor** resolves placeholder links into entities, the **drafter**
+writes wiki content for stub entities, and the **consolidator** deduplicates.
+
+Configure them via `~/.arkeon-wiki/workers.yaml` (override path with
+`ARKEON_WORKERS_CONFIG`). If the file doesn't exist, built-in defaults
+apply.
+
+### Global LLM settings
+
+The top-level `llm:` block sets the default LLM for all workers:
+
+```yaml
+llm:
+  provider: openai          # openai | anthropic | openrouter
+  base_url: https://api.openai.com/v1
+  api_key: sk-...
+  model: gpt-4o
+  max_tokens: 4096
+```
+
+This supersedes `llm.json` (which still works as a lower-priority fallback).
+
+### Per-worker settings
+
+Each worker can be individually configured under `workers:`:
+
+```yaml
+workers:
+  extractor:
+    enabled: true
+    prompt_mode: append       # prepend | append | replace
+    prompt: "Extra domain rules for extraction..."
+    llm:
+      model: gpt-4o-mini     # override model for this worker
+    steps:
+      resolve: { model: gpt-4o-mini, max_tokens: 256 }
+      exists:  { model: gpt-4o-mini, max_tokens: 512 }
+
+  drafter:
+    enabled: true
+    poll_interval: 10s        # how often to check for work
+    batch_size: 5             # entities per batch
+    max_depth: 2              # link-follow depth
+    llm:
+      model: gpt-4o
+      max_tokens: 8000
+
+  consolidator:
+    enabled: false            # disabled by default
+```
+
+### Prompt customization modes
+
+- **`append`** (default) — your custom prompt is added after the built-in prompt
+- **`prepend`** — your custom prompt is added before the built-in prompt
+- **`replace`** — your custom prompt completely replaces the built-in prompt
+
+### LLM resolution priority
+
+When a worker makes an LLM call, the model/config resolves in order:
+
+1. Per-step config (e.g., `workers.extractor.steps.resolve`)
+2. Per-worker `llm` block (e.g., `workers.extractor.llm`)
+3. Top-level `llm` block
+4. `llm.json` fallback (legacy)
+
+---
+
 ## Rate limiting (not implemented)
 
 Arkeon currently ships **without any in-process rate limiting**. This is

--- a/docs/dev/AUTH.md
+++ b/docs/dev/AUTH.md
@@ -23,9 +23,11 @@ The server hashes the key (SHA-256), looks up by hash, checks `revoked_at IS NUL
 
 **Do NOT use `Bearer` with API keys.** Bearer is reserved for future JWT support.
 
-## Self-Service Registration
+## Self-Service Registration (CLI-only, server routes not yet implemented)
 
-Agents can self-register without an invite via the Ed25519 + proof-of-work flow:
+The CLI has commands for self-registration via Ed25519 + proof-of-work (`auth register`, `auth recover`), but the server endpoints they call (`POST /auth/challenge`, `POST /auth/register`, `POST /auth/recover`) are **not yet implemented**. The CLI code is ready and will work once the server routes land.
+
+Intended flow:
 
 1. Client generates an Ed25519 keypair locally
 2. Client requests a PoW challenge from `POST /auth/challenge`, sending the public key
@@ -35,14 +37,14 @@ Agents can self-register without an invite via the Ed25519 + proof-of-work flow:
 6. Server creates the actor and returns an API key (shown once)
 7. Client stores credentials (API key, keypair, entity ID) in `~/.config/arkeon-cli/credentials.json`
 
-**Key recovery:** If an API key is lost, `POST /auth/recover` accepts a signed timestamp payload proving possession of the private key and issues a new API key for the same actor. The private key never leaves the client.
+**Key recovery:** `POST /auth/recover` will accept a signed timestamp payload proving possession of the private key and issue a new API key for the same actor. The private key never leaves the client.
 
-The PoW challenge prevents spam registrations without requiring manual approval. Difficulty is server-controlled and can be tuned.
+Until these routes are implemented, actors must be created via `POST /actors` (admin-only) or `arkeon auth add <name>` (which calls `POST /actors` under the hood).
 
 ## CLI Auth Commands
 
-- `auth register` — Self-service agent registration (Ed25519 + PoW). Generates keypair, solves challenge, stores credentials locally.
-- `auth recover` — Recover API key using the stored private key (signs a timestamped payload).
+- `auth register` — Self-service agent registration (Ed25519 + PoW). **Server routes not yet implemented** — will work once `POST /auth/challenge` and `POST /auth/register` land.
+- `auth recover` — Recover API key using the stored private key. **Server route not yet implemented** — will work once `POST /auth/recover` lands.
 - `auth set-api-key <key>` — Store a raw API key locally (no keypair, no recovery possible).
 - `auth status` / `auth whoami` — Show current identity. Profile-aware when inside an initialized repo; otherwise shows global credentials.
 - `auth logout` — Clear stored credentials from the global credential store.

--- a/docs/dev/AUTH.md
+++ b/docs/dev/AUTH.md
@@ -23,6 +23,44 @@ The server hashes the key (SHA-256), looks up by hash, checks `revoked_at IS NUL
 
 **Do NOT use `Bearer` with API keys.** Bearer is reserved for future JWT support.
 
+## Self-Service Registration
+
+Agents can self-register without an invite via the Ed25519 + proof-of-work flow:
+
+1. Client generates an Ed25519 keypair locally
+2. Client requests a PoW challenge from `POST /auth/challenge`, sending the public key
+3. Client solves the PoW (hash with nonce until difficulty target is met)
+4. Client signs the challenge nonce with the private key
+5. Client submits public key, nonce, signature, solution to `POST /auth/register`
+6. Server creates the actor and returns an API key (shown once)
+7. Client stores credentials (API key, keypair, entity ID) in `~/.config/arkeon-cli/credentials.json`
+
+**Key recovery:** If an API key is lost, `POST /auth/recover` accepts a signed timestamp payload proving possession of the private key and issues a new API key for the same actor. The private key never leaves the client.
+
+The PoW challenge prevents spam registrations without requiring manual approval. Difficulty is server-controlled and can be tuned.
+
+## CLI Auth Commands
+
+- `auth register` — Self-service agent registration (Ed25519 + PoW). Generates keypair, solves challenge, stores credentials locally.
+- `auth recover` — Recover API key using the stored private key (signs a timestamped payload).
+- `auth set-api-key <key>` — Store a raw API key locally (no keypair, no recovery possible).
+- `auth status` / `auth whoami` — Show current identity. Profile-aware when inside an initialized repo; otherwise shows global credentials.
+- `auth logout` — Clear stored credentials from the global credential store.
+- `auth use <name>` — Switch the active profile for the current repo (requires `arkeon init` first).
+- `auth add <name>` — Create a new actor on the graph and register it as a local profile. Requires admin privileges.
+- `auth remove <name>` — Remove a profile locally, optionally deactivate the actor on the graph with `--delete`.
+- `auth profiles` — List all profiles registered for the current instance.
+
+## Auth Resolution Priority
+
+When making API requests, the CLI resolves credentials in this order:
+
+1. **`ARKE_API_KEY` environment variable** — explicit override, highest priority
+2. **Per-repo actor key** — from `.arkeon/state.json` `current_actor` mapped through the instance actor registry
+3. **Global credential store** — `~/.config/arkeon-cli/credentials.json`
+
+Per-repo profiles are only active inside a directory with `.arkeon/state.json` (created by `arkeon init`). Outside a repo context, only the global store and env var apply.
+
 ## Security Notes
 
 - API keys are shown exactly once — store them securely
@@ -30,11 +68,10 @@ The server hashes the key (SHA-256), looks up by hash, checks `revoked_at IS NUL
 - Revoking a key is a soft delete (`revoked_at` timestamp)
 - Invalid/revoked API keys currently proceed as unauthenticated requests (no specific 401)
 - `agent_keys` INSERT is system-only (not through RLS)
+- Ed25519 private keys are stored client-side only; the server never sees them
 
 ## Future Enhancements
 
-- **Self-service registration** — PoW + Ed25519 key pair flow (helper functions exist in `lib/auth.ts` but are not wired up)
-- **Key recovery** — sign a challenge with a private key to get a new API key
 - **Key scopes** — limit what an API key can do
 - **Key expiration** — auto-expire keys after a TTL
 - **Human auth** — JWT for browser-based users

--- a/docs/future/INSTANCE_PROFILES.md
+++ b/docs/future/INSTANCE_PROFILES.md
@@ -1,124 +1,49 @@
-# CLI Instance Profiles (Future Enhancement)
+# CLI Instance Profiles
 
-Today the Arkeon CLI assumes a single ambient instance: there is one
-configured `apiUrl`, one stored API key, and one `pendingLlmConfig`
-slot. That's correct for the MVP — most users will have one local stack
-or one remote deployment they care about — but it falls over the moment
-someone wants to run more than one Arkeon instance side by side on the
-same machine.
+> **Partially shipped** — Per-repo auth profiles landed via `arkeon auth use/add/remove/profiles`. Named instances with auto-port isolation shipped via `arkeon up --name`. See `docs/dev/AUTH.md` for current auth state.
 
-## What "more than one instance" looks like
+## What shipped
 
-Concrete cases that already exist or are imminent:
+Per-repo actor switching is live. Inside an initialized repo (`arkeon init <space>`), users can:
 
-- A user running a local stack against their personal knowledge graph
-  AND simultaneously testing a fresh stack against a different Genesis
-  seed for a demo.
-- A developer with a `cli-quickstart` worktree running on `:8001` and a
-  `merge-feature` worktree running on `:8002`, both via `arkeon up`.
-- A consultant managing several customers' deployments at
-  `acme.arkeon.tech`, `widget.arkeon.tech`, etc., from one CLI install.
-- The same developer wanting to point at staging vs production of a
-  single deployment without re-typing API keys.
+- `arkeon auth add <name>` — create an actor on the graph and register it as a named profile
+- `arkeon auth use <name>` — switch the active profile for the current repo
+- `arkeon auth remove <name>` — remove a profile (optionally deactivate the actor)
+- `arkeon auth profiles` — list profiles for the current instance
 
-In all of these the CLI today forces the user to manually `arkeon
-config set-url` and `arkeon auth set-api-key` every time they switch.
-The conf store has one slot, and `arkeon up` clobbers it.
+Profiles are scoped to a repo directory (`.arkeon/state.json` tracks `current_actor`). Actor keys are stored in the global credential store keyed by actor ID. Named instances (`arkeon up --name <slug>`) get deterministic port assignments, so multiple local stacks can coexist.
 
-## Proposed shape
+## What remains unimplemented
 
-Add a "profile" concept to the CLI conf layout. A profile is a named
-bundle of:
+### Global `--profile` flag
 
-- `apiUrl` (the existing config store value)
-- `apiKey` + `keyPrefix` + optional identity keypair (the existing
-  credentials store value)
-- `spaceId` (the existing default space override)
-- `pendingLlmConfig` (the brief carrier between `init` and `up`)
-
-The conf stores stay the same on disk but become keyed by profile name:
-
-```jsonc
-// ~/Library/Preferences/arkeon-cli/config.json
-{
-  "activeProfile": "local",
-  "profiles": {
-    "local":     { "apiUrl": "http://localhost:8000" },
-    "staging":   { "apiUrl": "https://staging.arkeon.tech", "spaceId": "01..." },
-    "acme-prod": { "apiUrl": "https://acme.arkeon.tech" }
-  }
-}
-```
-
-Credentials work the same way, namespaced by profile.
-
-### CLI surface
-
-```
-arkeon profile list                    # show all profiles, marking active
-arkeon profile use <name>              # switch active profile
-arkeon profile create <name> --url <url>
-arkeon profile delete <name>
-arkeon profile rename <old> <new>
-```
-
-Plus a `--profile <name>` global flag (alongside the existing
-`--api-url` / `--space-id` overrides) so single commands can target a
-profile without flipping the global active state:
+A `--profile <name>` flag on every command, allowing single-command targeting without switching the active profile:
 
 ```
 arkeon --profile staging entities list
 arkeon --profile acme-prod seed --dry-run
 ```
 
-`arkeon init` would gain `--profile <name>` and create the named
-profile (defaulting to a slug derived from cwd, e.g. the directory
-name) instead of clobbering the active one. `arkeon up` would write its
-results into that profile.
+This would be useful for scripting and one-off commands against non-default instances.
 
-### Migration
+### Top-level `arkeon profile` command group
 
-The first time the CLI is run after this lands, the existing flat
-config layout is migrated into a profile named `default` and that
-profile becomes active. No user action required; existing scripts that
-call `arkeon config set-url` keep working against the active profile.
+The original design proposed `arkeon profile list/use/create/delete/rename` as a top-level command group separate from auth. The current implementation folded profile management into `arkeon auth` since profiles are fundamentally about identity. Whether a top-level `profile` alias is worth adding is an open question.
 
-## Open questions to settle when this lands
+### Profile renaming
 
-1. **Profile scope of `pendingLlmConfig`.** It's a per-instance carrier,
-   so it should live inside each profile. Confirm.
-2. **Worktree integration.** Should `arkeon init` in a worktree create
-   a profile named after the worktree slug automatically? That would
-   plug into the local-dev skill cleanly but introduces magic.
-3. **Profile in env var.** `ARKE_PROFILE=staging` as a process-local
-   override, mirroring `ARKE_API_URL` / `ARKE_SPACE_ID`. Probably yes.
-4. **Profile vs space.** A profile bundles "which instance + which key";
-   a space is an in-instance scoping concept. They are orthogonal.
-   Document the distinction in `arkeon profile --help` so people don't
-   expect spaces to switch when they switch profiles.
-5. **Conf store on-disk format.** The existing `Conf` library supports
-   dotted-path access, so the migration is mechanical, but we need to
-   decide whether `credentials.json` becomes a single keyed map or
-   stays flat with the profile name baked into a `credentials.<name>`
-   property.
-6. **`arkeon up` and shared docker compose project names.** Two profiles
-   pointing at two local stacks need two distinct docker compose
-   project names so they don't share volumes. The local-dev skill
-   already handles this for worktrees via `-p arkeon-<slug>`. The CLI
-   should probably do the same automatically when `arkeon up` runs
-   inside a non-default profile.
+No `rename` command exists. Workaround: `auth remove old && auth add new`.
 
-## Why not now
+### Global profile switching
 
-The MVP ships without profiles because:
+Current profiles are per-repo only. There is no global "active profile" that applies outside of an initialized repo directory. The original design proposed a global `activeProfile` in the config store; this may not be needed given the per-repo model works well for the primary use cases.
 
-- One ambient instance is the right default for the "I just installed
-  this from npm and want to try the demo" path.
-- Adding profiles before there's a second user driving demand for them
-  ossifies the design around guesswork.
-- The conf-store migration is reversible — flat-to-profiled is a
-  one-way function but a small one, and the file format isn't a public
-  contract.
+### `ARKE_PROFILE` environment variable
 
-When the second concrete need shows up (or when the multi-worktree dev
-loop gets painful enough), revisit this doc.
+A process-local override mirroring `ARKE_API_URL` / `ARKE_SPACE_ID`. Would complement the `--profile` flag.
+
+## Open questions
+
+1. **Global vs per-repo.** The per-repo model covers the developer workflow well. The consultant managing `acme.arkeon.tech` + `widget.arkeon.tech` might want global profiles — but they could also just use separate repo directories. Is global switching worth the complexity?
+2. **Profile vs space.** A profile bundles "which instance + which key"; a space is an in-instance scoping concept. They are orthogonal. This distinction should be documented clearly if a top-level `profile` command is added.
+3. **Conf store format.** If global profiles land, the config store would need to become keyed by profile name. The migration from flat to profiled is straightforward but one-way.

--- a/docs/user/QUICKSTART.md
+++ b/docs/user/QUICKSTART.md
@@ -82,6 +82,64 @@ arkeon up
 Embedded services are skipped when external URLs are set. Migrations
 still run on startup.
 
+## Working with wikis
+
+### Creating wikis via the CLI
+
+Create a wiki entity directly:
+
+```bash
+arkeon wiki create --label "Claude Shannon" --type person \
+  --body "Father of information theory."
+```
+
+### The pull-edit-push workflow
+
+Pull entities to disk as Markdown files with YAML frontmatter, edit
+locally, then push changes back:
+
+```bash
+arkeon pull "information theory"    # downloads matching entities to wiki/
+# edit the files in wiki/ with your editor
+arkeon diff                         # see what changed
+arkeon add wiki/                    # push edits back to the graph
+```
+
+Pulled files include `id` and `ver` in their frontmatter. The `ver`
+field enables optimistic concurrency — the server rejects updates if
+someone else modified the entity since you pulled it.
+
+### Adding raw documents
+
+Add Markdown, text, or LaTeX files without frontmatter. The wiki
+pipeline extracts entities and relationships automatically:
+
+```bash
+arkeon add papers/          # ingest all documents in papers/
+arkeon add notes.md         # ingest a single file
+```
+
+## Configuration priority
+
+### Space selection
+
+When multiple spaces exist, the active space resolves in this order:
+
+1. `ARKE_SPACE_ID` environment variable
+2. `.arkeon/state.json` `space_id` (per-repo, set by `arkeon init`)
+3. `arkeon config set-space` (global default)
+
+### Authentication
+
+API key resolution order:
+
+1. `ARKE_API_KEY` environment variable
+2. Per-repo actor key (from `.arkeon/state.json` actors + instance registry)
+3. Global credential store (`~/.config/arkeon-cli/credentials.json`)
+
+For most local usage, `arkeon init` sets up the per-repo actor key
+automatically and you never need to think about this.
+
 ## What's next
 
 - [API documentation](http://localhost:8000/llms.txt) — full API reference

--- a/packages/arkeon/assets/skills/body/arkeon-connect.md
+++ b/packages/arkeon/assets/skills/body/arkeon-connect.md
@@ -17,7 +17,13 @@ If there's no admin profile, set one up:
 npx arkeon auth profiles
 ```
 
-If "admin" is not listed, you need the admin bootstrap key from the instance's `secrets.json`.
+If "admin" is not listed, register the admin profile using the bootstrap key:
+
+```bash
+cat ~/.arkeon-wiki/secrets.json | grep admin_api_key   # find the key
+npx arkeon auth set-api-key <key>                      # store it as your default key
+npx arkeon auth add admin                              # create a named "admin" profile
+```
 
 ## Workflow
 

--- a/packages/arkeon/assets/skills/body/arkeon-connect.md
+++ b/packages/arkeon/assets/skills/body/arkeon-connect.md
@@ -17,13 +17,15 @@ If there's no admin profile, set one up:
 npx arkeon auth profiles
 ```
 
-If "admin" is not listed, register the admin profile using the bootstrap key:
+If "admin" is not listed, store the bootstrap admin key directly:
 
 ```bash
 cat ~/.arkeon-wiki/secrets.json | grep admin_api_key   # find the key
-npx arkeon auth set-api-key <key>                      # store it as your default key
-npx arkeon auth add admin                              # create a named "admin" profile
+npx arkeon auth set-api-key <key>                      # store it as your global key
 ```
+
+Note: `auth add` creates a *new* actor — for the bootstrap admin, use
+`auth set-api-key` to store the existing admin key instead.
 
 ## Workflow
 

--- a/packages/arkeon/src/cli/commands/guide/index.ts
+++ b/packages/arkeon/src/cli/commands/guide/index.ts
@@ -7,6 +7,7 @@ import {
   WHAT_IS_ARKEON,
   CORE_CONCEPTS,
   AUTHENTICATION,
+  AUTH_PROFILES,
   BEST_PRACTICES,
   FILTERING_HINT,
 } from "../../../shared/index.js";
@@ -37,16 +38,48 @@ Or use environment variables:
 ## Your First Workflow
 
 1. Create an entity
-   arkeon entities create --type note --properties '{"title":"Hello","body":"My first entity."}'
+   arkeon wiki create --type note --properties '{"title":"Hello","body":"My first entity."}'
 
 2. List entities
-   arkeon entities list
+   arkeon wiki list
 
 3. Create a relationship (source entity is the path argument, target is a flag)
    arkeon relationships create <source-entity-id> --predicate references --target-id <target-entity-id>
 
 4. Search
    arkeon search query --q hello
+
+## Working with Files
+
+Arkeon can ingest and manage files on disk, keeping them in sync with the
+knowledge graph.
+
+Initialize a repo:
+  arkeon init <space-name>
+
+This binds the current directory to a space and creates .arkeon/state.json
+to track the binding.
+
+Ingest files into the graph:
+  arkeon add <paths>
+
+Raw documents are posted to the wiki pipeline. Files with YAML frontmatter
+are treated as entity definitions and upserted directly.
+
+Download graph entities to disk:
+  arkeon pull
+
+Writes wiki entities as wiki/<type>/<slug>.md files with YAML frontmatter.
+You can then edit these files locally and push changes back.
+
+Compare disk state with the graph:
+  arkeon diff
+
+Remove documents and their extracted children:
+  arkeon rm <paths>
+
+The typical workflow is: pull entities, edit on disk, then add the changed
+files to push updates back to the graph.
 
 ## Working Within a Space
 
@@ -71,6 +104,22 @@ Override priority: --space-id flag > ARKE_SPACE_ID env var > config set-space
 View or clear your space config:
   arkeon config get-space
   arkeon config clear-space
+
+## Auth Profiles
+
+${AUTH_PROFILES}
+
+List profiles for the current instance:
+  arkeon auth profiles
+
+Switch the active profile:
+  arkeon auth use <name>
+
+Create a new actor and register it as a local profile (requires admin):
+  arkeon auth add <name>
+
+Self-service registration (no admin required):
+  arkeon auth register
 
 ## Filtering
 

--- a/packages/arkeon/src/cli/commands/guide/index.ts
+++ b/packages/arkeon/src/cli/commands/guide/index.ts
@@ -118,7 +118,7 @@ Switch the active profile:
 Create a new actor and register it as a local profile (requires admin):
   arkeon auth add <name>
 
-Self-service registration (no admin required):
+Self-service registration (server routes not yet implemented):
   arkeon auth register
 
 ## Filtering

--- a/packages/arkeon/src/cli/commands/local/reset.ts
+++ b/packages/arkeon/src/cli/commands/local/reset.ts
@@ -28,6 +28,7 @@ import {
   readPidfile,
   removePidfile,
 } from "../../lib/local-runtime.js";
+import { loadRepoState } from "../../lib/repo-state.js";
 
 interface ResetOptions {
   hard?: boolean;
@@ -75,5 +76,21 @@ export function registerResetCommand(program: Command): void {
         console.log(`Removed ${target}`);
       }
       console.log("Done.");
+
+      // Warn if repo state references the destroyed instance
+      const repoState = loadRepoState();
+      if (repoState) {
+        const url = repoState.api_url;
+        const isLocal = url.includes("localhost") || url.includes("127.0.0.1");
+        if (isLocal) {
+          console.log("");
+          console.log(
+            "Warning: .arkeon/state.json in this repo still references the destroyed instance.",
+          );
+          console.log(
+            "Run `arkeon init` to re-initialize, or delete .arkeon/state.json manually.",
+          );
+        }
+      }
     });
 }

--- a/packages/arkeon/src/cli/commands/repo/add.ts
+++ b/packages/arkeon/src/cli/commands/repo/add.ts
@@ -280,7 +280,7 @@ export function registerAddCommand(program: Command): void {
           if (parsed.short_description) properties.short_description = parsed.short_description;
           if (parsed.properties) Object.assign(properties, parsed.properties);
 
-          const resp = await apiPut<{ entity: EntityResult }>(
+          const resp = await apiPut<{ wiki: EntityResult }>(
             state.api_url,
             `/wiki/${parsed.id}`,
             apiKey,
@@ -291,7 +291,7 @@ export function registerAddCommand(program: Command): void {
           const absPath = join(cwd, relPath);
           manifest.entries[relPath] = {
             entity_id: parsed.id!,
-            ver: resp.entity.ver,
+            ver: resp.wiki.ver,
             content_hash: contentHash(absPath),
             synced_at: new Date().toISOString(),
           };

--- a/packages/arkeon/src/cli/commands/repo/diff.ts
+++ b/packages/arkeon/src/cli/commands/repo/diff.ts
@@ -15,6 +15,7 @@ import { extname, join, relative } from "node:path";
 
 import { apiGet } from "../../lib/api-client.js";
 import { credentials } from "../../lib/credentials.js";
+import { loadManifest } from "../../lib/manifest.js";
 import { output } from "../../lib/output.js";
 import { requireRepoState } from "../../lib/repo-state.js";
 
@@ -107,8 +108,11 @@ export async function computeDiff(cwd: string, extensions?: Set<string>): Promis
   if (!actorId) throw new Error("No ingestor actor in state. Run `arkeon init` first.");
   const apiKey = credentials.requireActorKey(actorId);
 
-  // Get document entities from the graph
+  // Get document entities from the graph (tracks raw-document adds via source_file)
   const graphDocs = await fetchDocumentEntities(state.api_url, apiKey, state.space_id);
+
+  // Load manifest (tracks pulled entities)
+  const manifest = loadManifest(cwd);
 
   // Walk disk
   const exts = extensions ?? DEFAULT_EXTENSIONS;
@@ -124,8 +128,20 @@ export async function computeDiff(cwd: string, extensions?: Set<string>): Promis
   for (const relPath of files) {
     seen.add(relPath);
     const hash = sha256(join(cwd, relPath));
-    const graphEntry = graphDocs.get(relPath);
 
+    // Check manifest first — pulled entities are tracked here, not via source_file
+    const manifestEntry = manifest.entries[relPath];
+    if (manifestEntry) {
+      if (hash !== manifestEntry.content_hash) {
+        modified.push({ path: relPath, sha256: hash, entity_id: manifestEntry.entity_id });
+      } else {
+        unchanged++;
+      }
+      continue;
+    }
+
+    // Fall through to graph lookup for raw-document entities
+    const graphEntry = graphDocs.get(relPath);
     if (!graphEntry) {
       added.push({ path: relPath, sha256: hash });
     } else if (graphEntry.source_hash !== hash) {
@@ -139,6 +155,13 @@ export async function computeDiff(cwd: string, extensions?: Set<string>): Promis
   for (const [sourceFile, entry] of graphDocs) {
     if (!seen.has(sourceFile)) {
       deleted.push({ path: sourceFile, entity_id: entry.entity_id });
+    }
+  }
+
+  // Manifest entries not on disk are also deleted
+  for (const [path, entry] of Object.entries(manifest.entries)) {
+    if (!seen.has(path)) {
+      deleted.push({ path, entity_id: entry.entity_id });
     }
   }
 

--- a/packages/arkeon/src/server/routes/help.ts
+++ b/packages/arkeon/src/server/routes/help.ts
@@ -336,47 +336,18 @@ Actors represent identities in the system. An actor has a kind ("agent"),
 a label, and optional properties. Admin actors can manage other actors;
 non-admin actors can read/write entities within their access level.
 
-## Self-Service Registration
+## Self-Service Registration (not yet available)
 
-Agents can register themselves without an admin. The flow uses Ed25519
-keypair authentication:
+The CLI includes commands for self-registration via Ed25519 + proof-of-work
+(\`arkeon-wiki auth register\`, \`arkeon-wiki auth recover\`), but the server
+endpoints they call are not yet implemented. These commands will work once
+the server routes land.
 
-1. Generate an Ed25519 keypair locally (the CLI does this automatically).
-2. Request a proof-of-work challenge from the server:
-     GET /auth/challenge?pub=<base64-public-key>
-   The server returns a challenge string and a difficulty target.
-3. Solve the PoW challenge (find a nonce where SHA-256 of
-   challenge+nonce has the required leading zero bits).
-4. Submit registration:
-     POST /auth/register
-     {
-       "pub": "<base64-public-key>",
-       "challenge": "<challenge-string>",
-       "nonce": "<solution>",
-       "signature": "<Ed25519 signature of challenge>",
-       "label": "My Agent"
-     }
-   The server verifies the signature and PoW solution, creates an actor,
-   and returns an API key.
+Until then, new actors must be created by an admin via \`POST /actors\` or
+\`arkeon-wiki auth add <name>\` (which calls POST /actors under the hood).
 
-The private key is stored locally in \`~/.arkeon-wiki/credentials.json\`.
-Never share it — it is your recovery mechanism.
-
-## Key Recovery
-
-If you lose your API key but still have your private key:
-
-1. Request a challenge:
-     GET /auth/challenge?pub=<base64-public-key>
-2. Sign the challenge with your stored private key:
-     POST /auth/recover
-     {
-       "pub": "<base64-public-key>",
-       "challenge": "<challenge-string>",
-       "signature": "<Ed25519 signature of challenge>"
-     }
-   The server issues a new API key for the actor associated with that
-   public key. The old key is revoked.
+If you have an admin-issued API key, store it directly:
+  arkeon-wiki auth set-api-key <your-key>
 
 ## Auth Profiles
 
@@ -385,8 +356,8 @@ the actor name, API key, and instance URL.
 
 ### CLI Commands
 
-  arkeon-wiki auth register         Self-register a new actor (keypair + PoW)
-  arkeon-wiki auth recover          Recover API key using stored private key
+  arkeon-wiki auth register         Self-register (not yet available — server routes pending)
+  arkeon-wiki auth recover          Recover API key (not yet available — server routes pending)
   arkeon-wiki auth set-api-key <k>  Set API key directly (e.g. admin-issued)
   arkeon-wiki auth status           Show current auth state and actor info
   arkeon-wiki auth whoami           Alias for auth status

--- a/packages/arkeon/src/server/routes/help.ts
+++ b/packages/arkeon/src/server/routes/help.ts
@@ -105,6 +105,8 @@ available as a command. Use --help on any command for full options.
 GET /help                         Full route index with auth & summary
 GET /help/GET/wiki/{id}           Detailed docs for any specific route
 GET /help/guide/wiki              Authoring wikis with typed links
+GET /help/guide/auth              Authentication and profiles
+GET /help/guide/workers           Worker and LLM configuration
 GET /help/guide/explorer          Explorer graph + screenshot server docs
 GET /llms.txt                     Machine-readable route index
 `;
@@ -322,6 +324,170 @@ GET  /wiki/{id}                     Read the published wiki as an entity
 GET  /wiki/{id}/relationships       See the materialized edges
 `;
 
+const AUTH_GUIDE = `# Arkeon — Authentication & Profiles
+
+## Authentication Model
+
+Arkeon uses API keys to authenticate requests. Every request must include
+an \`X-API-Key\` header. Keys are tied to actors — each actor can have
+multiple keys, but each key belongs to exactly one actor.
+
+Actors represent identities in the system. An actor has a kind ("agent"),
+a label, and optional properties. Admin actors can manage other actors;
+non-admin actors can read/write entities within their access level.
+
+## Self-Service Registration
+
+Agents can register themselves without an admin. The flow uses Ed25519
+keypair authentication:
+
+1. Generate an Ed25519 keypair locally (the CLI does this automatically).
+2. Request a proof-of-work challenge from the server:
+     GET /auth/challenge?pub=<base64-public-key>
+   The server returns a challenge string and a difficulty target.
+3. Solve the PoW challenge (find a nonce where SHA-256 of
+   challenge+nonce has the required leading zero bits).
+4. Submit registration:
+     POST /auth/register
+     {
+       "pub": "<base64-public-key>",
+       "challenge": "<challenge-string>",
+       "nonce": "<solution>",
+       "signature": "<Ed25519 signature of challenge>",
+       "label": "My Agent"
+     }
+   The server verifies the signature and PoW solution, creates an actor,
+   and returns an API key.
+
+The private key is stored locally in \`~/.arkeon-wiki/credentials.json\`.
+Never share it — it is your recovery mechanism.
+
+## Key Recovery
+
+If you lose your API key but still have your private key:
+
+1. Request a challenge:
+     GET /auth/challenge?pub=<base64-public-key>
+2. Sign the challenge with your stored private key:
+     POST /auth/recover
+     {
+       "pub": "<base64-public-key>",
+       "challenge": "<challenge-string>",
+       "signature": "<Ed25519 signature of challenge>"
+     }
+   The server issues a new API key for the actor associated with that
+   public key. The old key is revoked.
+
+## Auth Profiles
+
+Profiles let you maintain per-repo actor identities. Each profile stores
+the actor name, API key, and instance URL.
+
+### CLI Commands
+
+  arkeon-wiki auth register         Self-register a new actor (keypair + PoW)
+  arkeon-wiki auth recover          Recover API key using stored private key
+  arkeon-wiki auth set-api-key <k>  Set API key directly (e.g. admin-issued)
+  arkeon-wiki auth status           Show current auth state and actor info
+  arkeon-wiki auth whoami           Alias for auth status
+  arkeon-wiki auth logout           Clear current auth credentials
+  arkeon-wiki auth profiles         List all saved profiles
+  arkeon-wiki auth use <name>       Switch to a named profile
+  arkeon-wiki auth add <name>       Create a new named profile
+  arkeon-wiki auth remove <name>    Delete a named profile
+
+### Auth Priority Chain
+
+When resolving which API key to use, the CLI checks in order:
+
+  1. ARKE_API_KEY environment variable (highest priority)
+  2. Per-repo actor key stored in .arkeon/state.json
+  3. Global credentials in ~/.arkeon-wiki/credentials.json
+
+The first non-empty value wins. Use env vars for CI/scripts, per-repo
+keys for project-specific identities, and global credentials as the
+default fallback.
+`;
+
+const WORKERS_GUIDE = `# Arkeon — Worker & LLM Configuration
+
+## Overview
+
+Workers are background processes that use LLMs to extract entities,
+draft wikis, and resolve links. Their behavior is controlled by a YAML
+config file.
+
+## File Location
+
+  Default:   ~/.arkeon-wiki/workers.yaml
+  Override:  ARKEON_WORKERS_CONFIG=/path/to/workers.yaml
+
+If the file does not exist, built-in defaults are used for all settings.
+
+## Full Schema
+
+  # Global LLM defaults — every worker inherits these unless overridden.
+  llm:
+    provider: openai
+    base_url: https://api.openai.com/v1
+    api_key: sk-...
+    model: gpt-4o
+    max_tokens: 4096
+
+  workers:
+    extractor:
+      enabled: true
+      prompt_mode: append
+      prompt: "Domain-specific extraction rules..."
+      llm: { model: gpt-4o-mini }
+      steps:
+        resolve: { model: gpt-4o-mini, max_tokens: 256 }
+        exists: { model: gpt-4o-mini, max_tokens: 512 }
+    drafter:
+      enabled: true
+      poll_interval: 10s
+      batch_size: 5
+      max_depth: 2
+      llm: { model: gpt-4o, max_tokens: 8000 }
+
+## Resolution Priority
+
+LLM settings resolve from most specific to least specific:
+
+  step > worker > global > hardcoded defaults
+
+For example, if the extractor's "resolve" step sets model: gpt-4o-mini,
+that overrides the extractor-level model, which overrides the global
+model. Any field not set at a given level falls through to the next.
+
+## Prompt Modes
+
+The prompt_mode field controls how a worker's custom prompt interacts
+with the built-in system prompt:
+
+  replace   Full override — your prompt replaces the built-in prompt
+            entirely. Use when you need complete control.
+  prepend   Your prompt is inserted before the built-in prompt.
+            Good for adding context or domain rules.
+  append    Your prompt is added after the built-in prompt (default).
+            Good for supplementary instructions.
+
+## Duration Strings
+
+The poll_interval field accepts human-readable duration strings:
+
+  ms   milliseconds   (e.g. 500ms)
+  s    seconds        (e.g. 10s)
+  m    minutes        (e.g. 2m)
+  h    hours          (e.g. 1h)
+
+## Hot Reload
+
+The config file is cached by mtime + file size. Edits take effect
+without restarting the server — the next worker tick picks up changes
+automatically.
+`;
+
 const EXPLORER_GUIDE = `# Arkeon — Explorer & Visual Inspection
 
 ## What is the Explorer?
@@ -419,6 +585,14 @@ export function createHelpRouter(getSpec: () => { paths?: Record<string, unknown
   helpRouter.get("/guide/admin", (c) => {
     requireActor(c);
     return c.text(ADMIN_GUIDE, 200, TEXT_HEADERS);
+  });
+
+  helpRouter.get("/guide/auth", (c) => {
+    return c.text(AUTH_GUIDE, 200, TEXT_HEADERS);
+  });
+
+  helpRouter.get("/guide/workers", (c) => {
+    return c.text(WORKERS_GUIDE, 200, TEXT_HEADERS);
   });
 
   helpRouter.get("/guide/explorer", (c) => {

--- a/packages/arkeon/src/shared/concepts.ts
+++ b/packages/arkeon/src/shared/concepts.ts
@@ -115,9 +115,11 @@ with ARKEON_WORKERS_CONFIG).
 The top-level llm block sets global LLM defaults: provider, api_key, model,
 base_url, and max_tokens. These apply to every worker unless overridden.
 
-Individual workers are configured under the workers key. The four workers are:
+Individual workers are configured under the workers key. Currently implemented:
   extractor    Parses raw documents into entities and relationships
   drafter      Generates wiki articles from graph neighborhoods
+
+Planned (not yet implemented):
   consolidator Merges duplicate entities
   connector    Discovers missing relationships
 

--- a/packages/arkeon/src/shared/concepts.ts
+++ b/packages/arkeon/src/shared/concepts.ts
@@ -82,3 +82,53 @@ Entity columns: kind, type, arke_id, ver, owner_id,
 edited_by, created_at, updated_at
 
 Property paths: label:Neuroscience, metadata.source:arxiv, year>2020`;
+
+export const AUTH_PROFILES = `\
+Profiles are per-repo actor identities bound to an Arkeon instance. Each
+profile maps to an actor on the graph and carries its own API key.
+
+Switching profiles changes the active actor for the current repo — all
+subsequent operations run as that actor with its permissions.
+
+Adding a profile creates a new actor on the graph and registers it locally.
+This requires admin privileges. The admin profile is needed for cross-space
+operations and actor management.
+
+Profiles are stored in the instance actor registry, keyed by the instance
+host and port. Multiple repos can share profiles for the same instance.`;
+
+export const INSTANCES = `\
+Named instances allow running multiple isolated Arkeon stacks on one machine.
+Pass a name on startup and the instance gets its own state directory under
+~/.arkeon-wiki/<name>/ — separate database, search index, secrets, and config.
+
+Ports are automatically assigned to avoid conflicts. The instance registry at
+~/.arkeon-wiki/instances/<port>.json tracks each running stack so the CLI can
+discover and manage them.
+
+The default (unnamed) instance uses ~/.arkeon-wiki/ directly.`;
+
+export const WORKERS = `\
+Worker configuration lives in ~/.arkeon-wiki/workers.yaml (override the path
+with ARKEON_WORKERS_CONFIG).
+
+The top-level llm block sets global LLM defaults: provider, api_key, model,
+base_url, and max_tokens. These apply to every worker unless overridden.
+
+Individual workers are configured under the workers key. The four workers are:
+  extractor    Parses raw documents into entities and relationships
+  drafter      Generates wiki articles from graph neighborhoods
+  consolidator Merges duplicate entities
+  connector    Discovers missing relationships
+
+Each worker supports: enabled (boolean), llm overrides (same fields as the
+global block), prompt_mode (replace, prepend, or append), and prompt (custom
+text). Background workers (drafter, consolidator) also accept poll_interval
+(duration strings like 10s, 5m) and batch_size.
+
+The extractor supports per-step overrides under a steps key (e.g., resolve,
+exists) for fine-grained control over individual extraction stages.
+
+Resolution priority: step config > worker llm > global llm > hardcoded
+defaults. The legacy llm.json file still works as the lowest-priority
+fallback.`;

--- a/packages/arkeon/src/shared/index.ts
+++ b/packages/arkeon/src/shared/index.ts
@@ -7,6 +7,9 @@ export {
   AUTHENTICATION,
   BEST_PRACTICES,
   FILTERING_HINT,
+  AUTH_PROFILES,
+  INSTANCES,
+  WORKERS,
 } from "./concepts.js";
 
 export {


### PR DESCRIPTION
## Summary

- **P0 fix**: `arkeon add` crashed on pulled entities — PUT response typed as `{ entity }` but server returns `{ wiki }`, breaking manifest version tracking
- **P1 fix**: `arkeon diff` misclassified modified pulled files as "added" — now consults manifest before falling through to `source_file` graph lookup
- **P2 fix**: `arkeon reset --hard` left stale `.arkeon/state.json` with no warning — now prints re-init guidance when repo state references a destroyed local instance
- **Doc audit**: Full pass across all AX surfaces — concepts.ts, CLI guide, `/help` routes, QUICKSTART, ADVANCED, AUTH.md, README, arkeon-connect skill, INSTANCE_PROFILES reconciliation

### Files changed (13)

| File | Change |
|---|---|
| `add.ts` | `resp.entity.ver` → `resp.wiki.ver` |
| `diff.ts` | Manifest-first lookup for pulled entities |
| `reset.ts` | Stale state.json warning |
| `concepts.ts` | 3 new concepts: AUTH_PROFILES, INSTANCES, WORKERS |
| `guide/index.ts` | "Working with Files" + "Auth Profiles" sections |
| `help.ts` | New `/help/guide/auth` + `/help/guide/workers` routes |
| `ADVANCED.md` | workers.yaml user-facing docs |
| `QUICKSTART.md` | Wiki workflow, space/auth priority chains |
| `AUTH.md` | Fixed "not wired up" claim, added CLI commands + auth priority |
| `INSTANCE_PROFILES.md` | Reconciled with shipped features |
| `README.md` | Auth profiles + workers.yaml mentions, removed dead ref |
| `arkeon-connect.md` | Admin profile setup steps |
| `shared/index.ts` | Re-export new concepts |

## Test plan

- [x] `npm run typecheck -w packages/arkeon` — clean
- [x] `npm test -w packages/arkeon` — 164/164 pass
- [ ] Smoke test: `arkeon pull` → edit → `arkeon add` cycle (P0)
- [ ] Smoke test: `arkeon diff` after editing a pulled file (P1)
- [ ] Smoke test: `arkeon reset --hard` in an initialized repo (P2)
- [ ] Verify `/help/guide/auth` and `/help/guide/workers` render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)