### PR TITLE
feat: separate file entities from wikis with /files router

### DIFF
--- a/packages/arkeon/spec/openapi.snapshot.json
+++ b/packages/arkeon/spec/openapi.snapshot.json
@@ -1984,6 +1984,592 @@
         ]
       }
     },
+    "/files": {
+      "get": {
+        "operationId": "listFiles",
+        "parameters": [
+          {
+            "description": "Column/property filters. See GET /help for filter syntax.",
+            "in": "query",
+            "name": "filter",
+            "required": false,
+            "schema": {
+              "description": "Column/property filters. See GET /help for filter syntax.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "updated_at | created_at (default: updated_at)",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "description": "updated_at | created_at (default: updated_at)",
+              "enum": [
+                "updated_at",
+                "created_at"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "asc | desc (default: desc)",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "description": "asc | desc (default: desc)",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Projection: full (all fields, no relationships) | summary (label + short_description) | expanded (all fields + _relationships).",
+            "in": "query",
+            "name": "view",
+            "required": false,
+            "schema": {
+              "description": "Projection: full (all fields, no relationships) | summary (label + short_description) | expanded (all fields + _relationships).",
+              "enum": [
+                "full",
+                "summary",
+                "expanded"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Comma-separated field list",
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "description": "Comma-separated field list",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max results (default 50, max 200)",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "description": "Max results (default 50, max 200)",
+              "maximum": 200,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Pagination cursor",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "description": "Pagination cursor",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Scope results to a space ULID",
+            "in": "query",
+            "name": "space_id",
+            "required": false,
+            "schema": {
+              "description": "Scope results to a space ULID",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "cursor": {
+                      "description": "Opaque pagination cursor",
+                      "example": "eyJ0Ijoi...",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "files": {
+                      "items": {
+                        "$ref": "#/components/schemas/Entity"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "files",
+                    "cursor"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Paginated file list"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          }
+        },
+        "summary": "List file entities with filtering, sorting, and cursor pagination",
+        "tags": [
+          "Files"
+        ],
+        "x-arke-auth": "optional",
+        "x-arke-related": [
+          "GET /files/{id}",
+          "GET /wiki"
+        ],
+        "x-arke-rules": [
+          "Only returns entities with type=file — wiki entities are excluded",
+          "Relationships (kind=relationship) are always excluded"
+        ]
+      },
+      "post": {
+        "operationId": "createFile",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "content": {
+                    "description": "Text content of the file. Binary files should describe themselves.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "file_type": {
+                    "description": "Normalized file extension: markdown, text, latex, pdf, etc.",
+                    "maxLength": 80,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "folder": {
+                    "description": "Organizational folder path (e.g. 'physics/quantum'). No leading/trailing slashes.",
+                    "maxLength": 500,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "label": {
+                    "description": "Display name for the file (typically the filename or relative path)",
+                    "maxLength": 200,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "properties": {
+                    "additionalProperties": {},
+                    "description": "Additional JSON properties to store on the file entity",
+                    "type": "object"
+                  },
+                  "source_file": {
+                    "description": "Relative filesystem path of the source file (for change detection)",
+                    "maxLength": 500,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "source_hash": {
+                    "description": "SHA256 hash of the source file content (for change detection)",
+                    "type": "string"
+                  },
+                  "space_id": {
+                    "description": "Space to create the file in. Optional — defaults to the only space the actor can contribute to.",
+                    "example": "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                    "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$/i",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "label",
+                  "content"
+                ],
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "file": {
+                      "$ref": "#/components/schemas/Entity"
+                    }
+                  },
+                  "required": [
+                    "file"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "File created and enqueued for extraction"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          }
+        },
+        "summary": "Upload a file to the knowledge graph for entity extraction",
+        "tags": [
+          "Files"
+        ],
+        "x-arke-auth": "required",
+        "x-arke-related": [
+          "GET /files",
+          "GET /files/{id}"
+        ],
+        "x-arke-rules": [
+          "Returns 409 if a file with the same label already exists in the space",
+          "If space_id is omitted, falls back to the only space the actor can contribute to; 400 if ambiguous or none",
+          "Content is stored as-is — no wiki link resolution",
+          "Automatically enqueued for entity extraction"
+        ]
+      }
+    },
+    "/files/{id}": {
+      "delete": {
+        "operationId": "deleteFile",
+        "parameters": [
+          {
+            "description": "Entity ULID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Entity ULID",
+              "example": "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+              "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$/i",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "File deleted"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          }
+        },
+        "summary": "Delete a file entity",
+        "tags": [
+          "Files"
+        ],
+        "x-arke-auth": "required",
+        "x-arke-rules": [
+          "Only the owner or an admin may delete"
+        ]
+      },
+      "get": {
+        "operationId": "getFile",
+        "parameters": [
+          {
+            "description": "Entity ULID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Entity ULID",
+              "example": "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+              "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$/i",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Projection: full (all fields, no relationships) | summary (label + short_description) | expanded (all fields + _relationships).",
+            "in": "query",
+            "name": "view",
+            "required": false,
+            "schema": {
+              "description": "Projection: full (all fields, no relationships) | summary (label + short_description) | expanded (all fields + _relationships).",
+              "enum": [
+                "full",
+                "summary",
+                "expanded"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Comma-separated field list",
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "description": "Comma-separated field list",
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "file": {
+                      "$ref": "#/components/schemas/Entity"
+                    }
+                  },
+                  "required": [
+                    "file"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "File entity"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          }
+        },
+        "summary": "Fetch a single file entity by ID",
+        "tags": [
+          "Files"
+        ],
+        "x-arke-auth": "optional",
+        "x-arke-related": [
+          "PUT /files/{id}",
+          "DELETE /files/{id}"
+        ],
+        "x-arke-rules": [
+          "Returns 404 if entity does not exist or is not a file"
+        ]
+      },
+      "put": {
+        "operationId": "updateFile",
+        "parameters": [
+          {
+            "description": "Entity ULID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Entity ULID",
+              "example": "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+              "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$/i",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "note": {
+                    "type": "string"
+                  },
+                  "properties": {
+                    "additionalProperties": {},
+                    "type": "object"
+                  },
+                  "remove_properties": {
+                    "description": "Property keys to delete",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "ver": {
+                    "description": "Expected current version (CAS token)",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "ver"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "file": {
+                      "$ref": "#/components/schemas/Entity"
+                    }
+                  },
+                  "required": [
+                    "file"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "File updated"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          }
+        },
+        "summary": "Update file properties (content, source_hash, etc.)",
+        "tags": [
+          "Files"
+        ],
+        "x-arke-auth": "required",
+        "x-arke-related": [
+          "GET /files/{id}"
+        ],
+        "x-arke-rules": [
+          "Only the owner or an admin may update",
+          "Optimistic concurrency: must pass current ver to update",
+          "Properties are shallow-merged: only provided keys are updated, omitted keys are preserved",
+          "Re-enqueues for extraction if content changes"
+        ]
+      }
+    },
     "/graph/data": {
       "get": {
         "description": "Returns lightweight node and edge data suitable for rendering large graphs.\nNodes include only id, label, type, and space memberships.\nEdges include only id, source_id, target_id, and predicate.\nFull entity details should be loaded on-demand via GET /wiki/{id}.",
@@ -4298,12 +4884,6 @@
                   },
                   "subject_type": {
                     "description": "Semantic subject type for the page, e.g. person, concept, book, event. Stored as properties.subject_type; the internal entity type remains wiki.",
-                    "maxLength": 80,
-                    "minLength": 1,
-                    "type": "string"
-                  },
-                  "type": {
-                    "description": "Deprecated alias for subject_type. Stored as properties.subject_type; the internal entity type remains wiki.",
                     "maxLength": 80,
                     "minLength": 1,
                     "type": "string"

--- a/packages/arkeon/src/cli/commands/repo/add.ts
+++ b/packages/arkeon/src/cli/commands/repo/add.ts
@@ -16,7 +16,7 @@
 import type { Command } from "commander";
 import { createHash } from "node:crypto";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { extname, join, relative } from "node:path";
+import { dirname, extname, join, relative } from "node:path";
 
 import { apiGet, apiPost, apiPut } from "../../lib/api-client.js";
 import { credentials } from "../../lib/credentials.js";
@@ -65,13 +65,8 @@ type ListResponse = {
   cursor: string | null;
 };
 
-type CreateWikiResponse = {
-  wiki: EntityResult;
-};
-
 const TEXT_EXTENSIONS = new Set([".md", ".txt", ".tex", ".rst", ".adoc", ".org"]);
-const DOCUMENT_FILTER = "properties.subject_type:document";
-const LEGACY_DOCUMENT_FILTER = "type:document";
+const FILE_FILTER = "type:file";
 
 function sha256(filePath: string): string {
   const content = readFileSync(filePath);
@@ -99,20 +94,13 @@ async function findExistingDoc(
   spaceId: string,
   sourceFile: string,
 ): Promise<{ entity_id: string; source_hash: string; ver: number } | null> {
-  const filters = [
-    `${DOCUMENT_FILTER},properties.source_file:${sourceFile}`,
-    `${LEGACY_DOCUMENT_FILTER},properties.source_file:${sourceFile}`,
-  ];
-  let entity: EntityResult | undefined;
-  for (const filter of filters) {
-    const resp = await apiGet<ListResponse>(
-      apiUrl,
-      `/wiki?filter=${encodeURIComponent(filter)}&space_id=${spaceId}&limit=1`,
-      apiKey,
-    );
-    entity = resp.entities[0];
-    if (entity) break;
-  }
+  const filter = `${FILE_FILTER},properties.source_file:${sourceFile}`;
+  const resp = await apiGet<{ files: EntityResult[]; cursor: string | null }>(
+    apiUrl,
+    `/files?filter=${encodeURIComponent(filter)}&space_id=${spaceId}&limit=1`,
+    apiKey,
+  );
+  const entity = resp.files[0];
   if (!entity) return null;
   return {
     entity_id: entity.id,
@@ -121,19 +109,11 @@ async function findExistingDoc(
   };
 }
 
-function keyword(value: string): string {
-  return value.slice(0, 100);
-}
-
-function documentShortDescription(relPath: string): string {
-  return `Document registered from ${relPath}`.slice(0, 400);
-}
-
 function documentLabel(relPath: string): string {
   return relPath.length <= 200 ? relPath : relPath.slice(-200);
 }
 
-async function createDocumentWiki(
+async function createDocumentFile(
   apiUrl: string,
   apiKey: string,
   spaceId: string,
@@ -142,20 +122,17 @@ async function createDocumentWiki(
   const label = documentLabel(file.relPath);
   const fileKind = fileType(file.ext);
   const content = file.content ?? `Binary ${fileKind} document registered from ${file.relPath}.`;
-  const created = await apiPost<CreateWikiResponse>(apiUrl, "/wiki", apiKey, {
+  const folder = dirname(file.relPath);
+  const created = await apiPost<{ file: EntityResult }>(apiUrl, "/files", apiKey, {
     label,
-    subject_type: "document",
-    keywords: [keyword(file.relPath), keyword(fileKind)],
-    short_description: documentShortDescription(file.relPath),
     content,
-    properties: {
-      source_file: file.relPath,
-      source_hash: file.hash,
-      file_type: fileKind,
-    },
+    source_file: file.relPath,
+    source_hash: file.hash,
+    file_type: fileKind,
+    ...(folder !== "." ? { folder } : {}),
     space_id: spaceId,
   });
-  return created.wiki;
+  return created.file;
 }
 
 export function registerAddCommand(program: Command): void {
@@ -304,7 +281,7 @@ export function registerAddCommand(program: Command): void {
 
         // --- Raw documents: create new ---
         for (const file of rawToCreate) {
-          const entity = await createDocumentWiki(state.api_url, apiKey, state.space_id, file);
+          const entity = await createDocumentFile(state.api_url, apiKey, state.space_id, file);
           documents.push({ path: file.relPath, entity_id: entity.id, action: "added" });
           output.progress(`  + ${file.relPath} -> ${entity.id}`);
           addedCount++;
@@ -320,7 +297,7 @@ export function registerAddCommand(program: Command): void {
             properties.content = file.content;
           }
 
-          await apiPut(state.api_url, `/wiki/${file.entity_id}`, apiKey, {
+          await apiPut(state.api_url, `/files/${file.entity_id}`, apiKey, {
             ver: file.ver,
             properties,
           });

--- a/packages/arkeon/src/cli/commands/repo/diff.ts
+++ b/packages/arkeon/src/cli/commands/repo/diff.ts
@@ -25,15 +25,14 @@ type EntityResult = {
   properties: Record<string, unknown>;
 };
 
-type ListResponse = {
-  entities: EntityResult[];
+type FileListResponse = {
+  files: EntityResult[];
   cursor: string | null;
 };
 
 const DEFAULT_EXTENSIONS = new Set([".md", ".txt", ".tex"]);
 const IGNORE_DIRS = new Set([".arkeon", ".git", "node_modules", ".claude"]);
 const IGNORE_FILES = new Set(["AGENTS.md"]);
-const DOCUMENT_FILTERS = ["properties.subject_type:document", "type:document"];
 
 function walkDir(dir: string, base: string, extensions: Set<string>): string[] {
   const results: string[] = [];
@@ -75,30 +74,27 @@ async function fetchDocumentEntities(
   const docs = new Map<string, { entity_id: string; source_hash: string }>();
   let cursor: string | null = null;
 
-  for (const filter of DOCUMENT_FILTERS) {
-    cursor = null;
-    for (;;) {
-      const cursorParam = cursor ? `&cursor=${encodeURIComponent(cursor)}` : "";
-      const resp: ListResponse = await apiGet<ListResponse>(
-        apiUrl,
-        `/wiki?filter=${encodeURIComponent(filter)}&space_id=${spaceId}&limit=200${cursorParam}`,
-        apiKey,
-      );
+  for (;;) {
+    const cursorParam: string = cursor ? `&cursor=${encodeURIComponent(cursor)}` : "";
+    const resp: FileListResponse = await apiGet<FileListResponse>(
+      apiUrl,
+      `/files?space_id=${spaceId}&limit=200${cursorParam}`,
+      apiKey,
+    );
 
-      for (const entity of resp.entities) {
-        const sourceFile = entity.properties?.source_file as string | undefined;
-        const sourceHash = entity.properties?.source_hash as string | undefined;
-        if (sourceFile) {
-          docs.set(sourceFile, {
-            entity_id: entity.id,
-            source_hash: sourceHash ?? "",
-          });
-        }
+    for (const entity of resp.files) {
+      const sourceFile = entity.properties?.source_file as string | undefined;
+      const sourceHash = entity.properties?.source_hash as string | undefined;
+      if (sourceFile) {
+        docs.set(sourceFile, {
+          entity_id: entity.id,
+          source_hash: sourceHash ?? "",
+        });
       }
-
-      cursor = resp.cursor;
-      if (!cursor) break;
     }
+
+    cursor = resp.cursor;
+    if (!cursor) break;
   }
 
   return docs;

--- a/packages/arkeon/src/cli/commands/repo/rm.ts
+++ b/packages/arkeon/src/cli/commands/repo/rm.ts
@@ -20,11 +20,6 @@ type EntityResult = {
   properties: Record<string, unknown>;
 };
 
-type ListResponse = {
-  entities: EntityResult[];
-  cursor: string | null;
-};
-
 type RelationshipResult = {
   id: string;
   source_id: string;
@@ -35,8 +30,7 @@ type RelationshipsResponse = {
   cursor: string | null;
 };
 
-const DOCUMENT_FILTER = "properties.subject_type:document";
-const LEGACY_DOCUMENT_FILTER = "type:document";
+const FILE_FILTER = "type:file";
 
 async function findDocBySourceFile(
   apiUrl: string,
@@ -44,20 +38,13 @@ async function findDocBySourceFile(
   spaceId: string,
   sourceFile: string,
 ): Promise<string | null> {
-  const filters = [
-    `${DOCUMENT_FILTER},properties.source_file:${sourceFile}`,
-    `${LEGACY_DOCUMENT_FILTER},properties.source_file:${sourceFile}`,
-  ];
-  for (const filter of filters) {
-    const resp = await apiGet<ListResponse>(
-      apiUrl,
-      `/wiki?filter=${encodeURIComponent(filter)}&space_id=${spaceId}&limit=1`,
-      apiKey,
-    );
-    const id = resp.entities[0]?.id;
-    if (id) return id;
-  }
-  return null;
+  const filter = `${FILE_FILTER},properties.source_file:${sourceFile}`;
+  const resp = await apiGet<{ files: EntityResult[]; cursor: string | null }>(
+    apiUrl,
+    `/files?filter=${encodeURIComponent(filter)}&space_id=${spaceId}&limit=1`,
+    apiKey,
+  );
+  return resp.files[0]?.id ?? null;
 }
 
 /**
@@ -113,7 +100,7 @@ async function deleteDocumentAndChildren(
     if (!cursor) break;
   }
 
-  await apiDelete(apiUrl, `/wiki/${entityId}`, apiKey);
+  await apiDelete(apiUrl, `/files/${entityId}`, apiKey);
   return { cascaded, preserved };
 }
 

--- a/packages/arkeon/src/generated/index.ts
+++ b/packages/arkeon/src/generated/index.ts
@@ -202,6 +202,71 @@ const OPERATIONS: GeneratedOperation[] = [
     bodyFields: [{ name: "properties", description: "", required: false, type: "object" }],
   },
   {
+    operationId: "createFile",
+    group: "files",
+    action: "create-file",
+    method: "POST",
+    path: "/files",
+    summary: "Upload a file to the knowledge graph for entity extraction",
+    description: "Upload a file to the knowledge graph for entity extraction",
+    auth: "required",
+    pathParams: [],
+    queryParams: [],
+    bodyFields: [{ name: "content", description: "Text content of the file. Binary files should describe themselves.", required: true, type: "string" }, { name: "file_type", description: "Normalized file extension: markdown, text, latex, pdf, etc.", required: false, type: "string" }, { name: "folder", description: "Organizational folder path (e.g. 'physics/quantum'). No leading/trailing slashes.", required: false, type: "string" }, { name: "label", description: "Display name for the file (typically the filename or relative path)", required: true, type: "string" }, { name: "properties", description: "Additional JSON properties to store on the file entity", required: false, type: "object" }, { name: "source_file", description: "Relative filesystem path of the source file (for change detection)", required: false, type: "string" }, { name: "source_hash", description: "SHA256 hash of the source file content (for change detection)", required: false, type: "string" }, { name: "space_id", description: "Space to create the file in. Optional — defaults to the only space the actor can contribute to.", required: false, type: "string" }],
+  },
+  {
+    operationId: "deleteFile",
+    group: "files",
+    action: "delete-file",
+    method: "DELETE",
+    path: "/files/{id}",
+    summary: "Delete a file entity",
+    description: "Delete a file entity",
+    auth: "required",
+    pathParams: [{ name: "id", description: "Entity ULID", required: true, type: "string" }],
+    queryParams: [],
+    bodyFields: [],
+  },
+  {
+    operationId: "getFile",
+    group: "files",
+    action: "file",
+    method: "GET",
+    path: "/files/{id}",
+    summary: "Fetch a single file entity by ID",
+    description: "Fetch a single file entity by ID",
+    auth: "optional",
+    pathParams: [{ name: "id", description: "Entity ULID", required: true, type: "string" }],
+    queryParams: [{ name: "view", description: "Projection: full (all fields, no relationships) | summary (label + short_description) | expanded (all fields + _relationships).", required: false, type: "string", enumValues: ["full","summary","expanded"] }, { name: "fields", description: "Comma-separated field list", required: false, type: "string" }],
+    bodyFields: [],
+  },
+  {
+    operationId: "listFiles",
+    group: "files",
+    action: "list-files",
+    method: "GET",
+    path: "/files",
+    summary: "List file entities with filtering, sorting, and cursor pagination",
+    description: "List file entities with filtering, sorting, and cursor pagination",
+    auth: "optional",
+    pathParams: [],
+    queryParams: [{ name: "filter", description: "Column/property filters. See GET /help for filter syntax.", required: false, type: "string" }, { name: "sort", description: "updated_at | created_at (default: updated_at)", required: false, type: "string", enumValues: ["updated_at","created_at"] }, { name: "order", description: "asc | desc (default: desc)", required: false, type: "string", enumValues: ["asc","desc"] }, { name: "view", description: "Projection: full (all fields, no relationships) | summary (label + short_description) | expanded (all fields + _relationships).", required: false, type: "string", enumValues: ["full","summary","expanded"] }, { name: "fields", description: "Comma-separated field list", required: false, type: "string" }, { name: "limit", description: "Max results (default 50, max 200)", required: false, type: "integer" }, { name: "cursor", description: "Pagination cursor", required: false, type: "string" }, { name: "space_id", description: "Scope results to a space ULID", required: false, type: "string" }],
+    bodyFields: [],
+  },
+  {
+    operationId: "updateFile",
+    group: "files",
+    action: "update-file",
+    method: "PUT",
+    path: "/files/{id}",
+    summary: "Update file properties (content, source_hash, etc.)",
+    description: "Update file properties (content, source_hash, etc.)",
+    auth: "required",
+    pathParams: [{ name: "id", description: "Entity ULID", required: true, type: "string" }],
+    queryParams: [],
+    bodyFields: [{ name: "note", description: "", required: false, type: "string" }, { name: "properties", description: "", required: false, type: "object" }, { name: "remove_properties", description: "Property keys to delete", required: false, type: "array" }, { name: "ver", description: "Expected current version (CAS token). Server increments ver on success.", required: true, type: "integer" }],
+  },
+  {
     operationId: "graphTraverse",
     group: "graph",
     action: "get",
@@ -446,7 +511,7 @@ const OPERATIONS: GeneratedOperation[] = [
     auth: "required",
     pathParams: [],
     queryParams: [],
-    bodyFields: [{ name: "aliases", description: "Alternate titles or spellings for this wiki page. Used for duplicate detection and search metadata.", required: false, type: "array" }, { name: "content", description: "Markdown body. Typed [[links]] in the content are parsed and turned into relationships when the wiki is published.\n\nFour link forms — all wrapped in double square brackets:\n  [[entity:ULID]]                         Hard reference to an existing visible entity.\n  [[resolve:\"Label\"|\"Description\"]]       Let the server find a match via Meilisearch + LLM judge. Soft-degrades to placeholder on miss or when no LLM is configured; never fails the request.\n  [[placeholder:\"Label\"|\"Description\"]]   Unwritten stub. Not queued. Leave it, or fill it in later.\n  [[assign:\"Label\"|\"Description\"]]        Hand off to the background drafter. Queued for auto-drafting.\n\nLabels must be double-quoted. Description is optional for resolve/placeholder/assign but recommended — it gives the resolver and future drafters context. Entity IDs are unquoted ULIDs.\n\nEvery parsed link materializes as a `references` relationship from the published wiki to the target (or to a newly-minted placeholder). The wiki page itself is the canonical graph entity for its subject.\n\nChoosing between resolve / placeholder / assign: use `resolve` when the thing probably already exists and you want the server to find it; use `placeholder` when you want a stub but don't want anything auto-drafted; use `assign` to hand off actual drafting to a background worker.\n\nAfter processing, the stored entity has two content fields: `properties.content` (resolved — all links rewritten to `[[entity:ULID]]`) and `properties.submitted_content` (the original input with unresolved link syntax preserved). The same applies when updating content via PUT.\n\nCaveat: the parser scans every `[[...]]` pair in the content, including inside fenced code blocks. To discuss link syntax in prose, use alternative delimiters (e.g. `<<entity:id>>`). See GET /help/guide/wiki for a worked example.", required: true, type: "string" }, { name: "depth", description: "Internal recursion depth — clients should not set this", required: false, type: "integer" }, { name: "keywords", description: "Alternate names and search phrasings someone might use to find this wiki", required: true, type: "array" }, { name: "label", description: "Canonical display name for the wiki (like an article title)", required: true, type: "string" }, { name: "properties", description: "Additional JSON properties to store on the wiki entity. Reserved wiki metadata keys from this request take precedence.", required: false, type: "object" }, { name: "short_description", description: "One to two sentences of framing, used in search previews and multi-choice disambiguation. Min 10 chars, max 400.", required: true, type: "string" }, { name: "space_id", description: "Space to create the wiki in. Optional — defaults to the only space the actor can contribute to. 400 if ambiguous (multiple candidates) or none.", required: false, type: "string" }, { name: "subject_type", description: "Semantic subject type for the page, e.g. person, concept, book, event. Stored as properties.subject_type; the internal entity type remains wiki.", required: false, type: "string" }, { name: "type", description: "Deprecated alias for subject_type. Stored as properties.subject_type; the internal entity type remains wiki.", required: false, type: "string" }],
+    bodyFields: [{ name: "aliases", description: "Alternate titles or spellings for this wiki page. Used for duplicate detection and search metadata.", required: false, type: "array" }, { name: "content", description: "Markdown body. Typed [[links]] in the content are parsed and turned into relationships when the wiki is published.\n\nFour link forms — all wrapped in double square brackets:\n  [[entity:ULID]]                         Hard reference to an existing visible entity.\n  [[resolve:\"Label\"|\"Description\"]]       Let the server find a match via Meilisearch + LLM judge. Soft-degrades to placeholder on miss or when no LLM is configured; never fails the request.\n  [[placeholder:\"Label\"|\"Description\"]]   Unwritten stub. Not queued. Leave it, or fill it in later.\n  [[assign:\"Label\"|\"Description\"]]        Hand off to the background drafter. Queued for auto-drafting.\n\nLabels must be double-quoted. Description is optional for resolve/placeholder/assign but recommended — it gives the resolver and future drafters context. Entity IDs are unquoted ULIDs.\n\nEvery parsed link materializes as a `references` relationship from the published wiki to the target (or to a newly-minted placeholder). The wiki page itself is the canonical graph entity for its subject.\n\nChoosing between resolve / placeholder / assign: use `resolve` when the thing probably already exists and you want the server to find it; use `placeholder` when you want a stub but don't want anything auto-drafted; use `assign` to hand off actual drafting to a background worker.\n\nAfter processing, the stored entity has two content fields: `properties.content` (resolved — all links rewritten to `[[entity:ULID]]`) and `properties.submitted_content` (the original input with unresolved link syntax preserved). The same applies when updating content via PUT.\n\nCaveat: the parser scans every `[[...]]` pair in the content, including inside fenced code blocks. To discuss link syntax in prose, use alternative delimiters (e.g. `<<entity:id>>`). See GET /help/guide/wiki for a worked example.", required: true, type: "string" }, { name: "depth", description: "Internal recursion depth — clients should not set this", required: false, type: "integer" }, { name: "keywords", description: "Alternate names and search phrasings someone might use to find this wiki", required: true, type: "array" }, { name: "label", description: "Canonical display name for the wiki (like an article title)", required: true, type: "string" }, { name: "properties", description: "Additional JSON properties to store on the wiki entity. Reserved wiki metadata keys from this request take precedence.", required: false, type: "object" }, { name: "short_description", description: "One to two sentences of framing, used in search previews and multi-choice disambiguation. Min 10 chars, max 400.", required: true, type: "string" }, { name: "space_id", description: "Space to create the wiki in. Optional — defaults to the only space the actor can contribute to. 400 if ambiguous (multiple candidates) or none.", required: false, type: "string" }, { name: "subject_type", description: "Semantic subject type for the page, e.g. person, concept, book, event. Stored as properties.subject_type; the internal entity type remains wiki.", required: false, type: "string" }],
   },
   {
     operationId: "deleteWiki",
@@ -555,7 +620,7 @@ const OPERATIONS: GeneratedOperation[] = [
 ];
 
 export function registerApiCommands(program: Command, options: { skipExisting?: boolean } = {}): void {
-  for (const group of ["actors","admin","auth","graph","relationships","resolve","search","spaces","wiki"]) {
+  for (const group of ["actors","admin","auth","files","graph","relationships","resolve","search","spaces","wiki"]) {
     const existing = program.commands.find((command) => command.name() === group);
     if (existing && options.skipExisting) {
       registerGeneratedGroup(existing, OPERATIONS.filter((operation) => operation.group === group));

--- a/packages/arkeon/src/schema/002-graph.sql
+++ b/packages/arkeon/src/schema/002-graph.sql
@@ -33,9 +33,10 @@ CREATE INDEX IF NOT EXISTS idx_entities_type_label_lower
   ON entities (type, lower(properties->>'label'))
   WHERE kind = 'entity' AND properties->>'label' IS NOT NULL;
 
--- Migrate legacy document wikis to type 'file'
+-- Migrate legacy document wikis to type 'file' (one-time, pre-2026-04-21)
 UPDATE entities SET type = 'file'
-  WHERE type = 'wiki' AND properties->>'subject_type' = 'document';
+  WHERE type = 'wiki' AND properties->>'subject_type' = 'document'
+    AND created_at < '2026-04-21T00:00:00Z'::timestamptz;
 
 -- Index for folder property queries
 CREATE INDEX IF NOT EXISTS idx_entities_folder

--- a/packages/arkeon/src/schema/002-graph.sql
+++ b/packages/arkeon/src/schema/002-graph.sql
@@ -33,6 +33,15 @@ CREATE INDEX IF NOT EXISTS idx_entities_type_label_lower
   ON entities (type, lower(properties->>'label'))
   WHERE kind = 'entity' AND properties->>'label' IS NOT NULL;
 
+-- Migrate legacy document wikis to type 'file'
+UPDATE entities SET type = 'file'
+  WHERE type = 'wiki' AND properties->>'subject_type' = 'document';
+
+-- Index for folder property queries
+CREATE INDEX IF NOT EXISTS idx_entities_folder
+  ON entities ((properties->>'folder'))
+  WHERE kind = 'entity' AND properties->>'folder' IS NOT NULL;
+
 GRANT SELECT, INSERT, UPDATE, DELETE ON entities TO arke_app;
 
 

--- a/packages/arkeon/src/server/app.ts
+++ b/packages/arkeon/src/server/app.ts
@@ -28,6 +28,7 @@ import { resolveRouter } from "./routes/resolve";
 import { graphRouter } from "./routes/traverse";
 import { searchRouter } from "./routes/search";
 import { spacesRouter } from "./routes/spaces";
+import { filesRouter } from "./routes/files";
 import { wikiRouter } from "./routes/wiki";
 
 export const openApiConfig = {
@@ -150,6 +151,7 @@ export function createApp(options?: { adminKey?: string }) {
   app.route("/wiki", wikisRouter);
   app.route("/wiki", wikiRelationshipsRouter);
   app.route("/wiki", wikiRouter);
+  app.route("/files", filesRouter);
 
   app.notFound((c) => {
     const requestId = c.get("requestId");

--- a/packages/arkeon/src/server/lib/meilisearch.ts
+++ b/packages/arkeon/src/server/lib/meilisearch.ts
@@ -123,7 +123,7 @@ export async function ensureMeiliIndex(): Promise<void> {
   }
   await c.index(ENTITIES_INDEX).updateSettings({
     searchableAttributes: ["*"],
-    filterableAttributes: ["type", "kind", "owner_id", "space_ids"],
+    filterableAttributes: ["type", "kind", "owner_id", "space_ids", "folder"],
     sortableAttributes: ["updated_at", "created_at"],
   });
 }

--- a/packages/arkeon/src/server/routes/entities.ts
+++ b/packages/arkeon/src/server/routes/entities.ts
@@ -474,7 +474,7 @@ wikisRouter.openapi(listEntitiesRoute, async (c) => {
   const sort = parseSort(c.req.query("sort"), ["updated_at", "created_at"], "updated_at");
 
   const userFilter = c.req.query("filter");
-  const filter = mergeFilters("kind!:relationship", userFilter);
+  const filter = mergeFilters("kind!:relationship,type!:file", userFilter);
 
   const spaceId = c.req.query("space_id");
   const listing = buildEntityListingQuery({ filter, limit, cursor, sort, order, spaceId });
@@ -806,8 +806,8 @@ wikisRouter.openapi(bulkDeleteEntitiesRoute, async (c) => {
     throw new ApiError(400, "invalid_query", "At least one of filter or space_id is required");
   }
 
-  // Always exclude relationships — use dedicated relationship endpoints
-  const filter = mergeFilters("kind!:relationship", userFilter);
+  // Always exclude relationships and files — use dedicated endpoints
+  const filter = mergeFilters("kind!:relationship,type!:file", userFilter);
 
   const { whereSql, params } = buildEntityFilterWhere({ filter, spaceId });
 

--- a/packages/arkeon/src/server/routes/entities.ts
+++ b/packages/arkeon/src/server/routes/entities.ts
@@ -504,7 +504,7 @@ wikisRouter.openapi(getEntityRoute, async (c) => {
     ...setActorContext(sql, actor),
     sql`SELECT e.*,
       (SELECT COALESCE(array_agg(se.space_id), '{}') FROM space_entities se WHERE se.entity_id = e.id) AS space_ids
-      FROM entities e WHERE e.id = ${entityId} LIMIT 1`,
+      FROM entities e WHERE e.id = ${entityId} AND e.type != 'file' LIMIT 1`,
   ]);
 
   const entity = (results[results.length - 1] as EntityRecord[])[0];
@@ -783,7 +783,7 @@ wikisRouter.openapi(deleteEntityRoute, async (c) => {
   // Actor context set for ownership checks
   const results = await sql.transaction([
     ...setActorContext(sql, actor),
-    sql`DELETE FROM entities WHERE id = ${entityId} RETURNING id`,
+    sql`DELETE FROM entities WHERE id = ${entityId} AND type != 'file' RETURNING id`,
   ]);
 
   if ((results[results.length - 1] as Array<{ id: string }>).length === 0) {

--- a/packages/arkeon/src/server/routes/files.ts
+++ b/packages/arkeon/src/server/routes/files.ts
@@ -1,0 +1,536 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * /files — CRUD for file entities (documents uploaded via `arkeon add`).
+ *
+ * Files are source material that feeds the extraction pipeline. They skip
+ * the wiki link pipeline entirely — content is stored as-is, and new files
+ * are automatically enqueued for entity extraction.
+ */
+
+import { createRoute, z } from "@hono/zod-openapi";
+import postgres from "postgres";
+
+import { requireActor, parseCursorParam, parseJsonBody, parseLimit } from "../lib/http";
+import { fetchSpaceForActor, resolveDefaultSpace } from "../lib/spaces";
+import { ApiError } from "../lib/errors";
+import { generateUlid } from "../lib/ids";
+import { createRouter } from "../lib/openapi";
+import { createSql, withTransaction } from "../lib/sql";
+import { setActorContext, withSystemActorContext } from "../lib/actor-context";
+import { indexEntity, indexEntityById, removeEntity } from "../lib/meilisearch";
+import { backgroundTask } from "../lib/background";
+import { encodeCursor } from "../lib/cursor";
+import { parseProjection, projectEntity } from "../lib/entity-projection";
+import { buildEntityListingQuery, mergeFilters, parseOrder, parseSort } from "../lib/listing";
+import type { EntityRecord } from "../lib/entities";
+import {
+  EntityIdParam,
+  EntitySchema,
+  ProjectionQuery,
+  errorResponses,
+  filterQuerySchema,
+  jsonContent,
+  paginationQuerySchema,
+  entityIdParams,
+  queryParam,
+  cursorResponseSchema,
+} from "../lib/schemas";
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+const createFileRoute = createRoute({
+  method: "post",
+  path: "/",
+  operationId: "createFile",
+  tags: ["Files"],
+  summary: "Upload a file to the knowledge graph for entity extraction",
+  "x-arke-auth": "required",
+  "x-arke-related": ["GET /files", "GET /files/{id}"],
+  "x-arke-rules": [
+    "Returns 409 if a file with the same label already exists in the space",
+    "If space_id is omitted, falls back to the only space the actor can contribute to; 400 if ambiguous or none",
+    "Content is stored as-is — no wiki link resolution",
+    "Automatically enqueued for entity extraction",
+  ],
+  request: {
+    body: {
+      content: jsonContent(
+        z.object({
+          label: z
+            .string()
+            .min(1)
+            .max(200)
+            .describe("Display name for the file (typically the filename or relative path)"),
+          content: z
+            .string()
+            .min(1)
+            .describe("Text content of the file. Binary files should describe themselves."),
+          source_file: z
+            .string()
+            .min(1)
+            .max(500)
+            .optional()
+            .describe("Relative filesystem path of the source file (for change detection)"),
+          source_hash: z
+            .string()
+            .optional()
+            .describe("SHA256 hash of the source file content (for change detection)"),
+          file_type: z
+            .string()
+            .min(1)
+            .max(80)
+            .optional()
+            .describe("Normalized file extension: markdown, text, latex, pdf, etc."),
+          folder: z
+            .string()
+            .min(1)
+            .max(500)
+            .optional()
+            .describe("Organizational folder path (e.g. 'physics/quantum'). No leading/trailing slashes."),
+          properties: z
+            .record(z.string(), z.any())
+            .optional()
+            .describe("Additional JSON properties to store on the file entity"),
+          space_id: EntityIdParam
+            .optional()
+            .describe("Space to create the file in. Optional — defaults to the only space the actor can contribute to."),
+        }),
+      ),
+    },
+  },
+  responses: {
+    201: {
+      description: "File created and enqueued for extraction",
+      content: jsonContent(z.object({ file: EntitySchema })),
+    },
+    ...errorResponses([400, 401, 403, 409]),
+  },
+});
+
+const listFilesRoute = createRoute({
+  method: "get",
+  path: "/",
+  operationId: "listFiles",
+  tags: ["Files"],
+  summary: "List file entities with filtering, sorting, and cursor pagination",
+  "x-arke-auth": "optional",
+  "x-arke-related": ["GET /files/{id}", "GET /wiki"],
+  "x-arke-rules": [
+    "Only returns entities with type=file — wiki entities are excluded",
+    "Relationships (kind=relationship) are always excluded",
+  ],
+  request: {
+    query: filterQuerySchema(["updated_at", "created_at"], "updated_at")
+      .merge(ProjectionQuery)
+      .merge(paginationQuerySchema(50, 200))
+      .merge(z.object({
+        space_id: queryParam("space_id", z.string().optional(), "Scope results to a space ULID"),
+      })),
+  },
+  responses: {
+    200: {
+      description: "Paginated file list",
+      content: jsonContent(cursorResponseSchema("files", EntitySchema)),
+    },
+    ...errorResponses([400, 403]),
+  },
+});
+
+const getFileRoute = createRoute({
+  method: "get",
+  path: "/{id}",
+  operationId: "getFile",
+  tags: ["Files"],
+  summary: "Fetch a single file entity by ID",
+  "x-arke-auth": "optional",
+  "x-arke-related": ["PUT /files/{id}", "DELETE /files/{id}"],
+  "x-arke-rules": ["Returns 404 if entity does not exist or is not a file"],
+  request: {
+    params: entityIdParams(),
+    query: ProjectionQuery,
+  },
+  responses: {
+    200: {
+      description: "File entity",
+      content: jsonContent(z.object({ file: EntitySchema })),
+    },
+    ...errorResponses([404]),
+  },
+});
+
+const updateFileRoute = createRoute({
+  method: "put",
+  path: "/{id}",
+  operationId: "updateFile",
+  tags: ["Files"],
+  summary: "Update file properties (content, source_hash, etc.)",
+  "x-arke-auth": "required",
+  "x-arke-related": ["GET /files/{id}"],
+  "x-arke-rules": [
+    "Only the owner or an admin may update",
+    "Optimistic concurrency: must pass current ver to update",
+    "Properties are shallow-merged: only provided keys are updated, omitted keys are preserved",
+    "Re-enqueues for extraction if content changes",
+  ],
+  request: {
+    params: entityIdParams(),
+    body: {
+      required: true,
+      content: jsonContent(
+        z.object({
+          ver: z.number().int().describe("Expected current version (CAS token)"),
+          properties: z.record(z.string(), z.any()).optional(),
+          remove_properties: z
+            .array(z.string())
+            .optional()
+            .describe("Property keys to delete"),
+          note: z.string().optional(),
+        }),
+      ),
+    },
+  },
+  responses: {
+    200: {
+      description: "File updated",
+      content: jsonContent(z.object({ file: EntitySchema })),
+    },
+    ...errorResponses([400, 401, 403, 404, 409]),
+  },
+});
+
+const deleteFileRoute = createRoute({
+  method: "delete",
+  path: "/{id}",
+  operationId: "deleteFile",
+  tags: ["Files"],
+  summary: "Delete a file entity",
+  "x-arke-auth": "required",
+  "x-arke-rules": ["Only the owner or an admin may delete"],
+  request: { params: entityIdParams() },
+  responses: {
+    204: { description: "File deleted" },
+    ...errorResponses([401, 403, 404]),
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+export const filesRouter = createRouter();
+
+filesRouter.openapi(createFileRoute, async (c) => {
+  const actor = requireActor(c);
+  const body = await parseJsonBody<Record<string, unknown>>(c);
+
+  const label = typeof body.label === "string" ? body.label.trim() : "";
+  const content = typeof body.content === "string" ? body.content : "";
+  if (!label) throw new ApiError(400, "missing_required_field", "Missing label");
+  if (!content) throw new ApiError(400, "missing_required_field", "Missing content");
+
+  const source_file = typeof body.source_file === "string" ? body.source_file : undefined;
+  const source_hash = typeof body.source_hash === "string" ? body.source_hash : undefined;
+  const file_type = typeof body.file_type === "string" ? body.file_type : undefined;
+  const folder = typeof body.folder === "string" && body.folder.trim().length > 0 ? body.folder.trim() : undefined;
+  const space_id_input = typeof body.space_id === "string" ? body.space_id : undefined;
+  const extraProperties =
+    typeof body.properties === "object" && body.properties !== null && !Array.isArray(body.properties)
+      ? (body.properties as Record<string, unknown>)
+      : {};
+
+  const space_id = space_id_input?.trim()
+    ? space_id_input
+    : await resolveDefaultSpace(actor);
+
+  const targetSpace = await fetchSpaceForActor(actor, space_id);
+  if (!targetSpace) {
+    throw new ApiError(404, "not_found", "Space not found");
+  }
+
+  const fileId = generateUlid();
+  const now = new Date().toISOString();
+
+  const fileProperties: Record<string, unknown> = {
+    ...extraProperties,
+    label,
+    subject_type: "document",
+    content,
+    status: "published",
+    ...(source_file ? { source_file } : {}),
+    ...(source_hash ? { source_hash } : {}),
+    ...(file_type ? { file_type } : {}),
+    ...(folder ? { folder } : {}),
+  };
+
+  // Check for existing file with same label in space
+  const publishedFile = await withTransaction(async (tx) => {
+    for (const q of setActorContext(tx, actor)) await q;
+
+    const existing = await tx`
+      SELECT e.id FROM entities e
+      JOIN space_entities se ON se.entity_id = e.id
+      WHERE se.space_id = ${space_id}
+        AND e.type = 'file'
+        AND e.kind = 'entity'
+        AND lower(e.properties->>'label') = lower(${label})
+      LIMIT 1
+    `;
+    if (existing.length > 0) {
+      throw new ApiError(409, "file_exists", "A file with this label already exists in the space", {
+        existing_file_id: String(existing[0].id),
+      });
+    }
+
+    await tx`
+      INSERT INTO entities (
+        id, kind, type, ver, properties, owner_id,
+        edited_by, note, created_at, updated_at
+      ) VALUES (
+        ${fileId}, 'entity', 'file', 1, ${fileProperties}::jsonb, ${actor.id},
+        ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
+      )
+    `;
+
+    await tx`
+      INSERT INTO entity_versions (entity_id, ver, properties, edited_by, note, created_at)
+      VALUES (${fileId}, 1, ${fileProperties}::jsonb, ${actor.id}, NULL, ${now}::timestamptz)
+    `;
+
+    await tx`
+      INSERT INTO space_entities (space_id, entity_id, added_by, added_at)
+      VALUES (${space_id}, ${fileId}, ${actor.id}, ${now}::timestamptz)
+      ON CONFLICT (space_id, entity_id) DO NOTHING
+    `;
+
+    const [row] = await tx`SELECT * FROM entities WHERE id = ${fileId}`;
+    return row;
+  });
+
+  backgroundTask(indexEntity(publishedFile as Record<string, unknown>));
+
+  // Enqueue for entity extraction
+  backgroundTask(
+    withSystemActorContext(async (sql) => {
+      await sql`
+        INSERT INTO source_extract_queue (entity_id, owner_agent, status, created_at)
+        VALUES (${fileId}, ${actor.id}, 'pending', NOW())
+        ON CONFLICT (entity_id) DO NOTHING
+      `;
+    }).catch((err) => {
+      console.warn(`[files] failed to enqueue ${fileId} for extraction:`, (err as Error).message);
+    }),
+  );
+
+  return c.json({ file: publishedFile }, 201);
+});
+
+filesRouter.openapi(listFilesRoute, async (c) => {
+  const sql = createSql();
+  const actorCtx = c.get("actor");
+  const limit = parseLimit(c, { defaultValue: 50, maxValue: 200 });
+  const projection = parseProjection(c.req.query("view"), c.req.query("fields"));
+  const cursor = parseCursorParam(c);
+  const order = parseOrder(c.req.query("order"));
+  const sort = parseSort(c.req.query("sort"), ["updated_at", "created_at"], "updated_at");
+
+  const userFilter = c.req.query("filter");
+  const filter = mergeFilters("kind!:relationship,type:file", userFilter);
+
+  const spaceId = c.req.query("space_id");
+  const listing = buildEntityListingQuery({ filter, limit, cursor, sort, order, spaceId });
+
+  const txResults = await sql.transaction([
+    ...setActorContext(sql, actorCtx),
+    sql.query(listing.query, listing.params),
+  ]);
+  const rows = txResults[txResults.length - 1] as Array<Record<string, unknown>>;
+  const entities = rows.slice(0, limit);
+  const next = rows.length > limit ? entities[entities.length - 1] : null;
+
+  return c.json({
+    files: entities.map((row) => projectEntity(row, projection)),
+    cursor: next ? encodeCursor({ t: (next[sort] ?? next.updated_at) as string | Date, i: String(next.id) }) : null,
+  }, 200);
+});
+
+filesRouter.openapi(getFileRoute, async (c) => {
+  const actor = c.get("actor");
+  const projection = parseProjection(c.req.query("view"), c.req.query("fields"));
+  const entityId = c.req.param("id");
+  const sql = createSql();
+
+  const results = await sql.transaction([
+    ...setActorContext(sql, actor),
+    sql`SELECT * FROM entities WHERE id = ${entityId} AND type = 'file' LIMIT 1`,
+  ]);
+
+  const entity = (results[results.length - 1] as EntityRecord[])[0];
+  if (!entity) {
+    throw new ApiError(404, "not_found", "File not found");
+  }
+
+  return c.json({ file: projectEntity(entity, projection) }, 200);
+});
+
+filesRouter.openapi(updateFileRoute, async (c) => {
+  const actor = requireActor(c);
+  const entityId = c.req.param("id");
+  const body = await parseJsonBody<Record<string, unknown>>(c);
+  const expectedVer = typeof body.ver === "number" ? body.ver : null;
+  if (expectedVer === null) {
+    throw new ApiError(400, "missing_required_field", "Missing ver");
+  }
+
+  const properties = body.properties === undefined
+    ? undefined
+    : (typeof body.properties === "object" && body.properties !== null && !Array.isArray(body.properties)
+      ? (body.properties as Record<string, unknown>)
+      : (() => { throw new ApiError(400, "invalid_request", "properties must be an object"); })());
+  const removeProperties = Array.isArray(body.remove_properties)
+    ? (body.remove_properties as string[]).filter((k) => typeof k === "string" && k.length > 0)
+    : [];
+  const note = body.note === undefined ? null : typeof body.note === "string" ? body.note : null;
+
+  if (!properties && removeProperties.length === 0) {
+    throw new ApiError(400, "invalid_body", "No changes requested");
+  }
+
+  const sql = createSql();
+  const now = new Date().toISOString();
+
+  // Detect if content changed (for re-extraction)
+  const hasContentUpdate = typeof properties?.content === "string" && (properties.content as string).length > 0;
+
+  // Build dynamic property expression
+  const hasMerge = properties && Object.keys(properties).length > 0;
+  const hasRemove = removeProperties.length > 0;
+  let propsExpr: string;
+  const params: unknown[] = [];
+  let paramIdx = 1;
+
+  if (hasMerge && hasRemove) {
+    propsExpr = `(properties || $${paramIdx}::jsonb) - $${paramIdx + 1}::text[]`;
+    params.push(JSON.stringify(properties), removeProperties);
+    paramIdx += 2;
+  } else if (hasMerge) {
+    propsExpr = `properties || $${paramIdx}::jsonb`;
+    params.push(JSON.stringify(properties));
+    paramIdx += 1;
+  } else {
+    propsExpr = `properties - $${paramIdx}::text[]`;
+    params.push(removeProperties);
+    paramIdx += 1;
+  }
+
+  const editedByIdx = paramIdx;
+  const noteIdx = paramIdx + 1;
+  const nowIdx = paramIdx + 2;
+  const idIdx = paramIdx + 3;
+  const verIdx = paramIdx + 4;
+  params.push(actor.id, note, now, entityId, expectedVer);
+
+  let results;
+  try {
+    results = await sql.transaction([
+      ...setActorContext(sql, actor),
+      sql.query(
+        `UPDATE entities
+         SET properties = ${propsExpr},
+             ver = ver + 1,
+             edited_by = $${editedByIdx},
+             note = $${noteIdx},
+             updated_at = $${nowIdx}::timestamptz
+         WHERE id = $${idIdx} AND ver = $${verIdx} AND type = 'file'
+         RETURNING *`,
+        params,
+      ),
+    ]);
+  } catch (err) {
+    if (err instanceof postgres.PostgresError && err.code === "42501") {
+      // RLS denial may mask CAS conflict — check version
+      const check = await sql.transaction([
+        ...setActorContext(sql, actor),
+        sql`SELECT ver FROM entities WHERE id = ${entityId} AND type = 'file' LIMIT 1`,
+      ]);
+      const fresh = (check[check.length - 1] as Array<{ ver: number }>)[0];
+      if (!fresh) throw new ApiError(404, "not_found", "File not found");
+      if (fresh.ver !== expectedVer) {
+        throw new ApiError(409, "cas_conflict", "Version mismatch", {
+          entity_id: entityId,
+          expected_ver: expectedVer,
+        });
+      }
+    }
+    throw err;
+  }
+
+  const updated = (results[results.length - 1] as EntityRecord[])[0];
+  if (!updated) {
+    const check = await sql.transaction([
+      ...setActorContext(sql, actor),
+      sql`SELECT ver FROM entities WHERE id = ${entityId} AND type = 'file' LIMIT 1`,
+    ]);
+    const fresh = (check[check.length - 1] as Array<{ ver: number }>)[0];
+    if (!fresh) throw new ApiError(404, "not_found", "File not found");
+    if (fresh.ver !== expectedVer) {
+      throw new ApiError(409, "cas_conflict", "Version mismatch", {
+        entity_id: entityId,
+        expected_ver: expectedVer,
+      });
+    }
+    throw new ApiError(403, "forbidden", "You do not have write access on this file");
+  }
+
+  // Version snapshot
+  backgroundTask(
+    sql.transaction([
+      ...setActorContext(sql, actor),
+      sql.query(
+        `INSERT INTO entity_versions (entity_id, ver, properties, edited_by, note, created_at)
+         VALUES ($1, $2, $3::jsonb, $4, $5, $6::timestamptz)`,
+        [entityId, updated.ver, JSON.stringify(updated.properties), actor.id, note, now],
+      ),
+    ]).then(() => undefined).catch(console.error),
+  );
+  backgroundTask(indexEntity(updated));
+
+  // Re-enqueue for extraction if content changed
+  if (hasContentUpdate) {
+    backgroundTask(
+      withSystemActorContext(async (sysSql) => {
+        await sysSql`
+          INSERT INTO source_extract_queue (entity_id, owner_agent, status, created_at)
+          VALUES (${entityId}, ${actor.id}, 'pending', NOW())
+          ON CONFLICT (entity_id) DO UPDATE SET status = 'pending', created_at = NOW()
+        `;
+      }).catch((err) => {
+        console.warn(`[files] failed to re-enqueue ${entityId} for extraction:`, (err as Error).message);
+      }),
+    );
+  }
+
+  return c.json({ file: updated }, 200);
+});
+
+filesRouter.openapi(deleteFileRoute, async (c) => {
+  const actor = requireActor(c);
+  const entityId = c.req.param("id");
+  const sql = createSql();
+
+  const results = await sql.transaction([
+    ...setActorContext(sql, actor),
+    sql`DELETE FROM entities WHERE id = ${entityId} AND type = 'file' RETURNING id`,
+  ]);
+
+  if ((results[results.length - 1] as Array<{ id: string }>).length === 0) {
+    throw new ApiError(404, "not_found", "File not found");
+  }
+
+  backgroundTask(removeEntity(entityId));
+
+  return new Response(null, { status: 204 });
+});

--- a/packages/arkeon/src/server/routes/files.ts
+++ b/packages/arkeon/src/server/routes/files.ts
@@ -19,7 +19,7 @@ import { generateUlid } from "../lib/ids";
 import { createRouter } from "../lib/openapi";
 import { createSql, withTransaction } from "../lib/sql";
 import { setActorContext, withSystemActorContext } from "../lib/actor-context";
-import { indexEntity, indexEntityById, removeEntity } from "../lib/meilisearch";
+import { indexEntity, removeEntity } from "../lib/meilisearch";
 import { backgroundTask } from "../lib/background";
 import { encodeCursor } from "../lib/cursor";
 import { parseProjection, projectEntity } from "../lib/entity-projection";
@@ -37,6 +37,18 @@ import {
   queryParam,
   cursorResponseSchema,
 } from "../lib/schemas";
+
+/** Strip reserved file property keys from caller-supplied properties bag. */
+const FILE_RESERVED_KEYS = new Set([
+  "label", "subject_type", "content", "status",
+  "source_file", "source_hash", "file_type", "folder",
+]);
+
+function sanitizeFileProperties(properties: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(properties).filter(([key]) => !FILE_RESERVED_KEYS.has(key)),
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Route definitions
@@ -237,10 +249,11 @@ filesRouter.openapi(createFileRoute, async (c) => {
   const file_type = typeof body.file_type === "string" ? body.file_type : undefined;
   const folder = typeof body.folder === "string" && body.folder.trim().length > 0 ? body.folder.trim() : undefined;
   const space_id_input = typeof body.space_id === "string" ? body.space_id : undefined;
-  const extraProperties =
+  const extraProperties = sanitizeFileProperties(
     typeof body.properties === "object" && body.properties !== null && !Array.isArray(body.properties)
       ? (body.properties as Record<string, unknown>)
-      : {};
+      : {},
+  );
 
   const space_id = space_id_input?.trim()
     ? space_id_input

--- a/packages/arkeon/src/server/routes/wiki.ts
+++ b/packages/arkeon/src/server/routes/wiki.ts
@@ -19,7 +19,7 @@ import { ApiError } from "../lib/errors";
 import { generateUlid } from "../lib/ids";
 import { createRouter } from "../lib/openapi";
 import { withTransaction } from "../lib/sql";
-import { setActorContext, withSystemActorContext } from "../lib/actor-context";
+import { setActorContext } from "../lib/actor-context";
 import { indexEntity } from "../lib/meilisearch";
 import { backgroundTask } from "../lib/background";
 import {
@@ -91,12 +91,6 @@ const createWikiRoute = createRoute({
             .min(10)
             .max(400)
             .describe("One to two sentences of framing, used in search previews and multi-choice disambiguation. Min 10 chars, max 400."),
-          type: z
-            .string()
-            .min(1)
-            .max(80)
-            .optional()
-            .describe("Deprecated alias for subject_type. Stored as properties.subject_type; the internal entity type remains wiki."),
           subject_type: z
             .string()
             .min(1)
@@ -173,9 +167,7 @@ wikiRouter.openapi(createWikiRoute, async (c) => {
   const short_description = body.short_description as string;
   const subject_type = typeof body.subject_type === "string"
     ? body.subject_type.trim()
-    : typeof body.type === "string"
-      ? body.type.trim()
-      : undefined;
+    : undefined;
   const aliasesRaw = body.aliases;
   const extraPropertiesRaw = body.properties;
   const space_id_input = body.space_id;
@@ -193,9 +185,6 @@ wikiRouter.openapi(createWikiRoute, async (c) => {
   const keywords = (keywordsRaw as string[]).map((k) => k.trim());
   if (!short_description || typeof short_description !== "string" || short_description.trim().length < 10) {
     throw new ApiError(400, "invalid_request", "short_description is required and must be at least 10 characters");
-  }
-  if (body.type !== undefined && (!subject_type || typeof body.type !== "string")) {
-    throw new ApiError(400, "invalid_request", "type must be a non-empty string when provided");
   }
   if (body.subject_type !== undefined && (!subject_type || typeof body.subject_type !== "string")) {
     throw new ApiError(400, "invalid_request", "subject_type must be a non-empty string when provided");
@@ -365,24 +354,6 @@ wikiRouter.openapi(createWikiRoute, async (c) => {
 
   // Index in Meilisearch (background)
   backgroundTask(indexEntity(publishedWiki as Record<string, unknown>));
-
-  // Auto-enqueue document wikis for entity extraction. When `arkeon add`
-  // pushes a raw document, it arrives here with subject_type "document".
-  // The extract worker will read the content, identify notable subjects,
-  // and queue placeholder entities for auto-drafting.
-  if (subject_type === "document") {
-    backgroundTask(
-      withSystemActorContext(async (sql) => {
-        await sql`
-          INSERT INTO source_extract_queue (entity_id, owner_agent, status, created_at)
-          VALUES (${wikiId}, ${actor.id}, 'pending', NOW())
-          ON CONFLICT (entity_id) DO NOTHING
-        `;
-      }).catch((err) => {
-        console.warn(`[wiki] failed to enqueue ${wikiId} for extraction:`, (err as Error).message);
-      }),
-    );
-  }
 
   return c.json(
     {

--- a/packages/arkeon/test/e2e/cli.test.ts
+++ b/packages/arkeon/test/e2e/cli.test.ts
@@ -117,7 +117,7 @@ describe("CLI integration — generated API commands", () => {
     cliSpaceId = space.id;
 
     const result = arkeon(
-      `wiki create --label "CLI Smoke Test Person" --short-description "A test person entity" --keywords '["test"]' --content "A person for CLI smoke testing." --type person --space-id ${cliSpaceId}`,
+      `wiki create --label "CLI Smoke Test Person" --short-description "A test person entity" --keywords '["test"]' --content "A person for CLI smoke testing." --subject-type person --space-id ${cliSpaceId}`,
     );
     expect(result.ok).toBe(true);
 

--- a/packages/arkeon/test/e2e/repo-commands.test.ts
+++ b/packages/arkeon/test/e2e/repo-commands.test.ts
@@ -58,6 +58,25 @@ type ListResponse = {
   cursor: string | null;
 };
 
+type FileResponse = {
+  file: {
+    id: string;
+    type: string;
+    ver: number;
+    properties: Record<string, unknown>;
+  };
+};
+
+type FileListResponse = {
+  files: Array<{
+    id: string;
+    type: string;
+    ver: number;
+    properties: Record<string, unknown>;
+  }>;
+  cursor: string | null;
+};
+
 type RelationshipsResponse = {
   relationships: Array<{
     id: string;
@@ -108,7 +127,7 @@ async function createWiki(
       content,
       keywords: [label.toLowerCase()],
       short_description: `Test wiki: ${label}`,
-      subject_type: opts?.subjectType ?? "document",
+      ...(opts?.subjectType ? { subject_type: opts.subjectType } : {}),
       ...(opts?.spaceId ? { space_id: opts.spaceId } : {}),
     },
   });
@@ -116,12 +135,38 @@ async function createWiki(
   return body as WikiResponse;
 }
 
-async function listDocuments(apiKey: string, spaceId: string) {
+async function createFile(
+  apiKey: string,
+  label: string,
+  content: string,
+  opts?: { spaceId?: string; sourceFile?: string; folder?: string },
+) {
+  const { response, body } = await jsonRequest("/files", {
+    method: "POST",
+    apiKey,
+    json: {
+      label,
+      content,
+      ...(opts?.sourceFile ? { source_file: opts.sourceFile } : {}),
+      ...(opts?.folder ? { folder: opts.folder } : {}),
+      ...(opts?.spaceId ? { space_id: opts.spaceId } : {}),
+    },
+  });
+  expect(response.status).toBe(201);
+  return body as FileResponse;
+}
+
+async function listFiles(apiKey: string, spaceId: string) {
   const { body } = await getJson(
-    `/wiki?filter=${encodeURIComponent("properties.subject_type:document")}&space_id=${spaceId}&limit=200`,
+    `/files?space_id=${spaceId}&limit=200`,
     apiKey,
   );
-  return (body as ListResponse).entities;
+  return (body as FileListResponse).files;
+}
+
+async function listDocuments(apiKey: string, spaceId: string) {
+  // Legacy helper — lists files via the files endpoint
+  return listFiles(apiKey, spaceId);
 }
 
 async function getEntity(apiKey: string, entityId: string) {
@@ -129,6 +174,13 @@ async function getEntity(apiKey: string, entityId: string) {
   if (response.status === 404 || response.status === 410) return null;
   expect(response.status).toBe(200);
   return (body as EntityResponse).wiki;
+}
+
+async function getFile(apiKey: string, entityId: string) {
+  const { response, body } = await getJson(`/files/${entityId}`, apiKey);
+  if (response.status === 404) return null;
+  expect(response.status).toBe(200);
+  return (body as FileResponse).file;
 }
 
 async function getIncomingRelationships(apiKey: string, entityId: string, predicate?: string) {
@@ -153,6 +205,23 @@ async function updateEntity(apiKey: string, entityId: string, ver: number, prope
     method: "PUT",
     apiKey,
     json: { ver, properties },
+  });
+  return response.status;
+}
+
+async function updateFile(apiKey: string, entityId: string, ver: number, properties: Record<string, unknown>) {
+  const { response } = await jsonRequest(`/files/${entityId}`, {
+    method: "PUT",
+    apiKey,
+    json: { ver, properties },
+  });
+  return response.status;
+}
+
+async function deleteFile(apiKey: string, entityId: string) {
+  const response = await fetch(`${baseUrl}/files/${entityId}`, {
+    method: "DELETE",
+    headers: { authorization: `ApiKey ${apiKey}` },
   });
   return response.status;
 }
@@ -187,14 +256,14 @@ describe("Repo commands — init / diff / add / rm flow", () => {
   let doc2Id: string;
   let doc3Id: string;
 
-  test("add: create document wikis", async () => {
-    const d1 = await createWiki(actor.apiKey, "Book 01", "Augustine reflects on his early life.", { spaceId, subjectType: "document" });
-    const d2 = await createWiki(actor.apiKey, "Book 02", "Augustine discusses the nature of sin.", { spaceId, subjectType: "document" });
-    const d3 = await createWiki(actor.apiKey, "City of God", "A treatise on the two cities.", { spaceId, subjectType: "document" });
+  test("add: create file entities", async () => {
+    const d1 = await createFile(actor.apiKey, "Book 01", "Augustine reflects on his early life.", { spaceId });
+    const d2 = await createFile(actor.apiKey, "Book 02", "Augustine discusses the nature of sin.", { spaceId });
+    const d3 = await createFile(actor.apiKey, "City of God", "A treatise on the two cities.", { spaceId });
 
-    doc1Id = d1.wiki.id;
-    doc2Id = d2.wiki.id;
-    doc3Id = d3.wiki.id;
+    doc1Id = d1.file.id;
+    doc2Id = d2.file.id;
+    doc3Id = d3.file.id;
 
     expect(doc1Id).toBeTruthy();
     expect(doc2Id).toBeTruthy();
@@ -207,25 +276,26 @@ describe("Repo commands — init / diff / add / rm flow", () => {
   });
 
   test("diff: documents have correct properties", async () => {
-    const entity = await getEntity(actor.apiKey, doc1Id);
+    const entity = await getFile(actor.apiKey, doc1Id);
     expect(entity).not.toBeNull();
     expect(entity!.properties.label).toBe("Book 01");
     expect(entity!.properties.content).toBeTruthy();
+    expect(entity!.type).toBe("file");
   });
 
   // --- Update flow (simulate modified content) ---
 
-  test("add (update): modify document properties in place", async () => {
-    const entity = await getEntity(actor.apiKey, doc1Id);
+  test("add (update): modify file properties in place", async () => {
+    const entity = await getFile(actor.apiKey, doc1Id);
     expect(entity).not.toBeNull();
 
-    const status = await updateEntity(actor.apiKey, doc1Id, entity!.ver, {
+    const status = await updateFile(actor.apiKey, doc1Id, entity!.ver, {
       short_description: "Updated description for Book 01.",
     });
     expect(status).toBe(200);
 
     // Verify entity ID is stable
-    const updated = await getEntity(actor.apiKey, doc1Id);
+    const updated = await getFile(actor.apiKey, doc1Id);
     expect(updated).not.toBeNull();
     expect(updated!.id).toBe(doc1Id); // same ID
     expect(updated!.properties.short_description).toBe("Updated description for Book 01.");
@@ -257,29 +327,29 @@ describe("Repo commands — init / diff / add / rm flow", () => {
 
   // --- Remove flow ---
 
-  test("rm: delete document wiki", async () => {
-    const status = await deleteEntity(actor.apiKey, doc3Id);
+  test("rm: delete file entity", async () => {
+    const status = await deleteFile(actor.apiKey, doc3Id);
     expect(status).toBe(204);
-    expect(await getEntity(actor.apiKey, doc3Id)).toBeNull();
+    expect(await getFile(actor.apiKey, doc3Id)).toBeNull();
   });
 
-  test("rm: remaining documents are unaffected", async () => {
-    const docs = await listDocuments(actor.apiKey, spaceId);
-    // doc1, doc2 remain (doc3 deleted); Analysis of Book 01 also has subject_type "document"
+  test("rm: remaining files are unaffected", async () => {
+    const docs = await listFiles(actor.apiKey, spaceId);
+    // doc1, doc2 remain (doc3 deleted); Analysis of Book 01 is a wiki, not a file
     const labels = docs.map((d) => d.properties.label).sort();
-    expect(labels).toEqual(["Analysis of Book 01", "Book 01", "Book 02"]);
+    expect(labels).toEqual(["Book 01", "Book 02"]);
   });
 
   // --- Simple delete (no extracted children) ---
 
-  test("rm: delete document with no children", async () => {
-    const status = await deleteEntity(actor.apiKey, doc2Id);
+  test("rm: delete file with no children", async () => {
+    const status = await deleteFile(actor.apiKey, doc2Id);
     expect(status).toBe(204);
 
-    const docs = await listDocuments(actor.apiKey, spaceId);
-    expect(docs).toHaveLength(2);
+    const docs = await listFiles(actor.apiKey, spaceId);
+    expect(docs).toHaveLength(1);
     const labels = docs.map((d) => d.properties.label).sort();
-    expect(labels).toEqual(["Analysis of Book 01", "Book 01"]);
+    expect(labels).toEqual(["Book 01"]);
   });
 });
 

--- a/scripts/smoke-pack.sh
+++ b/scripts/smoke-pack.sh
@@ -281,7 +281,7 @@ else
 fi
 
 echo "arkeon-wiki wiki create..."
-CREATE_OUT=$(npx arkeon-wiki wiki create --label "Smoke Test Entity" --short-description "A smoke test entity" --keywords '["smoke"]' --content "Smoke test content." --type person --raw 2>&1) || fail "arkeon-wiki wiki create"
+CREATE_OUT=$(npx arkeon-wiki wiki create --label "Smoke Test Entity" --short-description "A smoke test entity" --keywords '["smoke"]' --content "Smoke test content." --subject-type person --raw 2>&1) || fail "arkeon-wiki wiki create"
 # grep returns exit 1 when no match — use || true to prevent set -eo pipefail from killing the script
 # --raw output uses "id": "..." (with spaces), so match both formats
 ENTITY_ID=$(echo "$CREATE_OUT" | grep -oE '"id"\s*:\s*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/' || true)


### PR DESCRIPTION
## Summary

- **New `type: "file"` entity type** — documents uploaded via `arkeon add` are no longer stored as `type: "wiki"` with `subject_type: "document"`. They get their own entity type with cleaner semantics.
- **Dedicated `/files` router** — full CRUD (POST, GET, GET/:id, PUT/:id, DELETE/:id). Files skip the wiki link pipeline entirely and auto-enqueue for entity extraction.
- **`folder` property** — organizational hierarchy derived from `dirname(source_file)` in the CLI. Queryable via existing filter system (`filter=folder:notes/physics`). No folder entities or hierarchy table — just a property.
- **`GET /wiki` excludes files** — file entities no longer appear in wiki listings. Clean separation between source material and knowledge graph articles.
- **Data migration** — existing `type:wiki + subject_type:document` entities are migrated to `type:file` on deploy.

## Test plan

- [x] Typecheck passes
- [x] 168 unit tests pass
- [x] Build succeeds (healthy dist sizes)
- [x] Smoke tested on running named instance:
  - POST /files creates file with folder property
  - GET /files lists only file entities with folder filtering
  - PUT /files/:id updates and preserves properties
  - DELETE /files/:id works correctly
  - GET /wiki excludes file entities
  - Wiki creation and cross-type relationships still work
  - Entity extraction runs from file content
- [ ] E2E tests (need running stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)