### PR TITLE
fix: deduplicate placeholders across extraction passes

### DIFF
--- a/packages/arkeon/spec/openapi.snapshot.json
+++ b/packages/arkeon/spec/openapi.snapshot.json
@@ -7327,6 +7327,7 @@
                 "schema": {
                   "properties": {
                     "created": {
+                      "description": "Number of new placeholders created",
                       "type": "integer"
                     },
                     "placeholders": {
@@ -7348,17 +7349,22 @@
                         "type": "object"
                       },
                       "type": "array"
+                    },
+                    "reused": {
+                      "description": "Number of existing placeholders/wikis reused (deduplication)",
+                      "type": "integer"
                     }
                   },
                   "required": [
                     "created",
+                    "reused",
                     "placeholders"
                   ],
                   "type": "object"
                 }
               }
             },
-            "description": "Placeholders created"
+            "description": "Placeholders created (or reused if duplicates existed)"
           },
           "400": {
             "content": {

--- a/packages/arkeon/src/server/lib/workers/draft-worker.ts
+++ b/packages/arkeon/src/server/lib/workers/draft-worker.ts
@@ -178,7 +178,10 @@ async function processItem(row: QueueRow): Promise<void> {
 
   console.log(`${tag} processing "${placeholder.label}" (depth=${row.depth}, attempt=${row.attempts})`);
 
-  // --- Step 1: Reconcile — does a wiki already cover this subject? ---
+  // --- Step 1: Reconcile — does a published wiki already cover this subject? ---
+  // Only check wikis, not other placeholders. If no wiki exists, the first
+  // placeholder through drafts one. Subsequent duplicates find that wiki and
+  // merge into it, preserving the original wiki's content.
   let reconcileCandidates: EntityMatch[] = [];
   try {
     reconcileCandidates = await findSimilarEntities(
@@ -194,6 +197,18 @@ async function processItem(row: QueueRow): Promise<void> {
     if (reconcileCandidates.length > 0 && reconcileCandidates[0]!.confidence >= 0.8) {
       const match = reconcileCandidates[0]!;
       console.log(`${tag} reconcile match: ${match.id} (confidence=${match.confidence})`);
+      // Merge transfers relationships from this placeholder to the wiki,
+      // creates a redirect, and deletes the placeholder.
+      const target = await api.getWikiEntity(match.id);
+      if (target) {
+        const { status } = await api.postMerge(target.id, placeholder.id, target.ver);
+        if (status === 200) {
+          console.log(`${tag} merged into ${target.id}`);
+          await markComplete(row.entity_id, { mergedInto: target.id });
+          return;
+        }
+        console.warn(`${tag} merge returned ${status}, falling back to redirect`);
+      }
       await api.postRedirect(placeholder.id, match.id);
       await markComplete(row.entity_id, { mergedInto: match.id });
       return;

--- a/packages/arkeon/src/server/lib/workers/draft-worker.ts
+++ b/packages/arkeon/src/server/lib/workers/draft-worker.ts
@@ -201,13 +201,13 @@ async function processItem(row: QueueRow): Promise<void> {
       // creates a redirect, and deletes the placeholder.
       const target = await api.getWikiEntity(match.id);
       if (target) {
-        const { status } = await api.postMerge(target.id, placeholder.id, target.ver);
+        const { status, body: mergeBody } = await api.postMerge(target.id, placeholder.id, target.ver);
         if (status === 200) {
           console.log(`${tag} merged into ${target.id}`);
           await markComplete(row.entity_id, { mergedInto: target.id });
           return;
         }
-        console.warn(`${tag} merge returned ${status}, falling back to redirect`);
+        console.warn(`${tag} merge returned ${status}, falling back to redirect:`, JSON.stringify(mergeBody).slice(0, 300));
       }
       await api.postRedirect(placeholder.id, match.id);
       await markComplete(row.entity_id, { mergedInto: match.id });

--- a/packages/arkeon/src/server/lib/workers/extract-worker.ts
+++ b/packages/arkeon/src/server/lib/workers/extract-worker.ts
@@ -278,6 +278,28 @@ async function processItem(row: QueueRow): Promise<void> {
   const existing = await fetchExistingExtractions(source.id);
   const existingLabels = new Set(existing.map((e) => normalizeLabel(e.label)));
 
+  // Also check all placeholders/wikis in the space — catches cross-source duplicates
+  const spaceEntities = await api.listEntities({
+    space_id: source.spaceId,
+    filter: "type:placeholder,type:wiki",
+    limit: 200,
+    view: "summary",
+  });
+  for (const e of spaceEntities) {
+    const props = e.properties ?? {};
+    const label = String(props.label ?? "");
+    if (label && !existingLabels.has(normalizeLabel(label))) {
+      existingLabels.add(normalizeLabel(label));
+      // Add to the existing array so the LLM knows about them too
+      existing.push({
+        id: e.id,
+        label,
+        description: String(props.description ?? ""),
+        subjectType: String(props.subject_type ?? ""),
+      });
+    }
+  }
+
   console.log(
     `${tag} extracting from "${source.label}" (${source.content.length} chars, ${existing.length} already extracted)`,
   );
@@ -323,9 +345,13 @@ async function processItem(row: QueueRow): Promise<void> {
     throw new Error(`POST /wiki/placeholders returned ${status}: ${errMsg}`);
   }
 
-  const created = placeholderResult.created;
+  const { created, reused } = placeholderResult;
 
-  console.log(`${tag} created ${created} new placeholders, queued for drafting`);
+  console.log(
+    `${tag} ${created} new placeholders created` +
+    (reused > 0 ? `, ${reused} reused (deduped)` : "") +
+    `, queued for drafting`,
+  );
   await markComplete(row.entity_id, created);
 }
 

--- a/packages/arkeon/src/server/lib/workers/extract-worker.ts
+++ b/packages/arkeon/src/server/lib/workers/extract-worker.ts
@@ -278,11 +278,14 @@ async function processItem(row: QueueRow): Promise<void> {
   const existing = await fetchExistingExtractions(source.id);
   const existingLabels = new Set(existing.map((e) => normalizeLabel(e.label)));
 
-  // Also check all placeholders/wikis in the space — catches cross-source duplicates
+  // Also check all placeholders/wikis in the space — catches cross-source duplicates.
+  // Belt-and-suspenders: POST /wiki/placeholders has the authoritative upsert guard;
+  // this is an optimization to avoid unnecessary LLM extraction + API calls.
+  // TODO: paginate via cursor for spaces with 1000+ entities.
   const spaceEntities = await api.listEntities({
     space_id: source.spaceId,
     filter: "type:placeholder,type:wiki",
-    limit: 200,
+    limit: 1000,
     view: "summary",
   });
   for (const e of spaceEntities) {

--- a/packages/arkeon/src/server/lib/workers/internal-api.ts
+++ b/packages/arkeon/src/server/lib/workers/internal-api.ts
@@ -246,8 +246,8 @@ export async function postPlaceholders(
   }>,
   spaceId: string,
   opts?: { enqueueDraft?: boolean },
-): Promise<{ status: number; body: { created: number; placeholders: Array<{ id: string; label: string }> } }> {
-  return post<{ created: number; placeholders: Array<{ id: string; label: string }> }>(
+): Promise<{ status: number; body: { created: number; reused: number; placeholders: Array<{ id: string; label: string }> } }> {
+  return post<{ created: number; reused: number; placeholders: Array<{ id: string; label: string }> }>(
     "/wiki/placeholders",
     { placeholders, space_id: spaceId, enqueue_draft: opts?.enqueueDraft },
   );
@@ -261,6 +261,21 @@ export async function postRedirect(
   targetId: string,
 ): Promise<{ status: number; body: Record<string, unknown> }> {
   return post<Record<string, unknown>>(`/wiki/${oldId}/redirect`, { target_id: targetId });
+}
+
+/**
+ * Merge source entity into target (transfers relationships, creates redirect, deletes source).
+ */
+export async function postMerge(
+  targetId: string,
+  sourceId: string,
+  targetVer: number,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  return post<Record<string, unknown>>(`/wiki/${targetId}/merge`, {
+    source_id: sourceId,
+    ver: targetVer,
+    property_strategy: "accumulate",
+  });
 }
 
 // Re-export the ApiEntity type for consumers

--- a/packages/arkeon/src/server/routes/entities.ts
+++ b/packages/arkeon/src/server/routes/entities.ts
@@ -1521,9 +1521,16 @@ wikisRouter.openapi(createPlaceholdersRoute, async (c) => {
         created.push({ id: phId, label: ph.label });
       }
 
-      // Always create relationships (links this source to the entity)
+      // Always create relationships (links this source to the entity).
+      // Skip if an identical edge already exists (same-source re-extraction).
       if (ph.relationships) {
         for (const rel of ph.relationships) {
+          const dupeCheck = await tx`
+            SELECT 1 FROM relationship_edges
+            WHERE source_id = ${phId} AND target_id = ${rel.target_id} AND predicate = ${rel.predicate}
+            LIMIT 1`;
+          if (dupeCheck.length > 0) continue;
+
           const relId = generateUlid();
           const relProps: Record<string, unknown> = {};
           if (rel.detail) relProps.detail = rel.detail;

--- a/packages/arkeon/src/server/routes/entities.ts
+++ b/packages/arkeon/src/server/routes/entities.ts
@@ -44,7 +44,7 @@ import {
   queryParam,
 } from "../lib/schemas";
 import { setActorContext } from "../lib/actor-context";
-import { createSql } from "../lib/sql";
+import { createSql, withTransaction } from "../lib/sql";
 import type { Actor } from "../types";
 import {
   processWikiContent,
@@ -1425,10 +1425,11 @@ const createPlaceholdersRoute = createRoute({
   },
   responses: {
     201: {
-      description: "Placeholders created",
+      description: "Placeholders created (or reused if duplicates existed)",
       content: jsonContent(
         z.object({
-          created: z.number().int(),
+          created: z.number().int().describe("Number of new placeholders created"),
+          reused: z.number().int().describe("Number of existing placeholders/wikis reused (deduplication)"),
           placeholders: z.array(z.object({ id: UlidSchema, label: z.string() })),
         }),
       ),
@@ -1460,16 +1461,42 @@ wikisRouter.openapi(createPlaceholdersRoute, async (c) => {
     throw new ApiError(400, "missing_required_field", "space_id is required");
   }
 
-  const sql = createSql();
   const now = new Date().toISOString();
-  const created: Array<{ id: string; label: string }> = [];
 
-  await sql.transaction([
-    ...setActorContext(sql, actor),
-    ...(function buildQueries() {
-      const queries: ReturnType<typeof sql.query>[] = [];
-      for (const ph of body.placeholders) {
-        const phId = generateUlid();
+  const result = await withTransaction(async (tx) => {
+    for (const q of setActorContext(tx, actor)) await q;
+
+    // Batch-query existing placeholders/wikis in this space with matching labels
+    const requestedLabels = body.placeholders.map((ph) => ph.label.trim().toLowerCase());
+    const existingRows = await tx`
+      SELECT e.id, lower(trim(e.properties->>'label')) AS norm_label
+      FROM entities e
+      JOIN space_entities se ON se.entity_id = e.id
+      WHERE se.space_id = ${body.space_id}
+        AND e.kind = 'entity'
+        AND e.type IN ('placeholder', 'wiki')
+        AND lower(trim(e.properties->>'label')) = ANY(${requestedLabels})
+    `;
+    const existingByLabel = new Map<string, string>();
+    for (const row of existingRows) {
+      existingByLabel.set(String(row.norm_label), String(row.id));
+    }
+
+    const created: Array<{ id: string; label: string }> = [];
+    const reused: Array<{ id: string; label: string }> = [];
+
+    for (const ph of body.placeholders) {
+      const normLabel = ph.label.trim().toLowerCase();
+      const existingId = existingByLabel.get(normLabel);
+      let phId: string;
+
+      if (existingId) {
+        // Reuse existing entity — skip INSERT
+        phId = existingId;
+        reused.push({ id: phId, label: ph.label });
+      } else {
+        // Create new placeholder entity
+        phId = generateUlid();
         const phProps: Record<string, unknown> = {
           label: ph.label,
           status: "assigned",
@@ -1477,69 +1504,62 @@ wikisRouter.openapi(createPlaceholdersRoute, async (c) => {
         if (ph.description) phProps.description = ph.description;
         if (ph.subject_type) phProps.subject_type = ph.subject_type;
 
-        // Create placeholder entity
-        queries.push(
-          sql`INSERT INTO entities (
+        await tx`INSERT INTO entities (
+          id, kind, type, ver, properties, owner_id,
+          edited_by, note, created_at, updated_at
+        ) VALUES (
+          ${phId}, 'entity', 'placeholder', 1, ${phProps}::jsonb, ${actor.id},
+          ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
+        )`;
+
+        await tx`INSERT INTO space_entities (space_id, entity_id, added_by, added_at)
+          VALUES (${body.space_id}, ${phId}, ${actor.id}, ${now}::timestamptz)
+          ON CONFLICT (space_id, entity_id) DO NOTHING`;
+
+        // Track this new entity so later placeholders in the same batch dedup
+        existingByLabel.set(normLabel, phId);
+        created.push({ id: phId, label: ph.label });
+      }
+
+      // Always create relationships (links this source to the entity)
+      if (ph.relationships) {
+        for (const rel of ph.relationships) {
+          const relId = generateUlid();
+          const relProps: Record<string, unknown> = {};
+          if (rel.detail) relProps.detail = rel.detail;
+
+          await tx`INSERT INTO entities (
             id, kind, type, ver, properties, owner_id,
             edited_by, note, created_at, updated_at
           ) VALUES (
-            ${phId}, 'entity', 'placeholder', 1, ${phProps}::jsonb, ${actor.id},
-            ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
-          )`,
-        );
-
-        // Add to space
-        queries.push(
-          sql`INSERT INTO space_entities (space_id, entity_id, added_by, added_at)
-            VALUES (${body.space_id}, ${phId}, ${actor.id}, ${now}::timestamptz)
-            ON CONFLICT (space_id, entity_id) DO NOTHING`,
-        );
-
-        // Create relationships
-        if (ph.relationships) {
-          for (const rel of ph.relationships) {
-            const relId = generateUlid();
-            const relProps: Record<string, unknown> = {};
-            if (rel.detail) relProps.detail = rel.detail;
-
-            queries.push(
-              sql`INSERT INTO entities (
-                id, kind, type, ver, properties, owner_id,
-                edited_by, note, created_at, updated_at
-              ) VALUES (
-                ${relId}, 'relationship', 'relationship', 1, ${relProps}::jsonb,
-                ${actor.id}, ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
-              )`,
-            );
-            queries.push(
-              sql`INSERT INTO relationship_edges (id, source_id, target_id, predicate)
-                VALUES (${relId}, ${phId}, ${rel.target_id}, ${rel.predicate})`,
-            );
-            queries.push(
-              sql`INSERT INTO space_entities (space_id, entity_id, added_by, added_at)
-                VALUES (${body.space_id}, ${relId}, ${actor.id}, ${now}::timestamptz)
-                ON CONFLICT (space_id, entity_id) DO NOTHING`,
-            );
-          }
+            ${relId}, 'relationship', 'relationship', 1, ${relProps}::jsonb,
+            ${actor.id}, ${actor.id}, NULL, ${now}::timestamptz, ${now}::timestamptz
+          )`;
+          await tx`INSERT INTO relationship_edges (id, source_id, target_id, predicate)
+            VALUES (${relId}, ${phId}, ${rel.target_id}, ${rel.predicate})`;
+          await tx`INSERT INTO space_entities (space_id, entity_id, added_by, added_at)
+            VALUES (${body.space_id}, ${relId}, ${actor.id}, ${now}::timestamptz)
+            ON CONFLICT (space_id, entity_id) DO NOTHING`;
         }
-
-        // Optionally enqueue for drafting in the same transaction
-        if (body.enqueue_draft) {
-          const deadline = new Date(Date.now() + 3600_000).toISOString();
-          queries.push(
-            sql`INSERT INTO wiki_draft_queue (entity_id, depth, owner_agent, deadline, status, created_at)
-              VALUES (${phId}, 0, ${actor.id}, ${deadline}::timestamptz, 'pending', ${now}::timestamptz)
-              ON CONFLICT (entity_id) DO NOTHING`,
-          );
-        }
-
-        created.push({ id: phId, label: ph.label });
       }
-      return queries;
-    })(),
-  ]);
 
-  return c.json({ created: created.length, placeholders: created }, 201);
+      // Enqueue for drafting (ON CONFLICT DO NOTHING handles already-queued)
+      if (body.enqueue_draft) {
+        const deadline = new Date(Date.now() + 3600_000).toISOString();
+        await tx`INSERT INTO wiki_draft_queue (entity_id, depth, owner_agent, deadline, status, created_at)
+          VALUES (${phId}, 0, ${actor.id}, ${deadline}::timestamptz, 'pending', ${now}::timestamptz)
+          ON CONFLICT (entity_id) DO NOTHING`;
+      }
+    }
+
+    return { created, reused };
+  });
+
+  return c.json({
+    created: result.created.length,
+    reused: result.reused.length,
+    placeholders: [...result.created, ...result.reused],
+  }, 201);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/arkeon/test/e2e/placeholder-dedup.test.ts
+++ b/packages/arkeon/test/e2e/placeholder-dedup.test.ts
@@ -1,0 +1,221 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * E2E tests for placeholder deduplication.
+ *
+ * Verifies that POST /wiki/placeholders upserts instead of creating
+ * duplicates when placeholders with the same label already exist.
+ *
+ * Requires a running stack:
+ *   npm run test:e2e -- placeholder-dedup
+ */
+
+import { describe, expect, test } from "vitest";
+import {
+  adminApiKey,
+  createActor,
+  createSpace,
+  createWiki,
+  getJson,
+  jsonRequest,
+  uniqueName,
+} from "./helpers";
+
+describe("Placeholder deduplication", () => {
+  let actor: Awaited<ReturnType<typeof createActor>>;
+  let spaceId: string;
+
+  test("setup: create actor and space", async () => {
+    actor = await createActor(adminApiKey);
+    const space = await createSpace(actor.apiKey, uniqueName("dedup-space"));
+    spaceId = space.id;
+  });
+
+  test("same label in one batch creates only one placeholder", async () => {
+    const label = uniqueName("BatchDup");
+    const { response, body } = await jsonRequest("/wiki/placeholders", {
+      method: "POST",
+      apiKey: actor.apiKey,
+      json: {
+        space_id: spaceId,
+        placeholders: [
+          { label, description: "First" },
+          { label, description: "Second" },
+          { label, description: "Third" },
+        ],
+      },
+    });
+
+    expect(response.status).toBe(201);
+    const data = body as any;
+    expect(data.created).toBe(1);
+    expect(data.reused).toBe(2);
+    expect(data.placeholders).toHaveLength(3);
+
+    // All three should share the same entity ID
+    const ids = data.placeholders.map((p: any) => p.id);
+    expect(new Set(ids).size).toBe(1);
+  });
+
+  test("second request with same label reuses existing placeholder", async () => {
+    const label = uniqueName("CrossReqDup");
+
+    // First request — creates the placeholder
+    const { response: r1, body: b1 } = await jsonRequest("/wiki/placeholders", {
+      method: "POST",
+      apiKey: actor.apiKey,
+      json: {
+        space_id: spaceId,
+        placeholders: [{ label, description: "Pass 1" }],
+      },
+    });
+    expect(r1.status).toBe(201);
+    const d1 = b1 as any;
+    expect(d1.created).toBe(1);
+    expect(d1.reused).toBe(0);
+    const originalId = d1.placeholders[0].id;
+
+    // Second request — same label, should reuse
+    const { response: r2, body: b2 } = await jsonRequest("/wiki/placeholders", {
+      method: "POST",
+      apiKey: actor.apiKey,
+      json: {
+        space_id: spaceId,
+        placeholders: [{ label, description: "Pass 2" }],
+      },
+    });
+    expect(r2.status).toBe(201);
+    const d2 = b2 as any;
+    expect(d2.created).toBe(0);
+    expect(d2.reused).toBe(1);
+    expect(d2.placeholders[0].id).toBe(originalId);
+  });
+
+  test("case-insensitive dedup (Church vs church vs CHURCH)", async () => {
+    const base = uniqueName("CaseDup");
+
+    const { response, body } = await jsonRequest("/wiki/placeholders", {
+      method: "POST",
+      apiKey: actor.apiKey,
+      json: {
+        space_id: spaceId,
+        placeholders: [
+          { label: base, description: "Original" },
+          { label: base.toLowerCase(), description: "Lowercase" },
+          { label: base.toUpperCase(), description: "Uppercase" },
+        ],
+      },
+    });
+
+    expect(response.status).toBe(201);
+    const data = body as any;
+    expect(data.created).toBe(1);
+    expect(data.reused).toBe(2);
+  });
+
+  test("reused placeholder still gets relationships created", async () => {
+    const label = uniqueName("RelDup");
+
+    // Create a "source" wiki to serve as relationship target
+    const source = await createWiki(actor.apiKey, uniqueName("source-doc"), "Source document content.", {
+      space_id: spaceId,
+    });
+
+    // First request — creates the placeholder with a relationship
+    const { body: b1 } = await jsonRequest("/wiki/placeholders", {
+      method: "POST",
+      apiKey: actor.apiKey,
+      json: {
+        space_id: spaceId,
+        placeholders: [{
+          label,
+          description: "Extracted subject",
+          relationships: [
+            { target_id: source.id, predicate: "extracted_from", detail: "Pass 1" },
+          ],
+        }],
+      },
+    });
+    const d1 = b1 as any;
+    expect(d1.created).toBe(1);
+    const phId = d1.placeholders[0].id;
+
+    // Second request — same label, should reuse but still create the relationship
+    const source2 = await createWiki(actor.apiKey, uniqueName("source-doc-2"), "Second source document.", {
+      space_id: spaceId,
+    });
+    const { body: b2 } = await jsonRequest("/wiki/placeholders", {
+      method: "POST",
+      apiKey: actor.apiKey,
+      json: {
+        space_id: spaceId,
+        placeholders: [{
+          label,
+          description: "Same subject from different source",
+          relationships: [
+            { target_id: source2.id, predicate: "extracted_from", detail: "Pass 2" },
+          ],
+        }],
+      },
+    });
+    const d2 = b2 as any;
+    expect(d2.created).toBe(0);
+    expect(d2.reused).toBe(1);
+    expect(d2.placeholders[0].id).toBe(phId);
+
+    // Check that both extracted_from relationships exist
+    const { body: relBody } = await getJson(
+      `/wiki/${phId}/relationships?direction=out&predicate=extracted_from`,
+      actor.apiKey,
+    );
+    const rels = (relBody as any).relationships;
+    expect(rels.length).toBe(2);
+    const targetIds = rels.map((r: any) => r.target_id);
+    expect(targetIds).toContain(source.id);
+    expect(targetIds).toContain(source2.id);
+  });
+
+  test("published wiki prevents duplicate placeholder", async () => {
+    const label = uniqueName("WikiExists");
+
+    // Create a published wiki with this label
+    await createWiki(actor.apiKey, label, `Wiki article about ${label}.`, {
+      space_id: spaceId,
+    });
+
+    // Try to create a placeholder with the same label — should reuse the wiki
+    const { response, body } = await jsonRequest("/wiki/placeholders", {
+      method: "POST",
+      apiKey: actor.apiKey,
+      json: {
+        space_id: spaceId,
+        placeholders: [{ label, description: "Should hit existing wiki" }],
+      },
+    });
+    expect(response.status).toBe(201);
+    const data = body as any;
+    expect(data.created).toBe(0);
+    expect(data.reused).toBe(1);
+  });
+
+  test("different labels create separate placeholders", async () => {
+    const { response, body } = await jsonRequest("/wiki/placeholders", {
+      method: "POST",
+      apiKey: actor.apiKey,
+      json: {
+        space_id: spaceId,
+        placeholders: [
+          { label: uniqueName("Distinct-A"), description: "First subject" },
+          { label: uniqueName("Distinct-B"), description: "Second subject" },
+        ],
+      },
+    });
+
+    expect(response.status).toBe(201);
+    const data = body as any;
+    expect(data.created).toBe(2);
+    expect(data.reused).toBe(0);
+    expect(new Set(data.placeholders.map((p: any) => p.id)).size).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- **POST /wiki/placeholders upsert**: Before inserting, queries the space for existing placeholders/wikis with matching normalized labels. Reuses existing entity IDs instead of creating duplicates. Still creates `extracted_from` relationships and enqueues for drafting. Returns `reused` count alongside `created`.
- **Extract worker broadened dedup**: Now queries all placeholders/wikis in the space (not just same-source extractions) before calling the LLM, so it skips known subjects.
- **Draft worker merge on reconcile**: When a published wiki matches a placeholder, uses `postMerge` (transfers relationships, repoints edges, creates redirect, deletes placeholder) instead of bare redirect. Falls back to redirect if merge fails.
- **E2E tests**: 7 new tests covering same-batch dedup, cross-request dedup, case-insensitivity, relationship preservation on reuse, wiki-blocks-placeholder, and distinct labels staying separate.

## Test plan

- [x] `npm run typecheck` passes
- [x] 168 unit tests pass
- [x] 7 new e2e tests pass against a live instance (`placeholder-dedup.test.ts`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)