### PR TITLE
feat: recover draft-worker and extract-worker from orphaned commits

### DIFF
--- a/packages/arkeon/src/schema/004-draft-extract-queues.sql
+++ b/packages/arkeon/src/schema/004-draft-extract-queues.sql
@@ -1,0 +1,45 @@
+-- 004-draft-extract-queues.sql
+-- Adds audit columns to wiki_draft_queue and creates source_extract_queue.
+-- All statements are idempotent.
+
+-- ---------------------------------------------------------------------------
+-- wiki_draft_queue: audit and debugging columns
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE wiki_draft_queue ADD COLUMN IF NOT EXISTS started_at TIMESTAMPTZ;
+ALTER TABLE wiki_draft_queue ADD COLUMN IF NOT EXISTS result_wiki_id TEXT;
+ALTER TABLE wiki_draft_queue ADD COLUMN IF NOT EXISTS merged_into TEXT;
+ALTER TABLE wiki_draft_queue ADD COLUMN IF NOT EXISTS context_dossier JSONB;
+
+-- The draft worker creates simple redirects (placeholder -> existing wiki)
+-- without going through the full perform_entity_merge() path.
+-- entity_redirects has RLS enabled (003-wiki.sql) with only a SELECT policy,
+-- so we need both the INSERT privilege and an RLS policy.
+GRANT INSERT ON entity_redirects TO arke_app;
+
+DROP POLICY IF EXISTS redirects_insert ON entity_redirects;
+CREATE POLICY redirects_insert ON entity_redirects
+  FOR INSERT TO arke_app
+  WITH CHECK (current_actor_id() IS NOT NULL);
+
+-- ---------------------------------------------------------------------------
+-- source_extract_queue: queue for the extract worker
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS source_extract_queue (
+  entity_id    TEXT PRIMARY KEY REFERENCES entities(id) ON DELETE CASCADE,
+  owner_agent  TEXT NOT NULL REFERENCES actors(id),
+  status       TEXT NOT NULL DEFAULT 'pending'
+               CHECK (status IN ('pending','processing','complete','failed')),
+  attempts     INTEGER NOT NULL DEFAULT 0,
+  max_attempts INTEGER NOT NULL DEFAULT 3,
+  error        TEXT,
+  placeholders_created INTEGER,
+  started_at   TIMESTAMPTZ,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS source_extract_queue_pending_idx
+  ON source_extract_queue (created_at) WHERE status = 'pending';
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON source_extract_queue TO arke_app;

--- a/packages/arkeon/src/server/lib/worker-registry.ts
+++ b/packages/arkeon/src/server/lib/worker-registry.ts
@@ -2,47 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Worker registry — loads workers.yaml, instantiates background workers,
- * manages their lifecycle.
+ * Worker registry — starts and stops background workers.
  *
- * The extractor is not registered here — it runs synchronously in the
- * request path and reads its config via worker-config.ts directly.
+ * Both the draft worker and extract worker use standalone start/stop
+ * functions with module-level state (same pattern as retention.ts).
+ * They gate themselves on LLM/Meilisearch availability at startup.
  */
 
-import { loadWorkersYaml, resolveWorkerConfig, type WorkerName } from "./worker-config.js";
-import { ArkeonWorker } from "./worker.js";
-import { DraftWorker } from "./workers/draft-worker.js";
-
-// Future workers — uncomment when implemented:
-// import { ConsolidatorWorker } from "./workers/consolidator-worker.js";
-// import { ConnectorWorker } from "./workers/connector-worker.js";
-
-const workers: ArkeonWorker[] = [];
-
-interface WorkerDef {
-  name: WorkerName;
-  Ctor: new (config: ReturnType<typeof resolveWorkerConfig>) => ArkeonWorker;
-}
-
-const WORKER_DEFS: WorkerDef[] = [
-  { name: "drafter", Ctor: DraftWorker },
-  // { name: "consolidator", Ctor: ConsolidatorWorker },
-  // { name: "connector", Ctor: ConnectorWorker },
-];
+import { startDraftWorker, stopDraftWorker } from "./workers/draft-worker.js";
+import { startExtractWorker, stopExtractWorker } from "./workers/extract-worker.js";
 
 export async function startWorkers(): Promise<void> {
-  const yamlConfig = loadWorkersYaml();
-
-  for (const { name, Ctor } of WORKER_DEFS) {
-    const config = resolveWorkerConfig(name, yamlConfig);
-    const worker = new Ctor(config);
-    await worker.init();
-    worker.start();
-    workers.push(worker);
-  }
+  startDraftWorker();
+  startExtractWorker();
 }
 
 export function stopWorkers(): void {
-  for (const w of workers) w.stop();
-  workers.length = 0;
+  stopDraftWorker();
+  stopExtractWorker();
 }

--- a/packages/arkeon/src/server/lib/workers/draft-gather.ts
+++ b/packages/arkeon/src/server/lib/workers/draft-gather.ts
@@ -14,23 +14,8 @@
  * is good enough and the LLM loop is skipped entirely.
  */
 
+import type { Actor } from "../../types.js";
 import type { EntityMatch } from "../entity-resolve.js";
-
-/**
- * Extended actor type for worker-internal use. Workers load actor rows
- * directly from the DB and need classification-level fields that the
- * slim request-path Actor type omits.
- */
-export interface WorkerActor {
-  id: string;
-  apiKeyId: string;
-  keyPrefix: string;
-  label: string | null;
-  maxReadLevel: number;
-  maxWriteLevel: number;
-  isAdmin: boolean;
-  canPublishPublic: boolean;
-}
 import { searchEntities, isMeilisearchConfigured } from "../meilisearch.js";
 import { withTransaction, type SqlClient } from "../sql.js";
 import { setActorContext } from "../actor-context.js";
@@ -97,7 +82,7 @@ const RICH_REFERRER_THRESHOLD = 2;
 
 async function fetchInboundSpans(
   placeholderId: string,
-  actor: WorkerActor,
+  actor: Actor,
 ): Promise<InboundSpan[]> {
   return withTransaction(async (sql) => {
     for (const q of setActorContext(sql, actor)) await q;
@@ -136,7 +121,7 @@ async function fetchInboundSpans(
  */
 async function fetchSourceContent(
   placeholderId: string,
-  actor: WorkerActor,
+  actor: Actor,
 ): Promise<{ sourceLabel: string; sourceContent: string } | null> {
   return withTransaction(async (sql) => {
     for (const q of setActorContext(sql, actor)) await q;
@@ -166,7 +151,7 @@ async function fetchSourceContent(
 async function searchNearbyEntities(
   label: string,
   description: string | null,
-  actor: WorkerActor,
+  actor: Actor,
   spaceId: string,
 ): Promise<DiscoveredEntity[]> {
   if (!isMeilisearchConfigured()) return [];
@@ -175,7 +160,6 @@ async function searchNearbyEntities(
   const result = await searchEntities(query, {
     filter: [
       'kind = "entity"',
-      `read_level <= ${actor.maxReadLevel}`,
       `space_ids = "${spaceId}"`,
     ],
     limit: 10,
@@ -207,7 +191,7 @@ async function searchNearbyEntities(
 async function searchRelatedWikis(
   label: string,
   description: string | null,
-  actor: WorkerActor,
+  actor: Actor,
   spaceId: string,
 ): Promise<WikiSnippet[]> {
   if (!isMeilisearchConfigured()) return [];
@@ -217,7 +201,6 @@ async function searchRelatedWikis(
     filter: [
       'kind = "entity"',
       'type = "wiki"',
-      `read_level <= ${actor.maxReadLevel}`,
       `space_ids = "${spaceId}"`,
     ],
     limit: 5,
@@ -247,7 +230,7 @@ async function searchRelatedWikis(
 
 async function fetchSpaceWikiSample(
   spaceId: string,
-  actor: WorkerActor,
+  actor: Actor,
 ): Promise<Array<{ label: string; shortDescription: string }>> {
   return withTransaction(async (sql) => {
     for (const q of setActorContext(sql, actor)) await q;
@@ -360,7 +343,7 @@ const GATHER_TOOLS: OpenAI.Chat.Completions.ChatCompletionTool[] = [
 async function executeTool(
   name: string,
   args: Record<string, unknown>,
-  actor: WorkerActor,
+  actor: Actor,
   spaceId: string,
   discovered: DiscoveredEntity[],
   wikiSnippets: WikiSnippet[],
@@ -371,7 +354,6 @@ async function executeTool(
       const limit = Math.min(Number(args.limit) || 10, 20);
       const filters: string[] = [
         'kind = "entity"',
-        `read_level <= ${actor.maxReadLevel}`,
         `space_ids = "${spaceId}"`,
       ];
       if (typeof args.type_filter === "string" && args.type_filter) {
@@ -594,7 +576,7 @@ function buildSeedMessage(
 
 export async function gatherDossier(
   placeholder: PlaceholderInfo,
-  actor: WorkerActor,
+  actor: Actor,
   depth: number,
   reconcileCandidates: EntityMatch[],
 ): Promise<Dossier> {

--- a/packages/arkeon/src/server/lib/workers/draft-gather.ts
+++ b/packages/arkeon/src/server/lib/workers/draft-gather.ts
@@ -357,7 +357,10 @@ async function executeTool(
         `space_ids = "${spaceId}"`,
       ];
       if (typeof args.type_filter === "string" && args.type_filter) {
-        filters.push(`type = "${args.type_filter}"`);
+        // Sanitize to alphanumeric + underscore/hyphen — this value comes
+        // from LLM tool arguments and is interpolated into a Meilisearch filter.
+        const safeType = args.type_filter.replace(/[^a-zA-Z0-9_-]/g, "");
+        if (safeType) filters.push(`type = "${safeType}"`);
       }
       if (!isMeilisearchConfigured()) return { results: [], note: "Search not configured" };
       const result = await searchEntities(query, {

--- a/packages/arkeon/src/server/lib/workers/draft-gather.ts
+++ b/packages/arkeon/src/server/lib/workers/draft-gather.ts
@@ -1,0 +1,712 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Gather agent for the wiki draft worker.
+ *
+ * A read-only tool-calling loop that explores the graph to build a
+ * context dossier for the drafting LLM. Pre-seeds deterministic context
+ * (inbound spans, nearby entities, related wikis) then optionally runs
+ * an LLM loop to follow leads and disambiguate.
+ *
+ * The LLM loop is gated: when the placeholder already has rich inbound
+ * context (>=5 spans from >=2 distinct referrers), the static dossier
+ * is good enough and the LLM loop is skipped entirely.
+ */
+
+import type { EntityMatch } from "../entity-resolve.js";
+
+/**
+ * Extended actor type for worker-internal use. Workers load actor rows
+ * directly from the DB and need classification-level fields that the
+ * slim request-path Actor type omits.
+ */
+export interface WorkerActor {
+  id: string;
+  apiKeyId: string;
+  keyPrefix: string;
+  label: string | null;
+  maxReadLevel: number;
+  maxWriteLevel: number;
+  isAdmin: boolean;
+  canPublishPublic: boolean;
+}
+import { searchEntities, isMeilisearchConfigured } from "../meilisearch.js";
+import { withTransaction, type SqlClient } from "../sql.js";
+import { setActorContext } from "../actor-context.js";
+import { getLlmClient } from "../llm.js";
+import type OpenAI from "openai";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface InboundSpan {
+  referrerEntityId: string;
+  referrerLabel: string;
+  referrerShortDesc: string;
+  predicate: string;
+  spanText: string;
+}
+
+export interface DiscoveredEntity {
+  id: string;
+  label: string;
+  type: string;
+  shortDescription: string;
+}
+
+export interface WikiSnippet {
+  id: string;
+  label: string;
+  firstParagraph: string;
+}
+
+export interface Dossier {
+  subjectSummary: string;
+  inboundSpans: InboundSpan[];
+  confidentEntityLinks: DiscoveredEntity[];
+  relatedWikiSnippets: WikiSnippet[];
+  reconcileCandidates: EntityMatch[];
+  spaceWikiSample: Array<{ label: string; shortDescription: string }>;
+  /** Source document content if this placeholder was extracted from a raw source. */
+  sourceContent: { label: string; content: string } | null;
+  gatherNotes: string;
+  usage: { tokensIn: number; tokensOut: number; turns: number };
+}
+
+export interface PlaceholderInfo {
+  id: string;
+  label: string;
+  description: string | null;
+  spaceId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_TURNS = 8;
+const WALL_TIME_MS = 30_000;
+const RICH_SPAN_THRESHOLD = 5;
+const RICH_REFERRER_THRESHOLD = 2;
+
+// ---------------------------------------------------------------------------
+// Pre-seed: deterministic context gathering (no LLM)
+// ---------------------------------------------------------------------------
+
+async function fetchInboundSpans(
+  placeholderId: string,
+  actor: WorkerActor,
+): Promise<InboundSpan[]> {
+  return withTransaction(async (sql) => {
+    for (const q of setActorContext(sql, actor)) await q;
+
+    const rows = await sql`
+      SELECT
+        re.predicate,
+        rel.properties AS rel_props,
+        src.id AS referrer_id,
+        src.properties AS src_props
+      FROM relationship_edges re
+      JOIN entities rel ON rel.id = re.id
+      JOIN entities src ON src.id = re.source_id
+      WHERE re.target_id = ${placeholderId}
+      ORDER BY rel.created_at DESC
+      LIMIT 30
+    `;
+
+    return (rows as Array<Record<string, unknown>>).map((r) => {
+      const relProps = (r.rel_props as Record<string, unknown>) ?? {};
+      const srcProps = (r.src_props as Record<string, unknown>) ?? {};
+      return {
+        referrerEntityId: String(r.referrer_id),
+        referrerLabel: String(srcProps.label ?? ""),
+        referrerShortDesc: String(srcProps.short_description ?? "").slice(0, 200),
+        predicate: String(r.predicate),
+        spanText: String(relProps.span_text ?? "").slice(0, 400),
+      };
+    });
+  });
+}
+
+/**
+ * If this placeholder was extracted from a source document, fetch the
+ * source content so the drafting LLM has primary material to draw from.
+ */
+async function fetchSourceContent(
+  placeholderId: string,
+  actor: WorkerActor,
+): Promise<{ sourceLabel: string; sourceContent: string } | null> {
+  return withTransaction(async (sql) => {
+    for (const q of setActorContext(sql, actor)) await q;
+
+    // Follow extracted_from edges from this placeholder to a source entity
+    const rows = await sql`
+      SELECT src.properties AS src_props
+      FROM relationship_edges re
+      JOIN entities src ON src.id = re.target_id
+      WHERE re.source_id = ${placeholderId}
+        AND re.predicate = 'extracted_from'
+        AND src.type = 'source'
+      LIMIT 1
+    `;
+    const row = (rows as Array<Record<string, unknown>>)[0];
+    if (!row) return null;
+    const srcProps = (row.src_props as Record<string, unknown>) ?? {};
+    const content = String(srcProps.content ?? "");
+    if (!content) return null;
+    return {
+      sourceLabel: String(srcProps.label ?? ""),
+      sourceContent: content.slice(0, 30_000), // cap for context window
+    };
+  });
+}
+
+async function searchNearbyEntities(
+  label: string,
+  description: string | null,
+  actor: WorkerActor,
+  spaceId: string,
+): Promise<DiscoveredEntity[]> {
+  if (!isMeilisearchConfigured()) return [];
+
+  const query = description ? `${label} ${description}`.slice(0, 200) : label;
+  const result = await searchEntities(query, {
+    filter: [
+      'kind = "entity"',
+      `read_level <= ${actor.maxReadLevel}`,
+      `space_ids = "${spaceId}"`,
+    ],
+    limit: 10,
+    attributesToSearchOn: ["label", "keywords", "short_description"],
+  });
+
+  if (result.ids.length === 0) return [];
+
+  return withTransaction(async (sql) => {
+    for (const q of setActorContext(sql, actor)) await q;
+    const rows = await sql`
+      SELECT id, type, properties FROM entities
+      WHERE id = ANY(${result.ids}) AND kind = 'entity'
+    `;
+    const byId = new Map<string, DiscoveredEntity>();
+    for (const r of rows as Array<Record<string, unknown>>) {
+      const props = (r.properties as Record<string, unknown>) ?? {};
+      byId.set(String(r.id), {
+        id: String(r.id),
+        label: String(props.label ?? ""),
+        type: String(r.type),
+        shortDescription: String(props.short_description ?? "").slice(0, 200),
+      });
+    }
+    return result.ids.map((id) => byId.get(id)).filter((e): e is DiscoveredEntity => !!e);
+  });
+}
+
+async function searchRelatedWikis(
+  label: string,
+  description: string | null,
+  actor: WorkerActor,
+  spaceId: string,
+): Promise<WikiSnippet[]> {
+  if (!isMeilisearchConfigured()) return [];
+
+  const query = description ? `${label} ${description}`.slice(0, 200) : label;
+  const result = await searchEntities(query, {
+    filter: [
+      'kind = "entity"',
+      'type = "wiki"',
+      `read_level <= ${actor.maxReadLevel}`,
+      `space_ids = "${spaceId}"`,
+    ],
+    limit: 5,
+    attributesToSearchOn: ["label", "keywords", "short_description"],
+  });
+
+  if (result.ids.length === 0) return [];
+
+  return withTransaction(async (sql) => {
+    for (const q of setActorContext(sql, actor)) await q;
+    const rows = await sql`
+      SELECT id, properties FROM entities
+      WHERE id = ANY(${result.ids}) AND type = 'wiki'
+    `;
+    return (rows as Array<Record<string, unknown>>).map((r) => {
+      const props = (r.properties as Record<string, unknown>) ?? {};
+      const content = String(props.content ?? "");
+      const firstPara = content.split("\n\n")[0]?.slice(0, 500) ?? "";
+      return {
+        id: String(r.id),
+        label: String(props.label ?? ""),
+        firstParagraph: firstPara,
+      };
+    });
+  });
+}
+
+async function fetchSpaceWikiSample(
+  spaceId: string,
+  actor: WorkerActor,
+): Promise<Array<{ label: string; shortDescription: string }>> {
+  return withTransaction(async (sql) => {
+    for (const q of setActorContext(sql, actor)) await q;
+    const rows = await sql`
+      SELECT e.properties FROM entities e
+      JOIN space_entities se ON se.entity_id = e.id
+      WHERE se.space_id = ${spaceId}
+        AND e.type = 'wiki'
+        AND e.kind = 'entity'
+      ORDER BY e.updated_at DESC
+      LIMIT 10
+    `;
+    return (rows as Array<Record<string, unknown>>).map((r) => {
+      const props = (r.properties as Record<string, unknown>) ?? {};
+      return {
+        label: String(props.label ?? ""),
+        shortDescription: String(props.short_description ?? "").slice(0, 200),
+      };
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions for the gather LLM loop
+// ---------------------------------------------------------------------------
+
+const GATHER_TOOLS: OpenAI.Chat.Completions.ChatCompletionTool[] = [
+  {
+    type: "function",
+    function: {
+      name: "search_entities",
+      description: "Search the knowledge graph for entities by text query",
+      parameters: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Search query text" },
+          type_filter: { type: "string", description: "Filter by entity type (e.g. 'wiki', 'person')" },
+          limit: { type: "number", description: "Max results (default 10, max 20)" },
+        },
+        required: ["query"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "get_entity",
+      description: "Fetch an entity's metadata by ID",
+      parameters: {
+        type: "object",
+        properties: {
+          id: { type: "string", description: "Entity ULID" },
+        },
+        required: ["id"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "get_wiki_content",
+      description: "Fetch the first portion of a wiki's markdown content",
+      parameters: {
+        type: "object",
+        properties: {
+          id: { type: "string", description: "Wiki entity ULID" },
+          max_chars: { type: "number", description: "Max characters to return (default 2000, max 4000)" },
+        },
+        required: ["id"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "traverse",
+      description: "List relationships for an entity (inbound, outbound, or both)",
+      parameters: {
+        type: "object",
+        properties: {
+          id: { type: "string", description: "Entity ULID" },
+          direction: { type: "string", enum: ["in", "out", "both"], description: "Default: both" },
+          limit: { type: "number", description: "Max edges (default 15, max 30)" },
+        },
+        required: ["id"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "emit_dossier",
+      description: "Signal that you have gathered enough context. Call this when done.",
+      parameters: {
+        type: "object",
+        properties: {
+          summary: { type: "string", description: "1-2 sentence summary of the subject based on what you found" },
+          notes: { type: "string", description: "Notes for the drafting agent about what to focus on or watch out for" },
+        },
+        required: ["summary"],
+      },
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tool execution
+// ---------------------------------------------------------------------------
+
+async function executeTool(
+  name: string,
+  args: Record<string, unknown>,
+  actor: WorkerActor,
+  spaceId: string,
+  discovered: DiscoveredEntity[],
+  wikiSnippets: WikiSnippet[],
+): Promise<unknown> {
+  switch (name) {
+    case "search_entities": {
+      const query = String(args.query ?? "");
+      const limit = Math.min(Number(args.limit) || 10, 20);
+      const filters: string[] = [
+        'kind = "entity"',
+        `read_level <= ${actor.maxReadLevel}`,
+        `space_ids = "${spaceId}"`,
+      ];
+      if (typeof args.type_filter === "string" && args.type_filter) {
+        filters.push(`type = "${args.type_filter}"`);
+      }
+      if (!isMeilisearchConfigured()) return { results: [], note: "Search not configured" };
+      const result = await searchEntities(query, {
+        filter: filters,
+        limit,
+        attributesToSearchOn: ["label", "keywords", "short_description"],
+      });
+      if (result.ids.length === 0) return { results: [] };
+
+      return withTransaction(async (sql) => {
+        for (const q of setActorContext(sql, actor)) await q;
+        const rows = await sql`
+          SELECT id, type, properties FROM entities
+          WHERE id = ANY(${result.ids}) AND kind = 'entity'
+        `;
+        const entities = (rows as Array<Record<string, unknown>>).map((r) => {
+          const props = (r.properties as Record<string, unknown>) ?? {};
+          const ent: DiscoveredEntity = {
+            id: String(r.id),
+            label: String(props.label ?? ""),
+            type: String(r.type),
+            shortDescription: String(props.short_description ?? "").slice(0, 200),
+          };
+          // Track discovered entities for the dossier
+          if (!discovered.some((d) => d.id === ent.id)) discovered.push(ent);
+          return ent;
+        });
+        return { results: entities };
+      });
+    }
+
+    case "get_entity": {
+      const id = String(args.id ?? "");
+      return withTransaction(async (sql) => {
+        for (const q of setActorContext(sql, actor)) await q;
+        const rows = await sql`
+          SELECT id, type, properties FROM entities WHERE id = ${id} AND kind = 'entity' LIMIT 1
+        `;
+        if (rows.length === 0) return { error: "Entity not found or not visible" };
+        const r = rows[0] as Record<string, unknown>;
+        const props = (r.properties as Record<string, unknown>) ?? {};
+        const ent: DiscoveredEntity = {
+          id: String(r.id),
+          label: String(props.label ?? ""),
+          type: String(r.type),
+          shortDescription: String(props.short_description ?? "").slice(0, 200),
+        };
+        if (!discovered.some((d) => d.id === ent.id)) discovered.push(ent);
+        return {
+          id: ent.id,
+          type: ent.type,
+          label: ent.label,
+          description: String(props.description ?? "").slice(0, 400),
+          keywords: Array.isArray(props.keywords) ? props.keywords : [],
+          short_description: ent.shortDescription,
+          aliases: Array.isArray(props.aliases) ? props.aliases : [],
+        };
+      });
+    }
+
+    case "get_wiki_content": {
+      const id = String(args.id ?? "");
+      const maxChars = Math.min(Number(args.max_chars) || 2000, 4000);
+      return withTransaction(async (sql) => {
+        for (const q of setActorContext(sql, actor)) await q;
+        const rows = await sql`
+          SELECT id, properties FROM entities WHERE id = ${id} AND type = 'wiki' LIMIT 1
+        `;
+        if (rows.length === 0) return { error: "Wiki not found or not visible" };
+        const r = rows[0] as Record<string, unknown>;
+        const props = (r.properties as Record<string, unknown>) ?? {};
+        const content = String(props.content ?? "").slice(0, maxChars);
+        const label = String(props.label ?? "");
+        const firstPara = content.split("\n\n")[0]?.slice(0, 500) ?? "";
+        if (!wikiSnippets.some((w) => w.id === id)) {
+          wikiSnippets.push({ id, label, firstParagraph: firstPara });
+        }
+        return { id, label, content };
+      });
+    }
+
+    case "traverse": {
+      const id = String(args.id ?? "");
+      const direction = String(args.direction ?? "both");
+      const limit = Math.min(Number(args.limit) || 15, 30);
+      return withTransaction(async (sql) => {
+        for (const q of setActorContext(sql, actor)) await q;
+
+        let dirClause: string;
+        if (direction === "out") dirClause = `re.source_id = $1`;
+        else if (direction === "in") dirClause = `re.target_id = $1`;
+        else dirClause = `(re.source_id = $1 OR re.target_id = $1)`;
+
+        const rows = await sql.query(
+          `SELECT
+            re.predicate,
+            re.source_id,
+            re.target_id,
+            rel.properties AS rel_props,
+            other.id AS other_id,
+            other.type AS other_type,
+            other.properties AS other_props
+          FROM relationship_edges re
+          JOIN entities rel ON rel.id = re.id
+          JOIN entities other ON other.id = CASE
+            WHEN re.source_id = $1 THEN re.target_id
+            ELSE re.source_id
+          END
+          WHERE ${dirClause}
+          ORDER BY rel.created_at DESC
+          LIMIT $2`,
+          [id, limit],
+        );
+
+        return {
+          edges: (rows as Array<Record<string, unknown>>).map((r) => {
+            const relProps = (r.rel_props as Record<string, unknown>) ?? {};
+            const otherProps = (r.other_props as Record<string, unknown>) ?? {};
+            return {
+              predicate: r.predicate,
+              other_id: r.other_id,
+              other_label: String(otherProps.label ?? ""),
+              other_type: r.other_type,
+              span_text: String(relProps.span_text ?? "").slice(0, 300),
+            };
+          }),
+        };
+      });
+    }
+
+    case "emit_dossier":
+      return { status: "done" };
+
+    default:
+      return { error: `Unknown tool: ${name}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Gather agent system prompt
+// ---------------------------------------------------------------------------
+
+function buildGatherSystemPrompt(placeholder: PlaceholderInfo): string {
+  return `You are a research agent gathering context to help draft a wiki article about "${placeholder.label}".
+
+You have read-only access to a knowledge graph via these tools:
+- search_entities: search by text query (searches label, keywords, short_description)
+- get_entity: fetch an entity's metadata by ID
+- get_wiki_content: read wiki page content (returns first N chars)
+- traverse: list an entity's relationships (inbound/outbound edges with span_text)
+- emit_dossier: signal you're done gathering (REQUIRED as your final tool call)
+
+Your goal: find information, relationships, and context about "${placeholder.label}" to help a wiki author write a comprehensive article. Focus on:
+1. What is this subject? Find entities and wikis that describe it.
+2. How does it relate to other things in the graph? Follow relationships.
+3. Are there existing wikis on closely related topics? Get their content for context.
+
+You MUST call emit_dossier when you have enough context. Include a summary of the subject and notes for the drafting agent.
+
+Keep your exploration focused. You have a limited number of tool calls.`;
+}
+
+function buildSeedMessage(
+  placeholder: PlaceholderInfo,
+  inboundSpans: InboundSpan[],
+  nearbyEntities: DiscoveredEntity[],
+  relatedWikis: WikiSnippet[],
+  reconcileCandidates: EntityMatch[],
+): string {
+  const parts: string[] = [];
+
+  parts.push(`Subject: "${placeholder.label}"`);
+  if (placeholder.description) parts.push(`Description: ${placeholder.description}`);
+  parts.push("");
+
+  if (inboundSpans.length > 0) {
+    parts.push("## Inbound References (published wikis that mention this subject)");
+    for (const span of inboundSpans) {
+      parts.push(`- From "${span.referrerLabel}": "${span.spanText}"`);
+    }
+    parts.push("");
+  }
+
+  if (nearbyEntities.length > 0) {
+    parts.push("## Nearby Entities (search results for the subject label)");
+    for (const ent of nearbyEntities) {
+      parts.push(`- ${ent.label} (${ent.type}, id=${ent.id}): ${ent.shortDescription}`);
+    }
+    parts.push("");
+  }
+
+  if (relatedWikis.length > 0) {
+    parts.push("## Related Published Wikis");
+    for (const wiki of relatedWikis) {
+      parts.push(`- ${wiki.label} (id=${wiki.id}): ${wiki.firstParagraph}`);
+    }
+    parts.push("");
+  }
+
+  if (reconcileCandidates.length > 0) {
+    parts.push("## Ambiguous Matches (may or may not be the same subject)");
+    for (const c of reconcileCandidates) {
+      parts.push(`- id=${c.id} (confidence=${c.confidence}): ${c.rationale ?? ""}`);
+    }
+    parts.push("");
+  }
+
+  parts.push("Use tools to explore further, then call emit_dossier when ready.");
+
+  return parts.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export async function gatherDossier(
+  placeholder: PlaceholderInfo,
+  actor: WorkerActor,
+  depth: number,
+  reconcileCandidates: EntityMatch[],
+): Promise<Dossier> {
+  const usage = { tokensIn: 0, tokensOut: 0, turns: 0 };
+
+  // Pre-seed deterministic context
+  const [inboundSpans, nearbyEntities, relatedWikis, spaceWikiSample, sourceDoc] = await Promise.all([
+    fetchInboundSpans(placeholder.id, actor),
+    searchNearbyEntities(placeholder.label, placeholder.description, actor, placeholder.spaceId),
+    searchRelatedWikis(placeholder.label, placeholder.description, actor, placeholder.spaceId),
+    fetchSpaceWikiSample(placeholder.spaceId, actor),
+    fetchSourceContent(placeholder.id, actor),
+  ]);
+
+  // Start with entities discovered during pre-seed
+  const discovered: DiscoveredEntity[] = [...nearbyEntities];
+  const wikiSnippets: WikiSnippet[] = [...relatedWikis];
+
+  // Gating: if we have rich inbound context, skip the LLM loop
+  const distinctReferrers = new Set(inboundSpans.map((s) => s.referrerEntityId)).size;
+  if (inboundSpans.length >= RICH_SPAN_THRESHOLD && distinctReferrers >= RICH_REFERRER_THRESHOLD) {
+    return {
+      subjectSummary: `${placeholder.label}: referenced by ${inboundSpans.length} spans from ${distinctReferrers} wikis`,
+      inboundSpans,
+      confidentEntityLinks: discovered,
+      relatedWikiSnippets: wikiSnippets,
+      reconcileCandidates,
+      spaceWikiSample,
+      sourceContent: sourceDoc ? { label: sourceDoc.sourceLabel, content: sourceDoc.sourceContent } : null,
+      gatherNotes: "Static dossier — rich inbound context, LLM gather skipped",
+      usage,
+    };
+  }
+
+  // LLM gather loop
+  let subjectSummary = "";
+  let gatherNotes = "";
+
+  try {
+    const { client, model, maxTokens } = getLlmClient("exists");
+
+    const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [
+      { role: "system", content: buildGatherSystemPrompt(placeholder) },
+      { role: "user", content: buildSeedMessage(placeholder, inboundSpans, nearbyEntities, relatedWikis, reconcileCandidates) },
+    ];
+
+    const startTime = Date.now();
+    let done = false;
+
+    while (!done && usage.turns < MAX_TURNS && (Date.now() - startTime) < WALL_TIME_MS) {
+      const response = await client.chat.completions.create({
+        model,
+        messages,
+        tools: GATHER_TOOLS,
+        max_completion_tokens: maxTokens,
+      });
+
+      const choice = response.choices[0];
+      if (!choice) break;
+
+      usage.tokensIn += response.usage?.prompt_tokens ?? 0;
+      usage.tokensOut += response.usage?.completion_tokens ?? 0;
+      usage.turns++;
+
+      const msg = choice.message;
+      messages.push(msg);
+
+      if (!msg.tool_calls || msg.tool_calls.length === 0) break;
+
+      // Execute all tool calls in parallel
+      const toolResults = await Promise.all(
+        msg.tool_calls.map(async (tc) => {
+          let args: Record<string, unknown> = {};
+          try { args = JSON.parse(tc.function.arguments); } catch { /* empty */ }
+
+          if (tc.function.name === "emit_dossier") {
+            subjectSummary = String(args.summary ?? "");
+            gatherNotes = String(args.notes ?? "");
+            done = true;
+            return { id: tc.id, content: JSON.stringify({ status: "done" }) };
+          }
+
+          try {
+            const result = await executeTool(
+              tc.function.name, args, actor, placeholder.spaceId,
+              discovered, wikiSnippets,
+            );
+            return { id: tc.id, content: JSON.stringify(result) };
+          } catch (err) {
+            return { id: tc.id, content: JSON.stringify({ error: (err as Error).message }) };
+          }
+        }),
+      );
+
+      for (const tr of toolResults) {
+        messages.push({ role: "tool", tool_call_id: tr.id, content: tr.content });
+      }
+    }
+  } catch (err) {
+    console.warn("[draft-gather] LLM loop failed:", (err as Error).message);
+    gatherNotes = `Gather agent failed: ${(err as Error).message}. Using static context only.`;
+  }
+
+  return {
+    subjectSummary: subjectSummary || `${placeholder.label}: ${placeholder.description ?? "no description"}`,
+    inboundSpans,
+    confidentEntityLinks: discovered,
+    relatedWikiSnippets: wikiSnippets,
+    reconcileCandidates,
+    spaceWikiSample,
+    sourceContent: sourceDoc ? { label: sourceDoc.sourceLabel, content: sourceDoc.sourceContent } : null,
+    gatherNotes,
+    usage,
+  };
+}

--- a/packages/arkeon/src/server/lib/workers/draft-prompt.ts
+++ b/packages/arkeon/src/server/lib/workers/draft-prompt.ts
@@ -1,0 +1,206 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Wiki drafting LLM prompt builder and response parser.
+ *
+ * Consumes a Dossier (from the gather agent) and produces a wiki page
+ * by calling the "draft" LLM step. The output is a JSON object that
+ * can be submitted directly to POST /wiki.
+ */
+
+import { getLlmClient } from "../llm.js";
+import type { Dossier, PlaceholderInfo } from "./draft-gather.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DraftResponse {
+  can_draft: boolean;
+  refused_reason?: string;
+  label: string;
+  keywords: string[];
+  short_description: string;
+  content: string;
+  aliases?: string[];
+  subject_type?: string;
+}
+
+export interface DraftResult {
+  draft: DraftResponse;
+  usage: { tokensIn: number; tokensOut: number };
+}
+
+// ---------------------------------------------------------------------------
+// Prompt
+// ---------------------------------------------------------------------------
+
+const MAX_DEPTH = 2;
+
+function buildSystemPrompt(depth: number): string {
+  const depthRemaining = MAX_DEPTH - depth;
+
+  return `You are a wiki author for a collaborative knowledge graph. Given a subject entity and a research dossier, write a wiki article or determine that there is insufficient information.
+
+Return ONLY a JSON object with this exact shape:
+{
+  "can_draft": true,
+  "label": "Canonical Title",
+  "keywords": ["keyword1", "keyword2", "keyword3"],
+  "short_description": "One to two sentences summarizing the subject.",
+  "content": "Markdown body of the wiki article...",
+  "aliases": ["Alternative Name"],
+  "subject_type": "person"
+}
+
+If you cannot write a meaningful article (only a name with no real context), return:
+{
+  "can_draft": false,
+  "refused_reason": "Brief explanation of why drafting is not possible."
+}
+
+Rules for the markdown content:
+- Write 200-800 words. Be concise and factual.
+- Use ## headings for sections.
+- Use ONLY information from the dossier. Do not hallucinate facts.
+- Link to entities from the dossier using typed wiki links:
+  - [[entity:ULID]] for entities listed in the dossier's confident links. IMPORTANT: entity links contain ONLY the bare ULID — no label, no pipe, no quotes. Correct: [[entity:01ABC123]]. WRONG: [[entity:01ABC123|Some Label]].
+  - [[resolve:"Label"|"Description"]] for concepts that probably exist in the graph but you're not sure which entity
+${depthRemaining > 0
+    ? `  - [[assign:"Label"|"Description"]] for concepts that clearly need their own wiki page (spawns auto-drafting)`
+    : `  - Do NOT use [[assign:...]] links — depth budget exhausted. Use [[resolve:...]] instead.`}
+- Do not link to the subject itself.
+
+Rules for metadata:
+- label: the most common/canonical name for the subject
+- keywords: 3-10 search terms (acronyms, alternate names, related concepts)
+- short_description: 1-2 sentences shown in search previews
+- aliases: alternate titles/spellings (optional, only if the subject has well-known alternatives)
+- subject_type: semantic type like person, organization, concept, event, place, book, theory (optional)`;
+}
+
+function buildUserMessage(placeholder: PlaceholderInfo, dossier: Dossier): string {
+  const parts: string[] = [];
+
+  parts.push(`# Subject: "${placeholder.label}"`);
+  if (placeholder.description) parts.push(`Description: ${placeholder.description}`);
+  if (dossier.subjectSummary) parts.push(`Research summary: ${dossier.subjectSummary}`);
+  parts.push("");
+
+  if (dossier.inboundSpans.length > 0) {
+    parts.push("## How This Subject Is Referenced");
+    parts.push("These published wikis mention the subject in context:");
+    for (const span of dossier.inboundSpans.slice(0, 15)) {
+      parts.push(`- "${span.referrerLabel}" (${span.predicate}): "${span.spanText}"`);
+    }
+    parts.push("");
+  }
+
+  if (dossier.confidentEntityLinks.length > 0) {
+    parts.push("## Entities You Can Link To (use [[entity:<id>]])");
+    for (const ent of dossier.confidentEntityLinks.slice(0, 20)) {
+      parts.push(`- ${ent.label} (${ent.type}, id=${ent.id}): ${ent.shortDescription}`);
+    }
+    parts.push("");
+  }
+
+  if (dossier.relatedWikiSnippets.length > 0) {
+    parts.push("## Related Wikis (do not duplicate their content)");
+    for (const wiki of dossier.relatedWikiSnippets.slice(0, 5)) {
+      parts.push(`### ${wiki.label} (id=${wiki.id})`);
+      parts.push(wiki.firstParagraph);
+      parts.push("");
+    }
+  }
+
+  if (dossier.sourceContent) {
+    parts.push("## Source Document (primary material — cite and draw from this)");
+    parts.push(`Source: "${dossier.sourceContent.label}"`);
+    parts.push("");
+    parts.push(dossier.sourceContent.content.slice(0, 20_000));
+    parts.push("");
+  }
+
+  if (dossier.spaceWikiSample.length > 0) {
+    parts.push("## Other Wikis in This Space (for voice/style reference)");
+    for (const w of dossier.spaceWikiSample.slice(0, 10)) {
+      parts.push(`- ${w.label}: ${w.shortDescription}`);
+    }
+    parts.push("");
+  }
+
+  if (dossier.gatherNotes) {
+    parts.push(`## Research Notes`);
+    parts.push(dossier.gatherNotes);
+    parts.push("");
+  }
+
+  return parts.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export async function generateDraft(
+  placeholder: PlaceholderInfo,
+  dossier: Dossier,
+  depth: number,
+): Promise<DraftResult> {
+  const { client, model, maxTokens } = getLlmClient("draft");
+
+  const response = await client.chat.completions.create({
+    model,
+    messages: [
+      { role: "system", content: buildSystemPrompt(depth) },
+      { role: "user", content: buildUserMessage(placeholder, dossier) },
+    ],
+    response_format: { type: "json_object" },
+    max_completion_tokens: maxTokens,
+  });
+
+  const usage = {
+    tokensIn: response.usage?.prompt_tokens ?? 0,
+    tokensOut: response.usage?.completion_tokens ?? 0,
+  };
+
+  const content = response.choices[0]?.message?.content;
+  if (!content) {
+    return {
+      draft: { can_draft: false, refused_reason: "LLM returned empty response", label: placeholder.label, keywords: [], short_description: "", content: "" },
+      usage,
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+
+    const draft: DraftResponse = {
+      can_draft: parsed.can_draft !== false && !!parsed.content,
+      refused_reason: typeof parsed.refused_reason === "string" ? parsed.refused_reason : undefined,
+      label: typeof parsed.label === "string" && parsed.label.trim() ? parsed.label.trim() : placeholder.label,
+      keywords: Array.isArray(parsed.keywords) ? parsed.keywords.filter((k): k is string => typeof k === "string") : [],
+      short_description: typeof parsed.short_description === "string" ? parsed.short_description : "",
+      content: typeof parsed.content === "string" ? parsed.content : "",
+      aliases: Array.isArray(parsed.aliases) ? parsed.aliases.filter((a): a is string => typeof a === "string") : undefined,
+      subject_type: typeof parsed.subject_type === "string" ? parsed.subject_type : undefined,
+    };
+
+    // Ensure minimum metadata when can_draft is true
+    if (draft.can_draft) {
+      if (draft.keywords.length === 0) draft.keywords = [placeholder.label.toLowerCase()];
+      if (draft.short_description.length < 10) {
+        draft.short_description = dossier.subjectSummary.slice(0, 400) || `Wiki article about ${placeholder.label}.`;
+      }
+    }
+
+    return { draft, usage };
+  } catch (err) {
+    console.error("[draft-prompt] Failed to parse LLM response:", content.slice(0, 200));
+    return {
+      draft: { can_draft: false, refused_reason: `JSON parse error: ${(err as Error).message}`, label: placeholder.label, keywords: [], short_description: "", content: "" },
+      usage,
+    };
+  }
+}

--- a/packages/arkeon/src/server/lib/workers/draft-worker.ts
+++ b/packages/arkeon/src/server/lib/workers/draft-worker.ts
@@ -2,109 +2,414 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Draft worker — polls wiki_draft_queue for pending placeholder entities
- * and drafts wiki content for them via LLM.
+ * Wiki draft worker — polls wiki_draft_queue and drafts wiki pages.
  *
- * Phase 2 stub: the poll loop is wired up and will dequeue items, but
- * the actual LLM drafting logic is not yet implemented.
+ * For each pending placeholder:
+ *   1. Reconcile: check if a published wiki already covers this subject.
+ *      If so, redirect the placeholder and skip drafting.
+ *   2. Gather: run a read-only agent loop to build a context dossier.
+ *   3. Draft: call the drafting LLM to produce a wiki page.
+ *   4. Submit: POST the draft to /wiki (existing pipeline handles
+ *      resolve, relationships, and publishing).
+ *
+ * Follows the retention.ts start/stop pattern with setInterval.
  */
 
-import { ArkeonWorker } from "../worker.js";
-import type { ResolvedWorkerConfig } from "../worker-config.js";
+import { findSimilarEntities, type EntityMatch } from "../entity-resolve.js";
+import { gatherDossier, type PlaceholderInfo, type WorkerActor } from "./draft-gather.js";
+import { generateDraft } from "./draft-prompt.js";
+import { isLlmConfigured } from "../llm.js";
+import { isMeilisearchConfigured } from "../meilisearch.js";
 import { withTransaction } from "../sql.js";
+import { setActorContext, withSystemActorContext } from "../actor-context.js";
 
-export class DraftWorker extends ArkeonWorker {
-  constructor(config: ResolvedWorkerConfig) {
-    super("drafter", config);
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+let timer: NodeJS.Timeout | null = null;
+let running = false;
+
+const POLL_MS = Number(process.env.DRAFT_WORKER_POLL_MS) || 10_000;
+
+// ---------------------------------------------------------------------------
+// Queue operations (run as system actor — the queue is not user-facing)
+// ---------------------------------------------------------------------------
+
+interface QueueRow {
+  entity_id: string;
+  depth: number;
+  owner_agent: string;
+  attempts: number;
+  max_attempts: number;
+}
+
+async function claimNext(): Promise<QueueRow | null> {
+  return withSystemActorContext(async (sql) => {
+    const rows = await sql.query(
+      `UPDATE wiki_draft_queue
+       SET status = 'processing',
+           attempts = attempts + 1,
+           started_at = NOW()
+       WHERE entity_id = (
+         SELECT entity_id FROM wiki_draft_queue
+         WHERE status = 'pending'
+         ORDER BY created_at ASC
+         LIMIT 1
+         FOR UPDATE SKIP LOCKED
+       )
+       RETURNING entity_id, depth, owner_agent, attempts, max_attempts`,
+      [],
+    );
+    const row = (rows as Array<Record<string, unknown>>)[0];
+    if (!row) return null;
+    return {
+      entity_id: String(row.entity_id),
+      depth: Number(row.depth),
+      owner_agent: String(row.owner_agent),
+      attempts: Number(row.attempts),
+      max_attempts: Number(row.max_attempts),
+    };
+  });
+}
+
+async function markComplete(
+  entityId: string,
+  result?: { resultWikiId?: string; mergedInto?: string; dossier?: unknown },
+): Promise<void> {
+  await withSystemActorContext(async (sql) => {
+    await sql.query(
+      `UPDATE wiki_draft_queue
+       SET status = 'complete',
+           result_wiki_id = $2,
+           merged_into = $3,
+           context_dossier = $4::jsonb
+       WHERE entity_id = $1`,
+      [
+        entityId,
+        result?.resultWikiId ?? null,
+        result?.mergedInto ?? null,
+        result?.dossier ? JSON.stringify(result.dossier) : null,
+      ],
+    );
+  });
+}
+
+async function markFailed(entityId: string, error: string, attempts: number, maxAttempts: number): Promise<void> {
+  const status = attempts >= maxAttempts ? "failed" : "pending";
+  await withSystemActorContext(async (sql) => {
+    await sql.query(
+      `UPDATE wiki_draft_queue SET status = $2, error = $3 WHERE entity_id = $1`,
+      [entityId, status, error.slice(0, 500)],
+    );
+  });
+}
+
+async function markUndraftable(entityId: string, reason: string, dossier?: unknown): Promise<void> {
+  await withSystemActorContext(async (sql) => {
+    await sql.query(
+      `UPDATE wiki_draft_queue
+       SET status = 'undraftable',
+           error = $2,
+           context_dossier = $3::jsonb
+       WHERE entity_id = $1`,
+      [entityId, reason.slice(0, 500), dossier ? JSON.stringify(dossier) : null],
+    );
+  });
+}
+
+async function recoverStuckRows(): Promise<number> {
+  return withSystemActorContext(async (sql) => {
+    const rows = await sql`
+      UPDATE wiki_draft_queue
+      SET status = 'pending'
+      WHERE status = 'processing'
+        AND attempts < max_attempts
+      RETURNING entity_id
+    `;
+    return (rows as unknown[]).length;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Actor + placeholder loading
+// ---------------------------------------------------------------------------
+
+async function loadActor(actorId: string): Promise<WorkerActor | null> {
+  return withSystemActorContext(async (sql) => {
+    const rows = await sql`
+      SELECT id, properties, max_read_level, max_write_level, is_admin, can_publish_public
+      FROM actors WHERE id = ${actorId} LIMIT 1
+    `;
+    const row = (rows as Array<Record<string, unknown>>)[0];
+    if (!row) return null;
+    const props = (row.properties as Record<string, unknown>) ?? {};
+    return {
+      id: String(row.id),
+      apiKeyId: "",
+      keyPrefix: "",
+      label: typeof props.label === "string" ? props.label : null,
+      maxReadLevel: Number(row.max_read_level),
+      maxWriteLevel: Number(row.max_write_level),
+      isAdmin: row.is_admin === true,
+      canPublishPublic: row.can_publish_public === true,
+    };
+  });
+}
+
+async function loadPlaceholder(entityId: string, actor: WorkerActor): Promise<PlaceholderInfo | null> {
+  return withTransaction(async (sql) => {
+    for (const q of setActorContext(sql, actor)) await q;
+
+    const rows = await sql`
+      SELECT e.id, e.type, e.properties,
+        (SELECT se.space_id FROM space_entities se WHERE se.entity_id = e.id LIMIT 1) AS space_id
+      FROM entities e
+      WHERE e.id = ${entityId} AND e.kind = 'entity'
+      LIMIT 1
+    `;
+    const row = (rows as Array<Record<string, unknown>>)[0];
+    if (!row) return null;
+    const props = (row.properties as Record<string, unknown>) ?? {};
+    return {
+      id: String(row.id),
+      label: String(props.label ?? ""),
+      description: typeof props.description === "string" ? props.description : null,
+      spaceId: String(row.space_id ?? ""),
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Redirect helper
+// ---------------------------------------------------------------------------
+
+async function redirectPlaceholder(placeholderId: string, targetWikiId: string, actorId: string): Promise<void> {
+  await withSystemActorContext(async (sql) => {
+    await sql`
+      INSERT INTO entity_redirects (old_id, new_id, merged_at, merged_by)
+      VALUES (${placeholderId}, ${targetWikiId}, NOW(), ${actorId})
+      ON CONFLICT (old_id) DO NOTHING
+    `;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Submit draft via HTTP to the local API
+// ---------------------------------------------------------------------------
+
+async function submitDraft(
+  draft: { label: string; keywords: string[]; short_description: string; content: string; aliases?: string[]; subject_type?: string },
+  spaceId: string,
+  depth: number,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const port = process.env.PORT ?? "8000";
+  const adminKey = process.env.ADMIN_BOOTSTRAP_KEY;
+  if (!adminKey) throw new Error("ADMIN_BOOTSTRAP_KEY not set — cannot submit draft");
+
+  const payload: Record<string, unknown> = {
+    content: draft.content,
+    label: draft.label,
+    keywords: draft.keywords,
+    short_description: draft.short_description,
+    space_id: spaceId,
+    depth,
+  };
+  if (draft.aliases && draft.aliases.length > 0) payload.aliases = draft.aliases;
+  if (draft.subject_type) payload.type = draft.subject_type;
+
+  const res = await fetch(`http://localhost:${port}/wiki`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-API-Key": adminKey,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const body = (await res.json()) as Record<string, unknown>;
+  return { status: res.status, body };
+}
+
+// ---------------------------------------------------------------------------
+// Core: process one queue item
+// ---------------------------------------------------------------------------
+
+async function processItem(row: QueueRow): Promise<void> {
+  const tag = `[draft-worker] ${row.entity_id.slice(0, 8)}`;
+
+  // Load the actor who requested the draft
+  const actor = await loadActor(row.owner_agent);
+  if (!actor) {
+    console.warn(`${tag} owner_agent ${row.owner_agent} not found, marking failed`);
+    await markFailed(row.entity_id, `owner_agent ${row.owner_agent} not found`, row.attempts, row.max_attempts);
+    return;
   }
 
-  protected async poll(): Promise<void> {
-    const batchSize = this.config.batchSize;
-    const maxDepth = (this.config.extra.max_depth as number) ?? 2;
-
-    // Claim a batch of pending items using advisory lock to prevent
-    // concurrent workers from grabbing the same rows.
-    const items = await withTransaction(async (tx) => {
-      // Try advisory lock — skip this tick if another worker holds it
-      const lockResult = await tx`SELECT pg_try_advisory_xact_lock(8675309) AS locked`;
-      if (!lockResult[0]?.locked) return [];
-
-      return tx`
-        UPDATE wiki_draft_queue
-        SET status = 'processing', attempts = attempts + 1
-        WHERE entity_id IN (
-          SELECT entity_id FROM wiki_draft_queue
-          WHERE status = 'pending'
-            AND depth <= ${maxDepth}
-          ORDER BY created_at ASC
-          LIMIT ${batchSize}
-          FOR UPDATE SKIP LOCKED
-        )
-        RETURNING entity_id, depth, owner_agent
-      `;
-    });
-
-    if (items.length === 0) return;
-
-    console.log(`[worker:drafter] dequeued ${items.length} item(s)`);
-
-    for (const item of items) {
-      const entityId = String(item.entity_id);
-      const depth = Number(item.depth);
-
-      try {
-        await this.draftEntity(entityId, depth, String(item.owner_agent));
-      } catch (err) {
-        console.error(`[worker:drafter] failed to draft ${entityId}:`, (err as Error).message);
-        await withTransaction(async (tx) => {
-          await tx`
-            UPDATE wiki_draft_queue
-            SET status = CASE WHEN attempts >= max_attempts THEN 'failed' ELSE 'pending' END,
-                error = ${(err as Error).message}
-            WHERE entity_id = ${entityId}
-          `;
-        });
-      }
-    }
+  // Load the placeholder entity
+  const placeholder = await loadPlaceholder(row.entity_id, actor);
+  if (!placeholder) {
+    console.log(`${tag} placeholder entity gone, marking complete`);
+    await markComplete(row.entity_id);
+    return;
+  }
+  if (!placeholder.spaceId) {
+    await markFailed(row.entity_id, "placeholder has no space", row.attempts, row.max_attempts);
+    return;
   }
 
-  private async draftEntity(entityId: string, depth: number, _ownerAgent: string): Promise<void> {
-    // Fetch the placeholder entity to get its label + description
-    const rows = await withTransaction(async (tx) => {
-      return tx`
-        SELECT properties FROM entities
-        WHERE id = ${entityId} AND kind = 'entity' AND type = 'placeholder'
-      `;
-    });
+  console.log(`${tag} processing "${placeholder.label}" (depth=${row.depth}, attempt=${row.attempts})`);
 
-    if (rows.length === 0) {
-      // Entity no longer exists or is no longer a placeholder — mark undraftable
-      await withTransaction(async (tx) => {
-        await tx`
-          UPDATE wiki_draft_queue SET status = 'undraftable'
-          WHERE entity_id = ${entityId}
-        `;
-      });
+  // --- Step 1: Reconcile — does a wiki already cover this subject? ---
+  let reconcileCandidates: EntityMatch[] = [];
+  try {
+    reconcileCandidates = await findSimilarEntities(
+      { label: placeholder.label, description: placeholder.description ?? undefined },
+      {
+        actor,
+        spaceId: placeholder.spaceId,
+        candidateFilter: ['type = "wiki"'],
+        llmStep: "exists",
+      },
+    );
+
+    if (reconcileCandidates.length > 0 && reconcileCandidates[0]!.confidence >= 0.8) {
+      const match = reconcileCandidates[0]!;
+      console.log(`${tag} reconcile match: ${match.id} (confidence=${match.confidence})`);
+      await redirectPlaceholder(placeholder.id, match.id, actor.id);
+      await markComplete(row.entity_id, { mergedInto: match.id });
       return;
     }
+  } catch (err) {
+    console.warn(`${tag} reconcile failed, continuing to draft:`, (err as Error).message);
+  }
 
-    const props = rows[0]!.properties as Record<string, unknown>;
-    const _label = String(props.label ?? "");
-    const _description = String(props.description ?? "");
+  // --- Step 2: Gather context ---
+  const dossier = await gatherDossier(placeholder, actor, row.depth, reconcileCandidates);
+  console.log(
+    `${tag} gather complete: ${dossier.inboundSpans.length} spans, ` +
+    `${dossier.confidentEntityLinks.length} entities, ` +
+    `${dossier.usage.turns} turns`,
+  );
 
-    // TODO(phase-2): Implement actual LLM drafting
-    // 1. Build prompt using this.resolvePrompt(DRAFT_PROMPT) with entity context
-    // 2. Call LLM to generate wiki content
-    // 3. POST /wiki with depth+1 to create the wiki (triggers the full pipeline)
-    // 4. Mark queue item as 'complete'
-    //
-    // For now, mark as undraftable so items don't spin forever.
-    await withTransaction(async (tx) => {
-      await tx`
-        UPDATE wiki_draft_queue SET status = 'undraftable',
-          error = 'draft worker not yet implemented'
-        WHERE entity_id = ${entityId}
-      `;
-    });
+  // --- Step 3: Draft ---
+  const { draft, usage: draftUsage } = await generateDraft(placeholder, dossier, row.depth);
+
+  if (!draft.can_draft) {
+    console.log(`${tag} undraftable: ${draft.refused_reason}`);
+    await markUndraftable(row.entity_id, draft.refused_reason ?? "LLM declined to draft", dossier);
+    // Update the placeholder entity's status to undraftable
+    try {
+      await withSystemActorContext(async (sql) => {
+        await sql`
+          UPDATE entities
+          SET properties = properties || '{"status": "undraftable"}'::jsonb
+          WHERE id = ${row.entity_id}
+        `;
+      });
+    } catch { /* best effort */ }
+    return;
+  }
+
+  // --- Step 4: Submit via POST /wiki ---
+  console.log(
+    `${tag} submitting draft "${draft.label}" (${draft.content.length} chars, ` +
+    `gather=${dossier.usage.tokensIn + dossier.usage.tokensOut}tok, ` +
+    `draft=${draftUsage.tokensIn + draftUsage.tokensOut}tok)`,
+  );
+
+  const { status, body } = await submitDraft(draft, placeholder.spaceId, row.depth);
+
+  if (status === 201) {
+    const wikiId = String((body.wiki as Record<string, unknown>)?.id ?? "");
+    console.log(`${tag} published wiki ${wikiId}`);
+    // Redirect the placeholder to the newly drafted wiki so that
+    // [[entity:<placeholder>]] links in the parent wiki resolve to it.
+    if (wikiId) {
+      await redirectPlaceholder(placeholder.id, wikiId, actor.id);
+    }
+    await markComplete(row.entity_id, { resultWikiId: wikiId, dossier });
+    return;
+  }
+
+  if (status === 409) {
+    // Wiki with this label already exists — redirect to it
+    const existingId = String(
+      ((body.error as Record<string, unknown>)?.details as Record<string, unknown>)?.existing_wiki_id ?? "",
+    );
+    if (existingId) {
+      console.log(`${tag} wiki already exists (${existingId}), redirecting`);
+      await redirectPlaceholder(placeholder.id, existingId, actor.id);
+      await markComplete(row.entity_id, { mergedInto: existingId, dossier });
+    } else {
+      await markFailed(row.entity_id, `409 wiki_exists but no existing_wiki_id in response`, row.attempts, row.max_attempts);
+    }
+    return;
+  }
+
+  // Other errors: retry or fail
+  const errMsg = JSON.stringify(body).slice(0, 400);
+  console.warn(`${tag} POST /wiki returned ${status}: ${errMsg}`);
+  await markFailed(row.entity_id, `POST /wiki ${status}: ${errMsg}`, row.attempts, row.max_attempts);
+}
+
+// ---------------------------------------------------------------------------
+// Worker loop
+// ---------------------------------------------------------------------------
+
+async function tick(): Promise<void> {
+  if (running) return;
+  running = true;
+  try {
+    const row = await claimNext();
+    if (!row) return;
+
+    try {
+      await processItem(row);
+    } catch (err) {
+      console.error(`[draft-worker] ${row.entity_id.slice(0, 8)} unexpected error:`, err);
+      await markFailed(
+        row.entity_id,
+        `Unexpected: ${(err as Error).message}`,
+        row.attempts,
+        row.max_attempts,
+      ).catch(() => {});
+    }
+  } finally {
+    running = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function startDraftWorker(): void {
+  if (timer) return;
+  if (!isLlmConfigured()) {
+    console.warn("[draft-worker] LLM not configured — draft worker disabled");
+    return;
+  }
+  if (!isMeilisearchConfigured()) {
+    console.warn("[draft-worker] Meilisearch not configured — draft worker disabled");
+    return;
+  }
+
+  // Recover any rows stuck in 'processing' from a previous crash
+  void recoverStuckRows().then((n) => {
+    if (n > 0) console.log(`[draft-worker] recovered ${n} stuck row(s)`);
+  });
+
+  console.log(`[draft-worker] started (poll=${POLL_MS}ms)`);
+  void tick(); // immediate first tick
+  timer = setInterval(() => void tick(), POLL_MS);
+  timer.unref?.();
+}
+
+export function stopDraftWorker(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+    console.log("[draft-worker] stopped");
   }
 }

--- a/packages/arkeon/src/server/lib/workers/draft-worker.ts
+++ b/packages/arkeon/src/server/lib/workers/draft-worker.ts
@@ -15,8 +15,9 @@
  * Follows the retention.ts start/stop pattern with setInterval.
  */
 
+import type { Actor } from "../../types.js";
 import { findSimilarEntities, type EntityMatch } from "../entity-resolve.js";
-import { gatherDossier, type PlaceholderInfo, type WorkerActor } from "./draft-gather.js";
+import { gatherDossier, type PlaceholderInfo } from "./draft-gather.js";
 import { generateDraft } from "./draft-prompt.js";
 import { isLlmConfigured } from "../llm.js";
 import { isMeilisearchConfigured } from "../meilisearch.js";
@@ -135,10 +136,10 @@ async function recoverStuckRows(): Promise<number> {
 // Actor + placeholder loading
 // ---------------------------------------------------------------------------
 
-async function loadActor(actorId: string): Promise<WorkerActor | null> {
+async function loadActor(actorId: string): Promise<Actor | null> {
   return withSystemActorContext(async (sql) => {
     const rows = await sql`
-      SELECT id, properties, max_read_level, max_write_level, is_admin, can_publish_public
+      SELECT id, properties
       FROM actors WHERE id = ${actorId} LIMIT 1
     `;
     const row = (rows as Array<Record<string, unknown>>)[0];
@@ -149,15 +150,11 @@ async function loadActor(actorId: string): Promise<WorkerActor | null> {
       apiKeyId: "",
       keyPrefix: "",
       label: typeof props.label === "string" ? props.label : null,
-      maxReadLevel: Number(row.max_read_level),
-      maxWriteLevel: Number(row.max_write_level),
-      isAdmin: row.is_admin === true,
-      canPublishPublic: row.can_publish_public === true,
     };
   });
 }
 
-async function loadPlaceholder(entityId: string, actor: WorkerActor): Promise<PlaceholderInfo | null> {
+async function loadPlaceholder(entityId: string, actor: Actor): Promise<PlaceholderInfo | null> {
   return withTransaction(async (sql) => {
     for (const q of setActorContext(sql, actor)) await q;
 

--- a/packages/arkeon/src/server/lib/workers/extract-worker.ts
+++ b/packages/arkeon/src/server/lib/workers/extract-worker.ts
@@ -14,7 +14,7 @@
  * Follows the same start/stop pattern as draft-worker.ts.
  */
 
-import type { WorkerActor } from "./draft-gather.js";
+import type { Actor } from "../../types.js";
 import { getLlmClient, isLlmConfigured } from "../llm.js";
 import { withTransaction } from "../sql.js";
 import { setActorContext, withSystemActorContext } from "../actor-context.js";
@@ -99,10 +99,10 @@ async function recoverStuckRows(): Promise<number> {
 // Actor + source loading
 // ---------------------------------------------------------------------------
 
-async function loadActor(actorId: string): Promise<WorkerActor | null> {
+async function loadActor(actorId: string): Promise<Actor | null> {
   return withSystemActorContext(async (sql) => {
     const rows = await sql`
-      SELECT id, properties, max_read_level, max_write_level, is_admin, can_publish_public
+      SELECT id, properties
       FROM actors WHERE id = ${actorId} LIMIT 1
     `;
     const row = (rows as Array<Record<string, unknown>>)[0];
@@ -113,10 +113,6 @@ async function loadActor(actorId: string): Promise<WorkerActor | null> {
       apiKeyId: "",
       keyPrefix: "",
       label: typeof props.label === "string" ? props.label : null,
-      maxReadLevel: Number(row.max_read_level),
-      maxWriteLevel: Number(row.max_write_level),
-      isAdmin: row.is_admin === true,
-      canPublishPublic: row.can_publish_public === true,
     };
   });
 }
@@ -129,7 +125,7 @@ interface SourceInfo {
   spaceId: string;
 }
 
-async function loadSource(entityId: string, actor: WorkerActor): Promise<SourceInfo | null> {
+async function loadSource(entityId: string, actor: Actor): Promise<SourceInfo | null> {
   return withTransaction(async (sql) => {
     for (const q of setActorContext(sql, actor)) await q;
     const rows = await sql`

--- a/packages/arkeon/src/server/lib/workers/extract-worker.ts
+++ b/packages/arkeon/src/server/lib/workers/extract-worker.ts
@@ -276,10 +276,10 @@ async function processItem(row: QueueRow): Promise<void> {
       await tx`
         INSERT INTO entities (
           id, kind, type, ver, properties, owner_id,
-          read_level, write_level, edited_by, note, created_at, updated_at
+          edited_by, note, created_at, updated_at
         ) VALUES (
           ${phId}, 'entity', 'placeholder', 1, ${phProps}::jsonb, ${actor.id},
-          1, 1, ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
+          ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
         )
       `;
 
@@ -296,14 +296,11 @@ async function processItem(row: QueueRow): Promise<void> {
       await tx`
         INSERT INTO entities (
           id, kind, type, ver, properties, owner_id,
-          read_level, write_level, edited_by, note, created_at, updated_at
-        ) SELECT
+          edited_by, note, created_at, updated_at
+        ) VALUES (
           ${relId}, 'relationship', 'relationship', 1, ${relProps}::jsonb,
-          ${actor.id}, GREATEST(src.read_level, tgt.read_level),
-          GREATEST(src.write_level, tgt.write_level),
-          ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
-        FROM entities src, entities tgt
-        WHERE src.id = ${phId} AND tgt.id = ${source.id}
+          ${actor.id}, ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
+        )
       `;
       await tx`
         INSERT INTO relationship_edges (id, source_id, target_id, predicate)

--- a/packages/arkeon/src/server/lib/workers/extract-worker.ts
+++ b/packages/arkeon/src/server/lib/workers/extract-worker.ts
@@ -1,0 +1,386 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Extract worker — reads source entities and produces placeholders.
+ *
+ * Polls source_extract_queue. For each source entity:
+ *   1. Load the source content
+ *   2. Call the LLM to identify notable subjects
+ *   3. Create placeholder entities for each subject
+ *   4. Create extracted_from relationships back to the source
+ *   5. Queue each placeholder for drafting via wiki_draft_queue
+ *
+ * Follows the same start/stop pattern as draft-worker.ts.
+ */
+
+import type { WorkerActor } from "./draft-gather.js";
+import { getLlmClient, isLlmConfigured } from "../llm.js";
+import { withTransaction } from "../sql.js";
+import { setActorContext, withSystemActorContext } from "../actor-context.js";
+import { generateUlid } from "../ids.js";
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+let timer: NodeJS.Timeout | null = null;
+let running = false;
+
+const POLL_MS = Number(process.env.EXTRACT_WORKER_POLL_MS) || 15_000;
+
+// ---------------------------------------------------------------------------
+// Queue operations
+// ---------------------------------------------------------------------------
+
+interface QueueRow {
+  entity_id: string;
+  owner_agent: string;
+  attempts: number;
+  max_attempts: number;
+}
+
+async function claimNext(): Promise<QueueRow | null> {
+  return withSystemActorContext(async (sql) => {
+    const rows = await sql.query(
+      `UPDATE source_extract_queue
+       SET status = 'processing', attempts = attempts + 1, started_at = NOW()
+       WHERE entity_id = (
+         SELECT entity_id FROM source_extract_queue
+         WHERE status = 'pending'
+         ORDER BY created_at ASC
+         LIMIT 1
+         FOR UPDATE SKIP LOCKED
+       ) RETURNING entity_id, owner_agent, attempts, max_attempts`,
+      [],
+    );
+    const row = (rows as Array<Record<string, unknown>>)[0];
+    if (!row) return null;
+    return {
+      entity_id: String(row.entity_id),
+      owner_agent: String(row.owner_agent),
+      attempts: Number(row.attempts),
+      max_attempts: Number(row.max_attempts),
+    };
+  });
+}
+
+async function markComplete(entityId: string, placeholdersCreated: number): Promise<void> {
+  await withSystemActorContext(async (sql) => {
+    await sql.query(
+      `UPDATE source_extract_queue SET status = 'complete', placeholders_created = $2 WHERE entity_id = $1`,
+      [entityId, placeholdersCreated],
+    );
+  });
+}
+
+async function markFailed(entityId: string, error: string, attempts: number, maxAttempts: number): Promise<void> {
+  const status = attempts >= maxAttempts ? "failed" : "pending";
+  await withSystemActorContext(async (sql) => {
+    await sql.query(
+      `UPDATE source_extract_queue SET status = $2, error = $3 WHERE entity_id = $1`,
+      [entityId, status, error.slice(0, 500)],
+    );
+  });
+}
+
+async function recoverStuckRows(): Promise<number> {
+  return withSystemActorContext(async (sql) => {
+    const rows = await sql`
+      UPDATE source_extract_queue SET status = 'pending'
+      WHERE status = 'processing' AND attempts < max_attempts
+      RETURNING entity_id
+    `;
+    return (rows as unknown[]).length;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Actor + source loading
+// ---------------------------------------------------------------------------
+
+async function loadActor(actorId: string): Promise<WorkerActor | null> {
+  return withSystemActorContext(async (sql) => {
+    const rows = await sql`
+      SELECT id, properties, max_read_level, max_write_level, is_admin, can_publish_public
+      FROM actors WHERE id = ${actorId} LIMIT 1
+    `;
+    const row = (rows as Array<Record<string, unknown>>)[0];
+    if (!row) return null;
+    const props = (row.properties as Record<string, unknown>) ?? {};
+    return {
+      id: String(row.id),
+      apiKeyId: "",
+      keyPrefix: "",
+      label: typeof props.label === "string" ? props.label : null,
+      maxReadLevel: Number(row.max_read_level),
+      maxWriteLevel: Number(row.max_write_level),
+      isAdmin: row.is_admin === true,
+      canPublishPublic: row.can_publish_public === true,
+    };
+  });
+}
+
+interface SourceInfo {
+  id: string;
+  label: string;
+  description: string | null;
+  content: string;
+  spaceId: string;
+}
+
+async function loadSource(entityId: string, actor: WorkerActor): Promise<SourceInfo | null> {
+  return withTransaction(async (sql) => {
+    for (const q of setActorContext(sql, actor)) await q;
+    const rows = await sql`
+      SELECT e.id, e.properties,
+        (SELECT se.space_id FROM space_entities se WHERE se.entity_id = e.id LIMIT 1) AS space_id
+      FROM entities e
+      WHERE e.id = ${entityId} AND e.kind = 'entity'
+      LIMIT 1
+    `;
+    const row = (rows as Array<Record<string, unknown>>)[0];
+    if (!row) return null;
+    const props = (row.properties as Record<string, unknown>) ?? {};
+    const content = String(props.content ?? "");
+    if (!content) return null;
+    return {
+      id: String(row.id),
+      label: String(props.label ?? ""),
+      description: typeof props.description === "string" ? props.description : null,
+      content,
+      spaceId: String(row.space_id ?? ""),
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// LLM extraction
+// ---------------------------------------------------------------------------
+
+interface ExtractedSubject {
+  label: string;
+  description: string;
+  subject_type: string;
+}
+
+const EXTRACT_PROMPT = `You are an entity extractor for a knowledge graph wiki.
+
+Given a source document, identify the notable subjects mentioned — people, organizations, concepts, events, places, books, theories, etc. For each, provide a label, a one-sentence description, and a semantic type.
+
+Return ONLY a JSON object:
+{
+  "subjects": [
+    {
+      "label": "Name of the subject",
+      "description": "One sentence describing what this is",
+      "subject_type": "person|organization|concept|event|place|book|theory|other"
+    }
+  ]
+}
+
+Rules:
+- Extract 5-30 subjects depending on document length and density
+- Focus on subjects that deserve their own wiki page — skip trivial mentions
+- Use the most canonical/common name for each subject
+- Descriptions should be self-contained (understandable without the source)
+- Do not extract the source document itself as a subject
+- Prefer specific subjects over generic ones ("ATP Synthase" over "enzymes")`;
+
+async function extractSubjects(content: string, sourceLabel: string): Promise<ExtractedSubject[]> {
+  const { client, model } = getLlmClient("draft"); // use draft config — extraction needs more tokens than exists
+
+  const userMessage = `Source document: "${sourceLabel}"\n\n${content.slice(0, 50_000)}`;
+
+  const response = await client.chat.completions.create({
+    model,
+    messages: [
+      { role: "system", content: EXTRACT_PROMPT },
+      { role: "user", content: userMessage },
+    ],
+    response_format: { type: "json_object" },
+    max_completion_tokens: 4000,
+  });
+
+  const raw = response.choices[0]?.message?.content;
+  if (!raw) return [];
+
+  try {
+    const parsed = JSON.parse(raw) as { subjects?: unknown[] };
+    if (!Array.isArray(parsed.subjects)) return [];
+
+    return parsed.subjects
+      .filter((s): s is Record<string, unknown> => typeof s === "object" && s !== null)
+      .map((s) => ({
+        label: String(s.label ?? "").trim(),
+        description: String(s.description ?? "").trim(),
+        subject_type: String(s.subject_type ?? "other").trim(),
+      }))
+      .filter((s) => s.label.length > 0);
+  } catch {
+    console.error("[extract-worker] Failed to parse LLM response:", raw.slice(0, 500));
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core: process one source
+// ---------------------------------------------------------------------------
+
+async function processItem(row: QueueRow): Promise<void> {
+  const tag = `[extract-worker] ${row.entity_id.slice(0, 8)}`;
+
+  const actor = await loadActor(row.owner_agent);
+  if (!actor) {
+    await markFailed(row.entity_id, `owner_agent ${row.owner_agent} not found`, row.attempts, row.max_attempts);
+    return;
+  }
+
+  const source = await loadSource(row.entity_id, actor);
+  if (!source) {
+    console.log(`${tag} source entity gone, marking complete`);
+    await markComplete(row.entity_id, 0);
+    return;
+  }
+  if (!source.spaceId) {
+    await markFailed(row.entity_id, "source has no space", row.attempts, row.max_attempts);
+    return;
+  }
+
+  console.log(`${tag} extracting from "${source.label}" (${source.content.length} chars)`);
+
+  // Call LLM to identify subjects
+  const subjects = await extractSubjects(source.content, source.label);
+  if (subjects.length === 0) {
+    console.log(`${tag} no subjects extracted`);
+    await markComplete(row.entity_id, 0);
+    return;
+  }
+
+  console.log(`${tag} extracted ${subjects.length} subjects: ${subjects.map((s) => s.label).join(", ")}`);
+
+  // Create placeholders and queue them for drafting
+  const now = new Date().toISOString();
+  const deadline = new Date(Date.now() + 3600_000).toISOString();
+  let created = 0;
+
+  await withTransaction(async (tx) => {
+    for (const q of setActorContext(tx, actor)) await q;
+
+    for (const subject of subjects) {
+      const phId = generateUlid();
+      const phProps = {
+        label: subject.label,
+        description: subject.description,
+        subject_type: subject.subject_type,
+        status: "assigned",
+      };
+
+      // Create placeholder entity
+      await tx`
+        INSERT INTO entities (
+          id, kind, type, ver, properties, owner_id,
+          read_level, write_level, edited_by, note, created_at, updated_at
+        ) VALUES (
+          ${phId}, 'entity', 'placeholder', 1, ${phProps}::jsonb, ${actor.id},
+          1, 1, ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
+        )
+      `;
+
+      // Add to space
+      await tx`
+        INSERT INTO space_entities (space_id, entity_id, added_by, added_at)
+        VALUES (${source.spaceId}, ${phId}, ${actor.id}, ${now}::timestamptz)
+        ON CONFLICT (space_id, entity_id) DO NOTHING
+      `;
+
+      // Create extracted_from relationship back to source
+      const relId = generateUlid();
+      const relProps = { detail: `Extracted from "${source.label}"` };
+      await tx`
+        INSERT INTO entities (
+          id, kind, type, ver, properties, owner_id,
+          read_level, write_level, edited_by, note, created_at, updated_at
+        ) SELECT
+          ${relId}, 'relationship', 'relationship', 1, ${relProps}::jsonb,
+          ${actor.id}, GREATEST(src.read_level, tgt.read_level),
+          GREATEST(src.write_level, tgt.write_level),
+          ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
+        FROM entities src, entities tgt
+        WHERE src.id = ${phId} AND tgt.id = ${source.id}
+      `;
+      await tx`
+        INSERT INTO relationship_edges (id, source_id, target_id, predicate)
+        VALUES (${relId}, ${phId}, ${source.id}, 'extracted_from')
+      `;
+      await tx`
+        INSERT INTO space_entities (space_id, entity_id, added_by, added_at)
+        VALUES (${source.spaceId}, ${relId}, ${actor.id}, ${now}::timestamptz)
+        ON CONFLICT (space_id, entity_id) DO NOTHING
+      `;
+
+      // Queue for drafting
+      await tx`
+        INSERT INTO wiki_draft_queue (entity_id, depth, owner_agent, deadline, status, created_at)
+        VALUES (${phId}, 0, ${actor.id}, ${deadline}::timestamptz, 'pending', ${now}::timestamptz)
+        ON CONFLICT (entity_id) DO NOTHING
+      `;
+
+      created++;
+    }
+  });
+
+  console.log(`${tag} created ${created} placeholders, queued for drafting`);
+  await markComplete(row.entity_id, created);
+}
+
+// ---------------------------------------------------------------------------
+// Worker loop
+// ---------------------------------------------------------------------------
+
+async function tick(): Promise<void> {
+  if (running) return;
+  running = true;
+  try {
+    const row = await claimNext();
+    if (!row) return;
+
+    try {
+      await processItem(row);
+    } catch (err) {
+      console.error(`[extract-worker] ${row.entity_id.slice(0, 8)} error:`, err);
+      await markFailed(row.entity_id, `Unexpected: ${(err as Error).message}`, row.attempts, row.max_attempts).catch(() => {});
+    }
+  } finally {
+    running = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function startExtractWorker(): void {
+  if (timer) return;
+  if (!isLlmConfigured()) {
+    console.warn("[extract-worker] LLM not configured — extract worker disabled");
+    return;
+  }
+
+  void recoverStuckRows().then((n) => {
+    if (n > 0) console.log(`[extract-worker] recovered ${n} stuck row(s)`);
+  });
+
+  console.log(`[extract-worker] started (poll=${POLL_MS}ms)`);
+  void tick();
+  timer = setInterval(() => void tick(), POLL_MS);
+  timer.unref?.();
+}
+
+export function stopExtractWorker(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+    console.log("[extract-worker] stopped");
+  }
+}

--- a/packages/arkeon/src/server/routes/entities.ts
+++ b/packages/arkeon/src/server/routes/entities.ts
@@ -508,16 +508,21 @@ wikisRouter.openapi(getEntityRoute, async (c) => {
   ]);
 
   const entity = (results[results.length - 1] as EntityRecord[])[0];
+
+  // Check if entity was merged/redirected into another — this covers both
+  // deleted entities and placeholder entities that were redirected by the
+  // draft worker (the placeholder row still exists but callers should
+  // follow the redirect).
+  const redirectRows = await sql`SELECT new_id, merged_at FROM entity_redirects WHERE old_id = ${entityId} LIMIT 1`;
+  const redirect = (redirectRows as Array<{ new_id: string; merged_at: string }>)[0];
+  if (redirect) {
+    throw new ApiError(410, "entity_merged", "This entity was merged into another entity", {
+      merged_into: redirect.new_id,
+      merged_at: redirect.merged_at,
+    });
+  }
+
   if (!entity) {
-    // Check if entity was merged into another
-    const redirectRows = await sql`SELECT new_id, merged_at FROM entity_redirects WHERE old_id = ${entityId} LIMIT 1`;
-    const redirect = (redirectRows as Array<{ new_id: string; merged_at: string }>)[0];
-    if (redirect) {
-      throw new ApiError(410, "entity_merged", "This entity was merged into another entity", {
-        merged_into: redirect.new_id,
-        merged_at: redirect.merged_at,
-      });
-    }
     throw new ApiError(404, "not_found", "Entity not found");
   }
 

--- a/packages/arkeon/test/e2e/draft-worker.test.ts
+++ b/packages/arkeon/test/e2e/draft-worker.test.ts
@@ -1,0 +1,243 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * E2E tests for the wiki draft worker.
+ *
+ * Requires a running stack with LLM and Meilisearch configured:
+ *   OPENAI_API_KEY=sk-... npm run test:e2e -- draft-worker
+ *
+ * These tests exercise the full pipeline: POST /wiki with assign links
+ * → placeholder queued → draft worker processes → wiki published.
+ */
+
+import { describe, expect, test } from "vitest";
+import {
+  adminApiKey,
+  baseUrl,
+  createActor,
+  createSpace,
+  createWiki,
+  getJson,
+  jsonRequest,
+  uniqueName,
+} from "./helpers";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Poll a condition until it resolves to true or timeout. */
+async function waitFor(
+  fn: () => Promise<boolean>,
+  { timeoutMs = 60_000, intervalMs = 2_000 } = {},
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await fn()) return;
+    await sleep(intervalMs);
+  }
+  throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+}
+
+async function getQueueStatus(entityId: string): Promise<string | null> {
+  // Use the admin key to query the DB directly via a search for the entity
+  const { response, body } = await getJson(`/wiki/${entityId}`, adminApiKey);
+  if (response.status === 410) return "redirected";
+  if (response.status === 404) return "gone";
+  if (response.status !== 200) return null;
+  const entity = (body as any).entity;
+  return entity?.properties?.status ?? entity?.type ?? null;
+}
+
+describe("Draft worker", () => {
+  // Skip if no LLM configured — draft worker requires it
+  const hasLlm = !!process.env.OPENAI_API_KEY;
+
+  let actor: Awaited<ReturnType<typeof createActor>>;
+  let spaceId: string;
+
+  test("setup: create actor and space", async () => {
+    actor = await createActor(adminApiKey, {
+      maxReadLevel: 2,
+      maxWriteLevel: 2,
+    });
+    const space = await createSpace(actor.apiKey, uniqueName("draft-space"));
+    spaceId = space.id;
+  });
+
+  test("assign link creates placeholder and queues it", async () => {
+    const label = uniqueName("assign-test");
+    const { response, body } = await jsonRequest("/wiki", {
+      method: "POST",
+      apiKey: actor.apiKey,
+      json: {
+        content: `This wiki discusses [[assign:"${label}"|"A concept to be drafted by the background worker"]].`,
+        label: uniqueName("parent-wiki"),
+        keywords: ["draft test"],
+        short_description: "A wiki that assigns a concept for background drafting.",
+        space_id: spaceId,
+      },
+    });
+
+    expect(response.status).toBe(201);
+    const created = body as any;
+    expect(created.placeholders).toHaveLength(1);
+    expect(created.placeholders[0].status).toBe("assigned");
+
+    const phId = created.placeholders[0].id;
+
+    // Verify the placeholder entity exists
+    const { response: phRes, body: phBody } = await getJson(`/wiki/${phId}`, actor.apiKey);
+    expect(phRes.status).toBe(200);
+    expect((phBody as any).entity.type).toBe("placeholder");
+    expect((phBody as any).entity.properties.status).toBe("assigned");
+  });
+
+  test.skipIf(!hasLlm)("draft worker processes queued placeholder into a published wiki", async () => {
+    const subjectLabel = uniqueName("ATP-Synthase");
+    const parentLabel = uniqueName("Cellular-Respiration");
+
+    // Create a parent wiki with context that references the subject
+    const { response, body } = await jsonRequest("/wiki", {
+      method: "POST",
+      apiKey: actor.apiKey,
+      json: {
+        content: [
+          `Cellular respiration is the metabolic process by which cells convert nutrients into ATP.`,
+          ``,
+          `A key enzyme in this process is [[assign:"${subjectLabel}"|"Enzyme complex that synthesizes ATP from a proton gradient across the inner mitochondrial membrane"]].`,
+          ``,
+          `The process involves glycolysis, the citric acid cycle, and oxidative phosphorylation.`,
+        ].join("\n"),
+        label: parentLabel,
+        keywords: ["cellular respiration", "ATP", "metabolism"],
+        short_description: "The metabolic pathway that converts nutrients into usable cellular energy (ATP).",
+        space_id: spaceId,
+      },
+    });
+
+    expect(response.status).toBe(201);
+    const created = body as any;
+    const assigned = created.placeholders.find((p: any) => p.status === "assigned");
+    expect(assigned).toBeTruthy();
+    const placeholderId = assigned.id;
+
+    console.log(`[test] placeholder ${placeholderId} queued for "${subjectLabel}"`);
+    console.log(`[test] waiting for draft worker to process (up to 90s)...`);
+
+    // Wait for the draft worker to process it.
+    // The placeholder should either become a published wiki (via redirect to a new wiki)
+    // or remain as a placeholder with status changed.
+    // Check by polling the queue status or looking for a new wiki with the subject label.
+    let resultWikiId: string | null = null;
+
+    await waitFor(async () => {
+      // Check if placeholder was redirected (merged into a new wiki)
+      const { response: phRes } = await getJson(`/wiki/${placeholderId}`, actor.apiKey);
+      if (phRes.status === 410) {
+        // Redirected — the draft was published and placeholder merged
+        const phBody = await phRes.json().catch(() => null);
+        resultWikiId = (phBody as any)?.error?.details?.merged_into ?? null;
+        return true;
+      }
+
+      // Check if a wiki with the subject label now exists in the space
+      const { response: searchRes, body: searchBody } = await getJson(
+        `/wiki?filter=type:wiki&space_id=${spaceId}`,
+        actor.apiKey,
+      );
+      if (searchRes.status === 200) {
+        const wikis = (searchBody as any).entities ?? [];
+        const found = wikis.find((w: any) =>
+          w.properties?.label?.includes(subjectLabel) ||
+          w.properties?.label?.toLowerCase().includes("atp")
+        );
+        if (found) {
+          resultWikiId = found.id;
+          return true;
+        }
+      }
+
+      // Check if placeholder entity's properties.status changed from "assigned"
+      const { response: entRes, body: entBody } = await getJson(`/wiki/${placeholderId}`, actor.apiKey);
+      if (entRes.status === 200) {
+        const status = (entBody as any).entity?.properties?.status;
+        if (status === "undraftable") {
+          console.log(`[test] placeholder marked undraftable`);
+          return true; // processed, just not drafted
+        }
+      }
+
+      return false;
+    }, { timeoutMs: 90_000, intervalMs: 3_000 });
+
+    if (resultWikiId) {
+      console.log(`[test] draft published as wiki ${resultWikiId}`);
+
+      // Verify the drafted wiki has content
+      const { response: wikiRes, body: wikiBody } = await getJson(`/wiki/${resultWikiId}`, actor.apiKey);
+      expect(wikiRes.status).toBe(200);
+      const wiki = (wikiBody as any).entity;
+      expect(wiki.type).toBe("wiki");
+      expect(wiki.properties.status).toBe("published");
+      expect(wiki.properties.content).toBeTruthy();
+      expect(wiki.properties.content.length).toBeGreaterThan(50);
+      expect(wiki.properties.keywords).toBeTruthy();
+      expect(wiki.properties.short_description).toBeTruthy();
+
+      console.log(`[test] verified: "${wiki.properties.label}" (${wiki.properties.content.length} chars)`);
+    } else {
+      console.log(`[test] placeholder processed but no wiki published (may be undraftable)`);
+    }
+  }, 120_000);
+
+  test("reconcile redirects placeholder when wiki already exists", async () => {
+    const sharedLabel = uniqueName("Existing-Concept");
+
+    // First, create a published wiki with this label
+    await createWiki(actor.apiKey, sharedLabel, `This is the canonical wiki about ${sharedLabel}.`, {
+      keywords: [sharedLabel.toLowerCase(), "existing concept"],
+      short_description: `The canonical reference for ${sharedLabel} in this knowledge graph.`,
+      space_id: spaceId,
+    });
+
+    // Give Meilisearch a moment to index
+    await sleep(1000);
+
+    // Now create a parent wiki that assigns the same label
+    const { response, body } = await jsonRequest("/wiki", {
+      method: "POST",
+      apiKey: actor.apiKey,
+      json: {
+        content: `See also [[assign:"${sharedLabel}"|"A concept that already has a published wiki"]].`,
+        label: uniqueName("parent-reconcile"),
+        keywords: ["reconcile test"],
+        short_description: "Tests that the draft worker redirects rather than re-drafts.",
+        space_id: spaceId,
+      },
+    });
+
+    expect(response.status).toBe(201);
+    const assigned = (body as any).placeholders.find((p: any) => p.status === "assigned");
+    expect(assigned).toBeTruthy();
+
+    console.log(`[test] placeholder ${assigned.id} queued, expecting reconcile redirect...`);
+
+    // Wait for draft worker to process — should redirect quickly (no LLM drafting needed)
+    if (hasLlm) {
+      await waitFor(async () => {
+        const { response: phRes } = await getJson(`/wiki/${assigned.id}`, actor.apiKey);
+        if (phRes.status === 410) return true; // redirected
+
+        // Also check if placeholder status changed
+        if (phRes.status === 200) {
+          const entity = ((await phRes.json().catch(() => null)) as any)?.entity;
+          const status = entity?.properties?.status;
+          if (status && status !== "assigned") return true;
+        }
+        return false;
+      }, { timeoutMs: 60_000, intervalMs: 2_000 });
+
+      console.log(`[test] reconcile redirect completed`);
+    }
+  }, 90_000);
+});

--- a/packages/arkeon/test/e2e/draft-worker.test.ts
+++ b/packages/arkeon/test/e2e/draft-worker.test.ts
@@ -132,10 +132,9 @@ describe("Draft worker", () => {
 
     await waitFor(async () => {
       // Check if placeholder was redirected (merged into a new wiki)
-      const { response: phRes } = await getJson(`/wiki/${placeholderId}`, actor.apiKey);
+      const { response: phRes, body: phBody } = await getJson(`/wiki/${placeholderId}`, actor.apiKey);
       if (phRes.status === 410) {
         // Redirected — the draft was published and placeholder merged
-        const phBody = await phRes.json().catch(() => null);
         resultWikiId = (phBody as any)?.error?.details?.merged_into ?? null;
         return true;
       }

--- a/packages/arkeon/test/e2e/draft-worker.test.ts
+++ b/packages/arkeon/test/e2e/draft-worker.test.ts
@@ -44,8 +44,8 @@ async function getQueueStatus(entityId: string): Promise<string | null> {
   if (response.status === 410) return "redirected";
   if (response.status === 404) return "gone";
   if (response.status !== 200) return null;
-  const entity = (body as any).entity;
-  return entity?.properties?.status ?? entity?.type ?? null;
+  const wiki = (body as any).wiki;
+  return wiki?.properties?.status ?? wiki?.type ?? null;
 }
 
 describe("Draft worker", () => {
@@ -88,8 +88,8 @@ describe("Draft worker", () => {
     // Verify the placeholder entity exists
     const { response: phRes, body: phBody } = await getJson(`/wiki/${phId}`, actor.apiKey);
     expect(phRes.status).toBe(200);
-    expect((phBody as any).entity.type).toBe("placeholder");
-    expect((phBody as any).entity.properties.status).toBe("assigned");
+    expect((phBody as any).wiki.type).toBe("placeholder");
+    expect((phBody as any).wiki.properties.status).toBe("assigned");
   });
 
   test.skipIf(!hasLlm)("draft worker processes queued placeholder into a published wiki", async () => {
@@ -160,7 +160,7 @@ describe("Draft worker", () => {
       // Check if placeholder entity's properties.status changed from "assigned"
       const { response: entRes, body: entBody } = await getJson(`/wiki/${placeholderId}`, actor.apiKey);
       if (entRes.status === 200) {
-        const status = (entBody as any).entity?.properties?.status;
+        const status = (entBody as any).wiki?.properties?.status;
         if (status === "undraftable") {
           console.log(`[test] placeholder marked undraftable`);
           return true; // processed, just not drafted
@@ -176,7 +176,7 @@ describe("Draft worker", () => {
       // Verify the drafted wiki has content
       const { response: wikiRes, body: wikiBody } = await getJson(`/wiki/${resultWikiId}`, actor.apiKey);
       expect(wikiRes.status).toBe(200);
-      const wiki = (wikiBody as any).entity;
+      const wiki = (wikiBody as any).wiki;
       expect(wiki.type).toBe("wiki");
       expect(wiki.properties.status).toBe("published");
       expect(wiki.properties.content).toBeTruthy();
@@ -230,7 +230,7 @@ describe("Draft worker", () => {
 
         // Also check if placeholder status changed
         if (phRes.status === 200) {
-          const entity = ((await phRes.json().catch(() => null)) as any)?.entity;
+          const entity = ((await phRes.json().catch(() => null)) as any)?.wiki;
           const status = entity?.properties?.status;
           if (status && status !== "assigned") return true;
         }

--- a/packages/arkeon/test/e2e/draft-worker.test.ts
+++ b/packages/arkeon/test/e2e/draft-worker.test.ts
@@ -200,8 +200,8 @@ describe("Draft worker", () => {
       space_id: spaceId,
     });
 
-    // Give Meilisearch a moment to index
-    await sleep(1000);
+    // Give Meilisearch time to index the new wiki so reconcile can find it
+    await sleep(2000);
 
     // Now create a parent wiki that assigns the same label
     const { response, body } = await jsonRequest("/wiki", {
@@ -222,7 +222,9 @@ describe("Draft worker", () => {
 
     console.log(`[test] placeholder ${assigned.id} queued, expecting reconcile redirect...`);
 
-    // Wait for draft worker to process — should redirect quickly (no LLM drafting needed)
+    // Wait for draft worker to process — reconcile involves a Meilisearch
+    // lookup + LLM judge call. The worker processes items sequentially,
+    // so this may wait behind any items queued by earlier tests.
     if (hasLlm) {
       await waitFor(async () => {
         const { response: phRes } = await getJson(`/wiki/${assigned.id}`, actor.apiKey);
@@ -235,9 +237,9 @@ describe("Draft worker", () => {
           if (status && status !== "assigned") return true;
         }
         return false;
-      }, { timeoutMs: 60_000, intervalMs: 2_000 });
+      }, { timeoutMs: 120_000, intervalMs: 2_000 });
 
       console.log(`[test] reconcile redirect completed`);
     }
-  }, 90_000);
+  }, 150_000);
 });


### PR DESCRIPTION
## Summary

- **Recovers** the full draft-worker and extract-worker implementations from dangling commits (`9a60bb4`) in the arkeon repo — these were committed to the wrong repo and became orphaned
- **Replaces** the Phase 2 stub `draft-worker.ts` with the complete 4-step pipeline: reconcile → gather → draft → submit
- **Adds** `extract-worker.ts` — takes raw source documents, extracts 5-30 entities via LLM, queues placeholders for auto-drafting
- **Adds** schema migration `004-draft-extract-queues.sql` with audit columns and `source_extract_queue` table

## Files changed (7 files, +1997/-125)

| File | Change |
|------|--------|
| `workers/draft-worker.ts` | Replaced stub with full implementation |
| `workers/extract-worker.ts` | New — source document extraction pipeline |
| `workers/draft-gather.ts` | New — context dossier builder (deterministic + LLM agent loop) |
| `workers/draft-prompt.ts` | New — LLM prompt construction and response parsing |
| `worker-registry.ts` | Simplified to start/stop both workers |
| `004-draft-extract-queues.sql` | New migration — queue columns + extract queue table |
| `test/e2e/draft-worker.test.ts` | New — e2e tests for assign links + draft processing |

## Test plan

- [x] `npm run typecheck` — passes clean
- [x] `npm test` — 164/164 unit tests pass
- [x] `npm run build` — dist at 2.5MB (within 3MB budget)
- [ ] Manual: start stack with LLM configured, POST wiki with `[[assign:...]]` link, verify draft worker processes it
- [ ] Manual: verify extract worker processes source documents when queued

🤖 Generated with [Claude Code](https://claude.com/claude-code)