### PR TITLE
fix: preserve entity category through draft pipeline

### DIFF
--- a/packages/arkeon/src/server/lib/workers/draft-gather.ts
+++ b/packages/arkeon/src/server/lib/workers/draft-gather.ts
@@ -67,6 +67,7 @@ export interface PlaceholderInfo {
   label: string;
   description: string | null;
   spaceId: string;
+  subjectType: string | null;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/arkeon/src/server/lib/workers/draft-worker.ts
+++ b/packages/arkeon/src/server/lib/workers/draft-worker.ts
@@ -145,6 +145,7 @@ async function loadPlaceholder(entityId: string): Promise<PlaceholderInfo | null
     label: String(props.label ?? ""),
     description: typeof props.description === "string" ? props.description : null,
     spaceId: entity.space_ids?.[0] ?? "",
+    subjectType: typeof props.subject_type === "string" ? props.subject_type : null,
   };
 }
 
@@ -244,7 +245,8 @@ async function processItem(row: QueueRow): Promise<void> {
     depth: row.depth,
   };
   if (draft.aliases && draft.aliases.length > 0) payload.aliases = draft.aliases;
-  if (draft.subject_type) payload.type = draft.subject_type;
+  const subjectType = draft.subject_type || placeholder.subjectType;
+  if (subjectType) payload.subject_type = subjectType;
 
   const { status, body } = await api.postWiki(payload);
 

--- a/packages/arkeon/src/server/lib/workers/internal-api.ts
+++ b/packages/arkeon/src/server/lib/workers/internal-api.ts
@@ -229,7 +229,7 @@ export async function postWiki(payload: {
   space_id: string;
   depth: number;
   aliases?: string[];
-  type?: string;
+  subject_type?: string;
 }): Promise<{ status: number; body: Record<string, unknown> }> {
   return post<Record<string, unknown>>("/wiki", payload);
 }


### PR DESCRIPTION
## Summary
- **Fixed parameter mismatch**: `postWiki()` in `internal-api.ts` sent category as `type` but the wiki route expects `subject_type` — value was silently dropped on every draft
- **Carry category from placeholder**: `loadPlaceholder()` now extracts `subject_type` from the stub entity and passes it through `PlaceholderInfo`, so the original extraction category is preserved even if the LLM draft omits it
- **Fallback logic**: draft worker uses `draft.subject_type || placeholder.subjectType`, preferring the LLM's classification but falling back to the extraction-time category

## Test plan
- [x] Typecheck passes
- [x] All 168 unit tests pass
- [ ] Run full extract+draft pipeline and verify drafted wikis retain their category (person, place, concept, etc.) instead of falling into `_uncategorized`
- [ ] Verify `arkeon-wiki pull` organizes files into category directories correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)