### PR TITLE
feat: queue monitoring API + arkeon watch CLI

### DIFF
--- a/packages/arkeon/spec/openapi.snapshot.json
+++ b/packages/arkeon/spec/openapi.snapshot.json
@@ -2791,6 +2791,237 @@
         "x-arke-rules": []
       }
     },
+    "/queues": {
+      "get": {
+        "operationId": "getQueueStatus",
+        "parameters": [
+          {
+            "description": "Number of recent completed/failed items to return per queue",
+            "in": "query",
+            "name": "recent",
+            "required": false,
+            "schema": {
+              "default": 5,
+              "description": "Number of recent completed/failed items to return per queue",
+              "maximum": 50,
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "queues": {
+                      "items": {
+                        "properties": {
+                          "counts": {
+                            "additionalProperties": {
+                              "type": "integer"
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "processing": {
+                            "items": {
+                              "properties": {
+                                "attempts": {
+                                  "type": "integer"
+                                },
+                                "created_at": {
+                                  "type": "string"
+                                },
+                                "entity_id": {
+                                  "type": "string"
+                                },
+                                "error": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "label": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "started_at": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "status": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "entity_id",
+                                "label",
+                                "status",
+                                "error",
+                                "attempts",
+                                "created_at",
+                                "started_at"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "recent_complete": {
+                            "items": {
+                              "properties": {
+                                "attempts": {
+                                  "type": "integer"
+                                },
+                                "created_at": {
+                                  "type": "string"
+                                },
+                                "entity_id": {
+                                  "type": "string"
+                                },
+                                "error": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "label": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "started_at": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "status": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "entity_id",
+                                "label",
+                                "status",
+                                "error",
+                                "attempts",
+                                "created_at",
+                                "started_at"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "recent_errors": {
+                            "items": {
+                              "properties": {
+                                "attempts": {
+                                  "type": "integer"
+                                },
+                                "created_at": {
+                                  "type": "string"
+                                },
+                                "entity_id": {
+                                  "type": "string"
+                                },
+                                "error": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "label": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "started_at": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "status": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "entity_id",
+                                "label",
+                                "status",
+                                "error",
+                                "attempts",
+                                "created_at",
+                                "started_at"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "counts",
+                          "processing",
+                          "recent_complete",
+                          "recent_errors"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "timestamp": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "queues",
+                    "timestamp"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Queue status for all background workers"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication required"
+          }
+        },
+        "summary": "Live status of all background worker queues (extract, draft)",
+        "tags": [
+          "Queues"
+        ],
+        "x-arke-auth": "required",
+        "x-arke-related": [
+          "GET /wiki",
+          "POST /wiki"
+        ],
+        "x-arke-rules": [
+          "Queue status includes entity IDs, labels, and error messages for all actors"
+        ]
+      }
+    },
     "/relationships": {
       "get": {
         "description": "Lists relationships across the entire graph. Use predicate, source_id, target_id, or space_id to narrow results. Each result includes source and target entity summaries.",

--- a/packages/arkeon/src/cli/commands/local/index.ts
+++ b/packages/arkeon/src/cli/commands/local/index.ts
@@ -38,6 +38,7 @@ import { registerSeedCommand } from "./seed.js";
 import { registerMigrateCommand } from "./migrate.js";
 import { registerResetCommand } from "./reset.js";
 import { registerUpdateCommand } from "./update.js";
+import { registerWatchCommand } from "./watch.js";
 
 export function registerLocalCommands(program: Command): void {
   // Registration order = --help display order. Surface the daemon
@@ -48,6 +49,7 @@ export function registerLocalCommands(program: Command): void {
   registerDownCommand(program);
   registerLogsCommand(program);
   registerStatusCommand(program);
+  registerWatchCommand(program);
   registerSeedCommand(program);
   registerStartCommand(program);
   registerStopCommand(program);

--- a/packages/arkeon/src/cli/commands/local/watch.ts
+++ b/packages/arkeon/src/cli/commands/local/watch.ts
@@ -82,7 +82,8 @@ async function runWatch(opts: WatchOptions): Promise<void> {
     output.error(new Error("Stack is not running. Start it with `arkeon up`."), {
       operation: "watch",
     });
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   const secrets = readSecrets();
@@ -90,7 +91,8 @@ async function runWatch(opts: WatchOptions): Promise<void> {
     output.error(new Error("No secrets.json found. Run `arkeon init` first."), {
       operation: "watch",
     });
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
   const adminKey = secrets.adminBootstrapKey;
 

--- a/packages/arkeon/src/cli/commands/local/watch.ts
+++ b/packages/arkeon/src/cli/commands/local/watch.ts
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `arkeon watch` — live dashboard showing extraction and drafting queue
+ * progress. Polls GET /queues and redraws the terminal on each tick.
+ *
+ * Exit codes:
+ *   0 — user hit Ctrl+C
+ *   1 — stack not running or fetch error
+ */
+
+import type { Command } from "commander";
+
+import {
+  DEFAULT_API_PORT,
+  isProcessAlive,
+  readPidfile,
+  readSecrets,
+} from "../../lib/local-runtime";
+import { output } from "../../lib/output";
+
+interface WatchOptions {
+  interval?: string;
+  json?: boolean;
+  port?: string;
+}
+
+interface QueueItem {
+  entity_id: string;
+  label: string | null;
+  status: string;
+  error: string | null;
+  attempts: number;
+  created_at: string;
+  started_at: string | null;
+}
+
+interface QueueStatus {
+  name: string;
+  counts: Record<string, number>;
+  processing: QueueItem[];
+  recent_complete: QueueItem[];
+  recent_errors: QueueItem[];
+}
+
+interface QueuesResponse {
+  queues: QueueStatus[];
+  timestamp: string;
+}
+
+export function registerWatchCommand(program: Command): void {
+  program
+    .command("watch")
+    .description("Live dashboard showing extraction and drafting queue progress")
+    .option("--interval <seconds>", "Poll interval in seconds", "3")
+    .option("--json", "Output one JSON object per tick (for piping)")
+    .option(
+      "--port <port>",
+      "API port to probe",
+      String(DEFAULT_API_PORT),
+    )
+    .action(async (opts: WatchOptions) => {
+      try {
+        await runWatch(opts);
+      } catch (error) {
+        output.error(error, { operation: "watch" });
+        process.exitCode = 1;
+      }
+    });
+}
+
+async function runWatch(opts: WatchOptions): Promise<void> {
+  const port = Number(opts.port ?? DEFAULT_API_PORT);
+  const intervalMs = Math.max(1, Number(opts.interval ?? 3)) * 1000;
+  const jsonMode = opts.json === true;
+  const apiUrl = `http://localhost:${port}`;
+
+  // Verify stack is running
+  const pid = readPidfile();
+  if (!pid || !isProcessAlive(pid)) {
+    output.error(new Error("Stack is not running. Start it with `arkeon up`."), {
+      operation: "watch",
+    });
+    process.exit(1);
+  }
+
+  const secrets = readSecrets();
+  if (!secrets) {
+    output.error(new Error("No secrets.json found. Run `arkeon init` first."), {
+      operation: "watch",
+    });
+    process.exit(1);
+  }
+  const adminKey = secrets.adminBootstrapKey;
+
+  // SIGINT → clean exit
+  process.on("SIGINT", () => process.exit(0));
+
+  // Immediate first tick, then interval
+  await tick(apiUrl, adminKey, jsonMode);
+  const timer = setInterval(() => void tick(apiUrl, adminKey, jsonMode), intervalMs);
+  timer.unref?.();
+
+  // Keep process alive until SIGINT
+  await new Promise<void>(() => {});
+}
+
+async function tick(
+  apiUrl: string,
+  adminKey: string,
+  jsonMode: boolean,
+): Promise<void> {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    const res = await fetch(`${apiUrl}/queues?recent=5`, {
+      headers: { authorization: `ApiKey ${adminKey}` },
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      process.stderr.write(`[watch] HTTP ${res.status}: ${body.slice(0, 200)}\n`);
+      return;
+    }
+
+    const data = (await res.json()) as QueuesResponse;
+
+    if (jsonMode) {
+      process.stdout.write(JSON.stringify(data) + "\n");
+    } else {
+      renderDashboard(data);
+    }
+  } catch (err) {
+    process.stderr.write(`[watch] fetch error: ${(err as Error).message}\n`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Terminal rendering
+// ---------------------------------------------------------------------------
+
+function renderDashboard(data: QueuesResponse): void {
+  // Clear screen + move cursor home
+  process.stdout.write("\x1b[2J\x1b[H");
+
+  const ts = new Date(data.timestamp).toLocaleTimeString();
+  const lines: string[] = [];
+
+  lines.push(`Arkeon Queue Monitor    ${ts}`);
+  lines.push("");
+
+  for (const q of data.queues) {
+    lines.push(`${q.name.toUpperCase()}`);
+    lines.push(formatCounts(q.counts));
+
+    if (q.processing.length > 0) {
+      lines.push("");
+      lines.push("  Processing:");
+      for (const item of q.processing) {
+        lines.push(`    ${itemLabel(item)} (attempt ${item.attempts})`);
+      }
+    }
+
+    if (q.recent_complete.length > 0 || q.recent_errors.length > 0) {
+      lines.push("");
+      lines.push("  Recent:");
+      for (const item of q.recent_complete) {
+        lines.push(`    [complete]     ${itemLabel(item)}    ${timeAgo(item.started_at)}`);
+      }
+      for (const item of q.recent_errors) {
+        const tag = item.status === "undraftable" ? "undraftable" : "failed";
+        const reason = item.error ? ` -- ${item.error.slice(0, 60)}` : "";
+        lines.push(`    [${tag}]  ${itemLabel(item)}${reason}    ${timeAgo(item.started_at)}`);
+      }
+    }
+
+    lines.push("");
+  }
+
+  lines.push("Ctrl+C to exit");
+
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+function formatCounts(counts: Record<string, number>): string {
+  if (Object.keys(counts).length === 0) return "  (empty queue)";
+  const parts = Object.entries(counts).map(([k, v]) => `${k}: ${v}`);
+  return "  " + parts.join("    ");
+}
+
+function itemLabel(item: QueueItem): string {
+  return item.label ?? item.entity_id.slice(0, 8);
+}
+
+function timeAgo(ts: string | null): string {
+  if (!ts) return "";
+  const diff = Date.now() - new Date(ts).getTime();
+  if (diff < 0) return "";
+  const secs = Math.floor(diff / 1000);
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  return `${hrs}h ago`;
+}

--- a/packages/arkeon/src/generated/index.ts
+++ b/packages/arkeon/src/generated/index.ts
@@ -293,6 +293,19 @@ const OPERATIONS: GeneratedOperation[] = [
     bodyFields: [],
   },
   {
+    operationId: "getQueueStatus",
+    group: "queues",
+    action: "queue-status",
+    method: "GET",
+    path: "/queues",
+    summary: "Live status of all background worker queues (extract, draft)",
+    description: "Live status of all background worker queues (extract, draft)",
+    auth: "required",
+    pathParams: [],
+    queryParams: [{ name: "recent", description: "Number of recent completed/failed items to return per queue", required: false, type: "integer" }],
+    bodyFields: [],
+  },
+  {
     operationId: "getRelationship",
     group: "relationships",
     action: "get",
@@ -620,7 +633,7 @@ const OPERATIONS: GeneratedOperation[] = [
 ];
 
 export function registerApiCommands(program: Command, options: { skipExisting?: boolean } = {}): void {
-  for (const group of ["actors","admin","auth","files","graph","relationships","resolve","search","spaces","wiki"]) {
+  for (const group of ["actors","admin","auth","files","graph","queues","relationships","resolve","search","spaces","wiki"]) {
     const existing = program.commands.find((command) => command.name() === group);
     if (existing && options.skipExisting) {
       registerGeneratedGroup(existing, OPERATIONS.filter((operation) => operation.group === group));

--- a/packages/arkeon/src/server/app.ts
+++ b/packages/arkeon/src/server/app.ts
@@ -29,6 +29,7 @@ import { graphRouter } from "./routes/traverse";
 import { searchRouter } from "./routes/search";
 import { spacesRouter } from "./routes/spaces";
 import { filesRouter } from "./routes/files";
+import { queuesRouter } from "./routes/queues";
 import { wikiRouter } from "./routes/wiki";
 
 export const openApiConfig = {
@@ -141,6 +142,7 @@ export function createApp(options?: { adminKey?: string }) {
   app.route("/admin", adminRouter);
   app.route("/auth", authRouter);
   app.route("/graph", graphRouter);
+  app.route("/queues", queuesRouter);
   app.route("/relationships", relationshipDirectRouter);
   app.route("/resolve", resolveRouter);
   app.route("/search", searchRouter);

--- a/packages/arkeon/src/server/routes/queues.ts
+++ b/packages/arkeon/src/server/routes/queues.ts
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRoute, z } from "@hono/zod-openapi";
+
+import { requireActor } from "../lib/http";
+import { createRouter } from "../lib/openapi";
+import { errorResponses, jsonContent } from "../lib/schemas";
+import { withSystemActorContext } from "../lib/actor-context";
+
+// ---------------------------------------------------------------------------
+// Queue definitions — add a row here when a new worker queue is introduced
+// ---------------------------------------------------------------------------
+
+interface QueueDef {
+  /** Display name returned in the API response */
+  name: string;
+  /** Postgres table name */
+  table: string;
+}
+
+const QUEUE_DEFS: QueueDef[] = [
+  { name: "extract", table: "source_extract_queue" },
+  { name: "draft", table: "wiki_draft_queue" },
+];
+
+// ---------------------------------------------------------------------------
+// Zod schemas
+// ---------------------------------------------------------------------------
+
+const QueueItemSchema = z.object({
+  entity_id: z.string(),
+  label: z.string().nullable(),
+  status: z.string(),
+  error: z.string().nullable(),
+  attempts: z.number().int(),
+  created_at: z.string(),
+  started_at: z.string().nullable(),
+});
+
+const QueueStatusSchema = z.object({
+  name: z.string(),
+  counts: z.record(z.string(), z.number().int()),
+  processing: z.array(QueueItemSchema),
+  recent_complete: z.array(QueueItemSchema),
+  recent_errors: z.array(QueueItemSchema),
+});
+
+// ---------------------------------------------------------------------------
+// Route definition
+// ---------------------------------------------------------------------------
+
+const queuesRoute = createRoute({
+  method: "get",
+  path: "/",
+  operationId: "getQueueStatus",
+  tags: ["Queues"],
+  summary: "Live status of all background worker queues (extract, draft)",
+  "x-arke-auth": "required",
+  "x-arke-rules": [],
+  request: {
+    query: z.object({
+      recent: z.coerce
+        .number()
+        .int()
+        .min(0)
+        .max(50)
+        .default(5)
+        .optional()
+        .describe("Number of recent completed/failed items to return per queue"),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Queue status for all background workers",
+      content: jsonContent(
+        z.object({
+          queues: z.array(QueueStatusSchema),
+          timestamp: z.string(),
+        }),
+      ),
+    },
+    ...errorResponses([401]),
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export const queuesRouter = createRouter();
+
+queuesRouter.openapi(queuesRoute, async (c) => {
+  requireActor(c);
+
+  const recent = Number(c.req.query("recent") ?? 5);
+
+  const queues = await withSystemActorContext(async (sql) => {
+    const results = [];
+
+    for (const def of QUEUE_DEFS) {
+      const t = def.table;
+
+      // Counts by status
+      const countRows = await sql.query(
+        `SELECT status, count(*)::int AS n FROM ${t} GROUP BY status`,
+      );
+      const counts: Record<string, number> = {};
+      for (const row of countRows as Array<{ status: string; n: number }>) {
+        counts[row.status] = row.n;
+      }
+
+      // Currently processing items (with labels)
+      const processing = await sql.query(
+        `SELECT q.entity_id, e.properties->>'label' AS label,
+                q.status, q.error, q.attempts, q.created_at, q.started_at
+         FROM ${t} q
+         LEFT JOIN entities e ON e.id = q.entity_id
+         WHERE q.status = 'processing'
+         ORDER BY q.started_at ASC`,
+      );
+
+      // Recent completions
+      const recentComplete = await sql.query(
+        `SELECT q.entity_id, e.properties->>'label' AS label,
+                q.status, q.error, q.attempts, q.created_at, q.started_at
+         FROM ${t} q
+         LEFT JOIN entities e ON e.id = q.entity_id
+         WHERE q.status = 'complete'
+         ORDER BY q.started_at DESC NULLS LAST
+         LIMIT $1`,
+        [recent],
+      );
+
+      // Recent errors (failed + undraftable)
+      const recentErrors = await sql.query(
+        `SELECT q.entity_id, e.properties->>'label' AS label,
+                q.status, q.error, q.attempts, q.created_at, q.started_at
+         FROM ${t} q
+         LEFT JOIN entities e ON e.id = q.entity_id
+         WHERE q.status IN ('failed', 'undraftable')
+         ORDER BY q.started_at DESC NULLS LAST
+         LIMIT $1`,
+        [recent],
+      );
+
+      results.push({
+        name: def.name,
+        counts,
+        processing: processing as unknown[],
+        recent_complete: recentComplete as unknown[],
+        recent_errors: recentErrors as unknown[],
+      });
+    }
+
+    return results;
+  });
+
+  return c.json(
+    {
+      queues,
+      timestamp: new Date().toISOString(),
+    },
+    200,
+  );
+});

--- a/packages/arkeon/src/server/routes/queues.ts
+++ b/packages/arkeon/src/server/routes/queues.ts
@@ -9,20 +9,25 @@ import { errorResponses, jsonContent } from "../lib/schemas";
 import { withSystemActorContext } from "../lib/actor-context";
 
 // ---------------------------------------------------------------------------
-// Queue definitions — add a row here when a new worker queue is introduced
+// Queue definitions — add a row here when a new worker queue is introduced.
+// SAFETY: table names are interpolated into SQL strings. Only hardcoded
+// values are allowed here — NEVER derive from user input or config.
 // ---------------------------------------------------------------------------
 
 interface QueueDef {
   /** Display name returned in the API response */
   name: string;
-  /** Postgres table name */
+  /** Postgres table name — must be a valid, hardcoded identifier */
   table: string;
 }
 
-const QUEUE_DEFS: QueueDef[] = [
+const QUEUE_DEFS: ReadonlyArray<QueueDef> = [
   { name: "extract", table: "source_extract_queue" },
   { name: "draft", table: "wiki_draft_queue" },
-];
+] as const;
+
+/** Allowlist of table names that may appear in queue queries. */
+const VALID_QUEUE_TABLES = new Set(QUEUE_DEFS.map((d) => d.table));
 
 // ---------------------------------------------------------------------------
 // Zod schemas
@@ -57,7 +62,8 @@ const queuesRoute = createRoute({
   tags: ["Queues"],
   summary: "Live status of all background worker queues (extract, draft)",
   "x-arke-auth": "required",
-  "x-arke-rules": [],
+  "x-arke-related": ["GET /wiki", "POST /wiki"],
+  "x-arke-rules": ["Queue status includes entity IDs, labels, and error messages for all actors"],
   request: {
     query: z.object({
       recent: z.coerce
@@ -93,63 +99,93 @@ export const queuesRouter = createRouter();
 queuesRouter.openapi(queuesRoute, async (c) => {
   requireActor(c);
 
-  const recent = Number(c.req.query("recent") ?? 5);
+  const recent = Number(c.req.query("recent"));
 
   const queues = await withSystemActorContext(async (sql) => {
     const results = [];
 
     for (const def of QUEUE_DEFS) {
       const t = def.table;
+      if (!VALID_QUEUE_TABLES.has(t)) continue;
 
-      // Counts by status
-      const countRows = await sql.query(
-        `SELECT status, count(*)::int AS n FROM ${t} GROUP BY status`,
+      // Single CTE query per queue: counts + processing + recent complete + recent errors
+      const rows = await sql.query(
+        `WITH
+           counts AS (
+             SELECT 'count' AS _section, status, count(*)::int AS n,
+                    NULL::text AS entity_id, NULL::text AS label,
+                    NULL::text AS error, NULL::int AS attempts,
+                    NULL::timestamptz AS created_at, NULL::timestamptz AS started_at
+             FROM ${t}
+             GROUP BY status
+           ),
+           processing AS (
+             SELECT 'processing' AS _section, q.status, NULL::int AS n,
+                    q.entity_id, e.properties->>'label' AS label,
+                    q.error, q.attempts, q.created_at, q.started_at
+             FROM ${t} q
+             LEFT JOIN entities e ON e.id = q.entity_id
+             WHERE q.status = 'processing'
+             ORDER BY q.started_at ASC
+           ),
+           recent_complete AS (
+             SELECT 'recent_complete' AS _section, q.status, NULL::int AS n,
+                    q.entity_id, e.properties->>'label' AS label,
+                    q.error, q.attempts, q.created_at, q.started_at
+             FROM ${t} q
+             LEFT JOIN entities e ON e.id = q.entity_id
+             WHERE q.status = 'complete'
+             ORDER BY q.started_at DESC NULLS LAST
+             LIMIT $1
+           ),
+           recent_errors AS (
+             SELECT 'recent_errors' AS _section, q.status, NULL::int AS n,
+                    q.entity_id, e.properties->>'label' AS label,
+                    q.error, q.attempts, q.created_at, q.started_at
+             FROM ${t} q
+             LEFT JOIN entities e ON e.id = q.entity_id
+             WHERE q.status IN ('failed', 'undraftable')
+             ORDER BY q.started_at DESC NULLS LAST
+             LIMIT $1
+           )
+         SELECT * FROM counts
+         UNION ALL SELECT * FROM processing
+         UNION ALL SELECT * FROM recent_complete
+         UNION ALL SELECT * FROM recent_errors`,
+        [recent],
       );
+
       const counts: Record<string, number> = {};
-      for (const row of countRows as Array<{ status: string; n: number }>) {
-        counts[row.status] = row.n;
+      const processing: unknown[] = [];
+      const recentComplete: unknown[] = [];
+      const recentErrors: unknown[] = [];
+
+      for (const row of rows as Array<Record<string, unknown>>) {
+        const section = row._section as string;
+        if (section === "count") {
+          counts[row.status as string] = row.n as number;
+        } else {
+          const item = {
+            entity_id: row.entity_id,
+            label: row.label,
+            status: row.status,
+            error: row.error,
+            attempts: row.attempts,
+            created_at: row.created_at,
+            started_at: row.started_at,
+          };
+          if (section === "processing") processing.push(item);
+          else if (section === "recent_complete") recentComplete.push(item);
+          else if (section === "recent_errors") recentErrors.push(item);
+        }
       }
-
-      // Currently processing items (with labels)
-      const processing = await sql.query(
-        `SELECT q.entity_id, e.properties->>'label' AS label,
-                q.status, q.error, q.attempts, q.created_at, q.started_at
-         FROM ${t} q
-         LEFT JOIN entities e ON e.id = q.entity_id
-         WHERE q.status = 'processing'
-         ORDER BY q.started_at ASC`,
-      );
-
-      // Recent completions
-      const recentComplete = await sql.query(
-        `SELECT q.entity_id, e.properties->>'label' AS label,
-                q.status, q.error, q.attempts, q.created_at, q.started_at
-         FROM ${t} q
-         LEFT JOIN entities e ON e.id = q.entity_id
-         WHERE q.status = 'complete'
-         ORDER BY q.started_at DESC NULLS LAST
-         LIMIT $1`,
-        [recent],
-      );
-
-      // Recent errors (failed + undraftable)
-      const recentErrors = await sql.query(
-        `SELECT q.entity_id, e.properties->>'label' AS label,
-                q.status, q.error, q.attempts, q.created_at, q.started_at
-         FROM ${t} q
-         LEFT JOIN entities e ON e.id = q.entity_id
-         WHERE q.status IN ('failed', 'undraftable')
-         ORDER BY q.started_at DESC NULLS LAST
-         LIMIT $1`,
-        [recent],
-      );
 
       results.push({
         name: def.name,
         counts,
-        processing: processing as unknown[],
-        recent_complete: recentComplete as unknown[],
-        recent_errors: recentErrors as unknown[],
+        processing,
+        recent_complete: recentComplete,
+        recent_errors: recentErrors,
       });
     }
 


### PR DESCRIPTION
## Summary

- Adds `GET /queues` endpoint returning live status of all background worker queues (counts by status, currently processing items, recent completions/errors)
- Adds `arkeon watch` CLI command that polls the endpoint and renders a live terminal dashboard
- Extensible design — adding a future worker queue requires one line in `QUEUE_DEFS`

## Test plan

- [x] Typecheck passes
- [x] All 168 unit tests pass
- [x] Smoke tested on fresh instance: added document, watched extract complete (11 placeholders), draft worker process them live
- [x] `GET /queues` returns correct JSON with counts, processing, recent_complete, recent_errors
- [x] `arkeon watch` renders live dashboard with ANSI clear/redraw
- [x] `arkeon watch --json` emits structured JSON per tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)