### PR TITLE
feat: make LLM config discoverable via CLI and API

### DIFF
--- a/packages/arkeon/src/cli/commands/config/index.ts
+++ b/packages/arkeon/src/cli/commands/config/index.ts
@@ -136,7 +136,9 @@ export function registerConfigCommands(program: Command): void {
       if (existsSync(path)) {
         try {
           doc = JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
-        } catch { /* overwrite malformed file */ }
+        } catch {
+          output.warn(`Existing ${path} is malformed JSON — overwriting with new config.`);
+        }
       }
 
       const def = (doc.default ?? {}) as Record<string, unknown>;
@@ -148,6 +150,7 @@ export function registerConfigCommands(program: Command): void {
       writeFileSync(path, JSON.stringify(doc, null, 2) + "\n", "utf-8");
       output.result({
         operation: "config.set-llm-key",
+        key_set: true,
         llm_config_path: path,
         model: def.model ?? null,
         base_url: def.base_url ?? null,

--- a/packages/arkeon/src/cli/commands/config/index.ts
+++ b/packages/arkeon/src/cli/commands/config/index.ts
@@ -1,9 +1,12 @@
 // Copyright (c) 2026 Arkeon Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import { Command } from "commander";
 
 import { config } from "../../lib/config.js";
+import { llmConfigFile, probeLlmConfig, workersConfigFile } from "../../lib/local-runtime.js";
 import { output } from "../../lib/output.js";
 
 export function registerConfigCommands(program: Command): void {
@@ -89,13 +92,66 @@ export function registerConfigCommands(program: Command): void {
     .description("Show all CLI configuration")
     .action(() => {
       const spaceId = config.get("spaceId");
+      const llm = probeLlmConfig();
       output.result({
         operation: "config.show",
         api_url: config.get("apiUrl"),
         api_url_source: process.env.ARKE_API_URL ? "ARKE_API_URL" : "config",
         space_id: spaceId ?? null,
         space_id_source: process.env.ARKE_SPACE_ID ? "ARKE_SPACE_ID" : spaceId ? "config" : null,
+        llm,
         config_path: config.path(),
       });
     });
+
+  configCmd
+    .command("get-llm")
+    .description("Show current LLM configuration status")
+    .action(() => {
+      const llm = probeLlmConfig();
+      output.result({
+        operation: "config.get-llm",
+        ...llm,
+        llm_config_path: llmConfigFile(),
+        workers_config_path: workersConfigFile(),
+        hint: llm.configured
+          ? undefined
+          : "Set an LLM key with: arkeon-wiki config set-llm-key <your-api-key>",
+      });
+    });
+
+  configCmd
+    .command("set-llm-key")
+    .description("Set the LLM API key (writes to llm.json)")
+    .argument("<key>", "OpenAI-compatible API key")
+    .option("--model <model>", "Default model to use (e.g. gpt-4o, claude-sonnet-4-20250514)")
+    .option("--base-url <url>", "Custom base URL for OpenAI-compatible providers")
+    .action((key: string, opts: { model?: string; baseUrl?: string }) => {
+      const path = llmConfigFile();
+      const dir = dirname(path);
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+      // Merge into existing file if present
+      let doc: Record<string, unknown> = {};
+      if (existsSync(path)) {
+        try {
+          doc = JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+        } catch { /* overwrite malformed file */ }
+      }
+
+      const def = (doc.default ?? {}) as Record<string, unknown>;
+      def.api_key = key;
+      if (opts.model) def.model = opts.model;
+      if (opts.baseUrl) def.base_url = opts.baseUrl;
+      doc.default = def;
+
+      writeFileSync(path, JSON.stringify(doc, null, 2) + "\n", "utf-8");
+      output.result({
+        operation: "config.set-llm-key",
+        llm_config_path: path,
+        model: def.model ?? null,
+        base_url: def.base_url ?? null,
+      });
+    });
 }
+

--- a/packages/arkeon/src/cli/commands/local/status.ts
+++ b/packages/arkeon/src/cli/commands/local/status.ts
@@ -17,6 +17,7 @@ import {
   arkeonDir,
   DEFAULT_API_PORT,
   isProcessAlive,
+  probeLlmConfig,
   readPidfile,
   readSecrets,
   removePidfile,
@@ -65,6 +66,8 @@ async function runStatus(opts: StatusOptions): Promise<void> {
 
   // Not running — still show state_dir + admin key prefix so the user
   // has what they need to bring the stack back up and authenticate.
+  const llm = probeLlmConfig();
+
   if (!pid) {
     const secrets = readSecrets();
     output.result({
@@ -72,6 +75,7 @@ async function runStatus(opts: StatusOptions): Promise<void> {
       state: "not_running",
       state_dir: arkeonDir(),
       admin_key_prefix: secrets ? `${secrets.adminBootstrapKey.slice(0, 8)}...` : null,
+      llm,
       repo,
       hint: "Run `arkeon up` to start the stack.",
     });
@@ -88,6 +92,7 @@ async function runStatus(opts: StatusOptions): Promise<void> {
       stale_pid: pid,
       state_dir: arkeonDir(),
       admin_key_prefix: secrets ? `${secrets.adminBootstrapKey.slice(0, 8)}...` : null,
+      llm,
       repo,
     });
     process.exit(2);
@@ -109,6 +114,7 @@ async function runStatus(opts: StatusOptions): Promise<void> {
       health: false,
       ready: false,
       state_dir: arkeonDir(),
+      llm,
       repo,
       hint: "Process is alive but /health is not responding. Check `arkeon logs` for errors.",
     });
@@ -130,6 +136,7 @@ async function runStatus(opts: StatusOptions): Promise<void> {
       health: true,
       ready,
       state_dir: arkeonDir(),
+      llm,
       repo,
       hint: "No secrets.json in the state dir — cannot run authenticated probes. Run `arkeon init` to generate one.",
     });
@@ -158,6 +165,7 @@ async function runStatus(opts: StatusOptions): Promise<void> {
     seed_book_id: seedState.bookId,
     state_dir: arkeonDir(),
     admin_key_prefix: `${adminKey.slice(0, 8)}...`,
+    llm,
     repo,
     instances: instances.length > 0 ? instances : undefined,
   });

--- a/packages/arkeon/src/cli/lib/local-runtime.ts
+++ b/packages/arkeon/src/cli/lib/local-runtime.ts
@@ -39,6 +39,7 @@ import { createConnection } from "node:net";
 import { fileURLToPath } from "node:url";
 
 import EmbeddedPostgres from "embedded-postgres";
+import yaml from "js-yaml";
 
 // =====================================================================
 // Paths + conventions
@@ -65,6 +66,56 @@ export function pidfile(): string { return join(arkeonHome(), "arkeon.pid"); }
 export function meiliPidfile(): string { return join(arkeonHome(), "meili.pid"); }
 export function logfile(): string { return join(arkeonHome(), "arkeon.log"); }
 export function llmConfigFile(): string { return join(arkeonHome(), "llm.json"); }
+export function workersConfigFile(): string { return join(arkeonHome(), "workers.yaml"); }
+
+export interface LlmProbeResult {
+  configured: boolean;
+  source: "workers.yaml" | "llm.json" | "OPENAI_API_KEY" | null;
+  model: string | null;
+}
+
+/**
+ * Check LLM configuration from local files and env vars.
+ * Pure filesystem/env read — no server import.
+ */
+export function probeLlmConfig(): LlmProbeResult {
+  // workers.yaml (highest priority config surface)
+  const workersPath = workersConfigFile();
+  if (existsSync(workersPath)) {
+    try {
+      const doc = yaml.load(readFileSync(workersPath, "utf-8")) as Record<string, unknown> | null;
+      const llm = doc?.llm as Record<string, unknown> | undefined;
+      if (llm?.api_key) {
+        return { configured: true, source: "workers.yaml", model: (llm.model as string) ?? null };
+      }
+    } catch { /* malformed yaml — fall through */ }
+  }
+
+  // llm.json
+  const llmPath = llmConfigFile();
+  if (existsSync(llmPath)) {
+    try {
+      const doc = JSON.parse(readFileSync(llmPath, "utf-8")) as Record<string, unknown>;
+      const def = doc.default as Record<string, unknown> | undefined;
+      if (def?.api_key) {
+        return { configured: true, source: "llm.json", model: (def.model as string) ?? null };
+      }
+      for (const step of ["resolve", "exists", "draft", "dedup"] as const) {
+        const s = doc[step] as Record<string, unknown> | undefined;
+        if (s?.api_key) {
+          return { configured: true, source: "llm.json", model: (s.model as string) ?? null };
+        }
+      }
+    } catch { /* malformed json — fall through */ }
+  }
+
+  // Environment variable
+  if (process.env.OPENAI_API_KEY) {
+    return { configured: true, source: "OPENAI_API_KEY", model: null };
+  }
+
+  return { configured: false, source: null, model: null };
+}
 
 // Meilisearch version pinned for reproducibility. Bump deliberately.
 const MEILI_VERSION = "v1.41.0";

--- a/packages/arkeon/src/cli/lib/local-runtime.ts
+++ b/packages/arkeon/src/cli/lib/local-runtime.ts
@@ -39,7 +39,6 @@ import { createConnection } from "node:net";
 import { fileURLToPath } from "node:url";
 
 import EmbeddedPostgres from "embedded-postgres";
-import yaml from "js-yaml";
 
 // =====================================================================
 // Paths + conventions
@@ -68,54 +67,8 @@ export function logfile(): string { return join(arkeonHome(), "arkeon.log"); }
 export function llmConfigFile(): string { return join(arkeonHome(), "llm.json"); }
 export function workersConfigFile(): string { return join(arkeonHome(), "workers.yaml"); }
 
-export interface LlmProbeResult {
-  configured: boolean;
-  source: "workers.yaml" | "llm.json" | "OPENAI_API_KEY" | null;
-  model: string | null;
-}
-
-/**
- * Check LLM configuration from local files and env vars.
- * Pure filesystem/env read — no server import.
- */
-export function probeLlmConfig(): LlmProbeResult {
-  // workers.yaml (highest priority config surface)
-  const workersPath = workersConfigFile();
-  if (existsSync(workersPath)) {
-    try {
-      const doc = yaml.load(readFileSync(workersPath, "utf-8")) as Record<string, unknown> | null;
-      const llm = doc?.llm as Record<string, unknown> | undefined;
-      if (llm?.api_key) {
-        return { configured: true, source: "workers.yaml", model: (llm.model as string) ?? null };
-      }
-    } catch { /* malformed yaml — fall through */ }
-  }
-
-  // llm.json
-  const llmPath = llmConfigFile();
-  if (existsSync(llmPath)) {
-    try {
-      const doc = JSON.parse(readFileSync(llmPath, "utf-8")) as Record<string, unknown>;
-      const def = doc.default as Record<string, unknown> | undefined;
-      if (def?.api_key) {
-        return { configured: true, source: "llm.json", model: (def.model as string) ?? null };
-      }
-      for (const step of ["resolve", "exists", "draft", "dedup"] as const) {
-        const s = doc[step] as Record<string, unknown> | undefined;
-        if (s?.api_key) {
-          return { configured: true, source: "llm.json", model: (s.model as string) ?? null };
-        }
-      }
-    } catch { /* malformed json — fall through */ }
-  }
-
-  // Environment variable
-  if (process.env.OPENAI_API_KEY) {
-    return { configured: true, source: "OPENAI_API_KEY", model: null };
-  }
-
-  return { configured: false, source: null, model: null };
-}
+// Re-export shared LLM detection for CLI consumers
+export { detectLlmConfig as probeLlmConfig, type LlmDetectResult as LlmProbeResult } from "../../shared/llm-detect.js";
 
 // Meilisearch version pinned for reproducibility. Bump deliberately.
 const MEILI_VERSION = "v1.41.0";

--- a/packages/arkeon/src/server/app.ts
+++ b/packages/arkeon/src/server/app.ts
@@ -16,6 +16,7 @@ import { requestContextMiddleware } from "./middleware/request-context";
 import { authMiddleware } from "./middleware/auth";
 import { ApiError, errorBody } from "./lib/errors";
 import { mapPostgresError } from "./lib/pg-errors";
+import { isLlmConfigured } from "./lib/llm";
 import { createSql } from "./lib/sql";
 import { actorsRouter } from "./routes/actors";
 import { adminRouter } from "./routes/admin";
@@ -119,9 +120,9 @@ export function createApp(options?: { adminKey?: string }) {
     try {
       const sql = createSql();
       await sql`SELECT 1`;
-      return c.json({ status: "ready" });
+      return c.json({ status: "ready", llm_configured: isLlmConfigured() });
     } catch {
-      return c.json({ status: "unavailable" }, 503);
+      return c.json({ status: "unavailable", llm_configured: isLlmConfigured() }, 503);
     }
   });
 

--- a/packages/arkeon/src/server/lib/llm.ts
+++ b/packages/arkeon/src/server/lib/llm.ts
@@ -24,6 +24,7 @@ import OpenAI from "openai";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { detectLlmConfig } from "../../shared/llm-detect.js";
 import { getWorkerLlmConfig } from "./worker-config.js";
 
 export type LlmStep = "resolve" | "exists" | "draft" | "dedup";
@@ -184,20 +185,10 @@ export function getLlmClient(step: LlmStep): ResolvedLlm {
  * True if any LLM configuration can be resolved. Lets the route layer
  * decide whether to reject requests that require LLM calls (e.g. a
  * wiki with [[resolve:...]] links) rather than 500 deep in the pipeline.
+ *
+ * Delegates to the shared detection module so CLI and server agree on
+ * what "configured" means.
  */
 export function isLlmConfigured(): boolean {
-  // Check workers.yaml first
-  const workerLlm = getWorkerLlmConfig("resolve");
-  if (workerLlm?.api_key) return true;
-
-  // Fall back to llm.json + env
-  const file = loadConfigFile();
-  const key =
-    file?.default?.api_key ??
-    file?.resolve?.api_key ??
-    file?.exists?.api_key ??
-    file?.draft?.api_key ??
-    file?.dedup?.api_key ??
-    process.env.OPENAI_API_KEY;
-  return Boolean(key);
+  return detectLlmConfig().configured;
 }

--- a/packages/arkeon/src/shared/llm-detect.ts
+++ b/packages/arkeon/src/shared/llm-detect.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * LLM configuration detection — shared between CLI and server.
+ *
+ * This module only reads files and env vars; it does NOT import OpenAI
+ * or any heavy server dependencies, so the CLI can safely use it without
+ * pulling in the server dependency tree.
+ *
+ * Detection mirrors the server's resolution chain:
+ *   workers.yaml (step > worker > global) > llm.json (step > default) > OPENAI_API_KEY env
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import yaml from "js-yaml";
+
+export interface LlmDetectResult {
+  configured: boolean;
+  source: "workers.yaml" | "llm.json" | "OPENAI_API_KEY" | null;
+  model: string | null;
+}
+
+function arkeonHome(): string {
+  return process.env.ARKEON_WIKI_HOME ?? join(homedir(), ".arkeon-wiki");
+}
+
+function workersYamlPath(): string {
+  return process.env.ARKEON_WORKERS_CONFIG ?? join(arkeonHome(), "workers.yaml");
+}
+
+function llmJsonPath(): string {
+  return process.env.WIKI_LLM_CONFIG_PATH ?? join(arkeonHome(), "llm.json");
+}
+
+/**
+ * Check whether any LLM API key is configured, and if so, where it
+ * comes from and what model is set. Checks all layers of the config
+ * stack (workers.yaml step/worker/global, llm.json step/default, env).
+ */
+export function detectLlmConfig(): LlmDetectResult {
+  // ── workers.yaml ──────────────────────────────────────────────
+  const wPath = workersYamlPath();
+  if (existsSync(wPath)) {
+    try {
+      const doc = yaml.load(readFileSync(wPath, "utf-8")) as Record<string, unknown> | null;
+      if (doc) {
+        const globalLlm = (doc.llm ?? {}) as Record<string, unknown>;
+        const workers = (doc.workers ?? {}) as Record<string, unknown>;
+
+        // Check step-level and worker-level api_key in each worker
+        for (const name of ["extractor", "drafter", "consolidator", "connector"]) {
+          const w = workers[name] as Record<string, unknown> | undefined;
+          if (!w) continue;
+
+          // Step-level (extractor only: steps.resolve, steps.exists)
+          const steps = w.steps as Record<string, Record<string, unknown>> | undefined;
+          if (steps) {
+            for (const step of Object.values(steps)) {
+              if (step?.api_key) {
+                return { configured: true, source: "workers.yaml", model: (step.model as string) ?? null };
+              }
+            }
+          }
+
+          // Worker-level llm block
+          const wLlm = w.llm as Record<string, unknown> | undefined;
+          if (wLlm?.api_key) {
+            return { configured: true, source: "workers.yaml", model: (wLlm.model as string) ?? null };
+          }
+        }
+
+        // Global-level llm block
+        if (globalLlm.api_key) {
+          return { configured: true, source: "workers.yaml", model: (globalLlm.model as string) ?? null };
+        }
+      }
+    } catch { /* malformed yaml — fall through */ }
+  }
+
+  // ── llm.json ──────────────────────────────────────────────────
+  const lPath = llmJsonPath();
+  if (existsSync(lPath)) {
+    try {
+      const doc = JSON.parse(readFileSync(lPath, "utf-8")) as Record<string, unknown>;
+      // Check step-level keys first, then default
+      for (const key of ["resolve", "exists", "draft", "dedup", "default"]) {
+        const block = doc[key] as Record<string, unknown> | undefined;
+        if (block?.api_key) {
+          return { configured: true, source: "llm.json", model: (block.model as string) ?? null };
+        }
+      }
+    } catch { /* malformed json — fall through */ }
+  }
+
+  // ── Environment variable ──────────────────────────────────────
+  if (process.env.OPENAI_API_KEY) {
+    return { configured: true, source: "OPENAI_API_KEY", model: null };
+  }
+
+  return { configured: false, source: null, model: null };
+}


### PR DESCRIPTION
## Summary
- Users had no way to check if LLM was configured or how to set it up — `config`, `status`, and API endpoints all silently omitted LLM state
- Add `config get-llm` and `config set-llm-key <key>` CLI commands
- Add LLM probe (`configured`, `source`, `model`) to all `status` output paths
- Include `llm_configured` in `GET /ready` API response
- Extract shared `probeLlmConfig()` into `local-runtime.ts`

## Test plan
- [x] `npm run typecheck` passes
- [x] All 168 unit tests pass
- [ ] `arkeon-wiki status` shows `llm` block
- [ ] `arkeon-wiki config get-llm` shows config state and hint when unconfigured
- [ ] `arkeon-wiki config set-llm-key sk-test` writes to `~/.arkeon-wiki/llm.json`
- [ ] `curl localhost:8000/ready` includes `llm_configured`

🤖 Generated with [Claude Code](https://claude.com/claude-code)