### PR TITLE
fix: version check references arkeon-wiki instead of arkeon

### DIFF
--- a/packages/arkeon/src/cli/lib/version-check.ts
+++ b/packages/arkeon/src/cli/lib/version-check.ts
@@ -69,7 +69,7 @@ export function isNewer(remote: string, local: string): boolean {
  */
 function spawnBackgroundCheck(): void {
   try {
-    const child = spawn("npm", ["view", "arkeon", "version", "--json"], {
+    const child = spawn("npm", ["view", "arkeon-wiki", "version", "--json"], {
       detached: true,
       stdio: ["ignore", "pipe", "ignore"],
     });
@@ -102,7 +102,7 @@ export function checkForUpdate(currentVersion: string): void {
       if (age < CHECK_INTERVAL_MS) {
         // Cache is fresh — warn if newer version exists
         if (isNewer(cache.latest, currentVersion)) {
-          const msg = `\x1b[33mUpdate available: arkeon ${cache.latest} (current: ${currentVersion}). Run \`arkeon update\` to update.\x1b[0m`;
+          const msg = `\x1b[33mUpdate available: arkeon-wiki ${cache.latest} (current: ${currentVersion}). Run \`arkeon-wiki update\` to update.\x1b[0m`;
           process.stderr.write(msg + "\n");
         }
         return;


### PR DESCRIPTION
## Summary
- Update `npm view` target from `arkeon` to `arkeon-wiki` so the version check queries the correct package
- Update the CLI warning message to say `arkeon-wiki` instead of `arkeon`

## Test plan
- [ ] Run `arkeon-wiki status` and verify no stale update warning referencing `arkeon`
- [ ] Delete `~/.arkeon-wiki/version-check.json` to force a fresh check, confirm it queries `arkeon-wiki`

🤖 Generated with [Claude Code](https://claude.com/claude-code)