### PR TITLE
fix: CAS 403→409, AGENTS.md diff noise, workers.yaml CLI docs

### DIFF
--- a/packages/arkeon/src/cli/commands/guide/index.ts
+++ b/packages/arkeon/src/cli/commands/guide/index.ts
@@ -10,6 +10,7 @@ import {
   AUTH_PROFILES,
   BEST_PRACTICES,
   FILTERING_HINT,
+  WORKERS,
 } from "../../../shared/index.js";
 
 const CLI_GUIDE = `# Arkeon CLI — Getting Started
@@ -120,6 +121,13 @@ Create a new actor and register it as a local profile (requires admin):
 
 Self-service registration (server routes not yet implemented):
   arkeon auth register
+
+## Worker Configuration
+
+${WORKERS}
+
+Edit ~/.arkeon-wiki/workers.yaml directly for customization.
+See the API guide for the full schema: GET /help/guide/workers
 
 ## Filtering
 

--- a/packages/arkeon/src/cli/commands/repo/diff.ts
+++ b/packages/arkeon/src/cli/commands/repo/diff.ts
@@ -32,6 +32,7 @@ type ListResponse = {
 
 const DEFAULT_EXTENSIONS = new Set([".md", ".txt", ".tex"]);
 const IGNORE_DIRS = new Set([".arkeon", ".git", "node_modules", ".claude"]);
+const IGNORE_FILES = new Set(["AGENTS.md"]);
 const DOCUMENT_FILTERS = ["properties.subject_type:document", "type:document"];
 
 function walkDir(dir: string, base: string, extensions: Set<string>): string[] {
@@ -41,6 +42,7 @@ function walkDir(dir: string, base: string, extensions: Set<string>): string[] {
       if (IGNORE_DIRS.has(entry.name)) continue;
       results.push(...walkDir(join(dir, entry.name), base, extensions));
     } else if (entry.isFile() && extensions.has(extname(entry.name).toLowerCase())) {
+      if (IGNORE_FILES.has(entry.name)) continue;
       results.push(relative(base, join(dir, entry.name)));
     }
   }

--- a/packages/arkeon/src/server/routes/entities.ts
+++ b/packages/arkeon/src/server/routes/entities.ts
@@ -3,6 +3,7 @@
 
 import { createRoute, z } from "@hono/zod-openapi";
 
+import postgres from "postgres";
 import { backgroundTask } from "../lib/background";
 import { deepMergeObjects } from "../lib/properties";
 import { encodeCursor } from "../lib/cursor";
@@ -670,20 +671,39 @@ wikisRouter.openapi(updateEntityRoute, async (c) => {
   params.push(actor.id, note, now, entityId, expectedVer);
 
   // Actor context set for ownership checks
-  const results = await sql.transaction([
-    ...setActorContext(sql, actor),
-    sql.query(
-      `UPDATE entities
-       SET properties = ${propsExpr},
-           ver = ver + 1,
-           edited_by = $${editedByIdx},
-           note = $${noteIdx},
-           updated_at = $${nowIdx}::timestamptz
-       WHERE id = $${idIdx} AND ver = $${verIdx}
-       RETURNING *`,
-      params,
-    ),
-  ]);
+  let results;
+  try {
+    results = await sql.transaction([
+      ...setActorContext(sql, actor),
+      sql.query(
+        `UPDATE entities
+         SET properties = ${propsExpr},
+             ver = ver + 1,
+             edited_by = $${editedByIdx},
+             note = $${noteIdx},
+             updated_at = $${nowIdx}::timestamptz
+         WHERE id = $${idIdx} AND ver = $${verIdx}
+         RETURNING *`,
+        params,
+      ),
+    ]);
+  } catch (err) {
+    // RLS denial (42501) may mask a CAS conflict — check version before surfacing 403
+    if (err instanceof postgres.PostgresError && err.code === "42501") {
+      const existsResult = await sql.transaction([
+        ...setActorContext(sql, actor),
+        sql`SELECT ver FROM entities WHERE id = ${entityId} LIMIT 1`,
+      ]);
+      const fresh = (existsResult[existsResult.length - 1] as Array<{ ver: number }>)[0];
+      if (fresh && fresh.ver !== expectedVer) {
+        throw new ApiError(409, "cas_conflict", "Version mismatch", {
+          entity_id: entityId,
+          expected_ver: expectedVer,
+        });
+      }
+    }
+    throw err;
+  }
 
   const updated = (results[results.length - 1] as EntityRecord[])[0];
   if (!updated) {

--- a/packages/arkeon/src/server/routes/entities.ts
+++ b/packages/arkeon/src/server/routes/entities.ts
@@ -45,12 +45,36 @@ import {
 } from "../lib/schemas";
 import { setActorContext } from "../lib/actor-context";
 import { createSql } from "../lib/sql";
+import type { Actor } from "../types";
 import {
   processWikiContent,
   fetchWikiReferences,
   diffWikiReferences,
   applyRelationshipDiff,
 } from "../lib/wiki-pipeline";
+
+/** Throw 409 if the entity's current ver differs from expectedVer, or 404 if it doesn't exist. */
+async function throwIfCasConflict(
+  sql: ReturnType<typeof createSql>,
+  actor: Actor,
+  entityId: string,
+  expectedVer: number,
+): Promise<void> {
+  const existsResult = await sql.transaction([
+    ...setActorContext(sql, actor),
+    sql`SELECT ver FROM entities WHERE id = ${entityId} LIMIT 1`,
+  ]);
+  const fresh = (existsResult[existsResult.length - 1] as Array<{ ver: number }>)[0];
+  if (!fresh) {
+    throw new ApiError(404, "not_found", "Entity not found");
+  }
+  if (fresh.ver !== expectedVer) {
+    throw new ApiError(409, "cas_conflict", "Version mismatch", {
+      entity_id: entityId,
+      expected_ver: expectedVer,
+    });
+  }
+}
 
 type VersionRow = {
   entity_id?: string;
@@ -690,17 +714,7 @@ wikisRouter.openapi(updateEntityRoute, async (c) => {
   } catch (err) {
     // RLS denial (42501) may mask a CAS conflict — check version before surfacing 403
     if (err instanceof postgres.PostgresError && err.code === "42501") {
-      const existsResult = await sql.transaction([
-        ...setActorContext(sql, actor),
-        sql`SELECT ver FROM entities WHERE id = ${entityId} LIMIT 1`,
-      ]);
-      const fresh = (existsResult[existsResult.length - 1] as Array<{ ver: number }>)[0];
-      if (fresh && fresh.ver !== expectedVer) {
-        throw new ApiError(409, "cas_conflict", "Version mismatch", {
-          entity_id: entityId,
-          expected_ver: expectedVer,
-        });
-      }
+      await throwIfCasConflict(sql, actor, entityId, expectedVer);
     }
     throw err;
   }
@@ -708,21 +722,8 @@ wikisRouter.openapi(updateEntityRoute, async (c) => {
   const updated = (results[results.length - 1] as EntityRecord[])[0];
   if (!updated) {
     // Distinguish CAS conflict from permission denial
-    const existsResult = await sql.transaction([
-      ...setActorContext(sql, actor),
-      sql`SELECT ver FROM entities WHERE id = ${entityId} LIMIT 1`,
-    ]);
-    const fresh = (existsResult[existsResult.length - 1] as Array<{ ver: number }>)[0];
-    if (fresh) {
-      if (fresh.ver !== expectedVer) {
-        throw new ApiError(409, "cas_conflict", "Version mismatch", {
-          entity_id: entityId,
-          expected_ver: expectedVer,
-        });
-      }
-      throw new ApiError(403, "forbidden", "You do not have write access on this entity");
-    }
-    throw new ApiError(404, "not_found", "Entity not found");
+    await throwIfCasConflict(sql, actor, entityId, expectedVer);
+    throw new ApiError(403, "forbidden", "You do not have write access on this entity");
   }
 
   // Version snapshot


### PR DESCRIPTION
## Summary

- **CAS version mismatch**: Entity UPDATE wrapped in try/catch — when RLS denies the UPDATE (42501), checks entity version before re-throwing. Returns 409 Conflict instead of misleading 403 Forbidden when the real cause is a stale CAS token.
- **AGENTS.md diff noise**: Added `IGNORE_FILES` set to `walkDir` so generated install artifacts like AGENTS.md don't appear as "added" on every diff.
- **workers.yaml CLI docs**: Added Worker Configuration section to CLI guide, reusing the shared `WORKERS` concept text from `concepts.ts`. CLI users can now discover workers.yaml via `arkeon guide`.

## Test plan

- [ ] Start stack, create entity, update it out-of-band, attempt PUT with stale ver — should get 409 not 403
- [ ] Run `arkeon diff` in a repo with AGENTS.md — should not appear in output
- [ ] Run `arkeon guide` — should show Worker Configuration section
- [ ] `npm run typecheck -w packages/arkeon` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)