### PR TITLE
feat: switch wiki frontmatter from JSON to YAML

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Filesystem-first knowledge graph. You point it at directories, it watches for ch
 1. `arkeon-wiki up` — starts SQLite database + API server as a detached background daemon (survives the terminal closing)
 2. `arkeon-wiki init` — registers the current directory as a space; the daemon starts watching it
 3. You add/edit/delete files — the file watcher detects changes and syncs to SQLite automatically
-4. Wiki files (`wiki/**/*.md`) use JSON frontmatter for structured metadata and standard markdown links for cross-references
+4. Wiki files (`wiki/**/*.md`) use YAML frontmatter for structured metadata and standard markdown links for cross-references
 5. Links between wiki files become relationship edges in SQLite
 
 There are no manual sync commands. The filesystem is the source of truth.
@@ -36,13 +36,13 @@ Two npm workspaces. Only one is published.
 
 ```markdown
 ---
-{
-  "id": "01JSG...",
-  "label": "Claude Shannon",
-  "subject_type": "person",
-  "birth_year": 1916,
-  "fields": ["mathematics", "information theory"]
-}
+id: 01JSG...
+label: Claude Shannon
+subject_type: person
+birth_year: 1916
+fields:
+  - mathematics
+  - information theory
 ---
 
 Claude Shannon was the father of information theory.
@@ -50,7 +50,8 @@ Claude Shannon was the father of information theory.
 He worked at [Bell Labs](../organization/bell-labs.md).
 ```
 
-- JSON between `---` fences (not YAML). Properties stored as JSON text in SQLite.
+- YAML between `---` fences. Parsed with js-yaml's `JSON_SCHEMA` so values map cleanly to JSON-compatible types (no Norway problem — `country: NO` stays the string `"NO"`). Properties are serialized to JSON text in SQLite.
+- Supports nested mappings, sequences, multi-line strings (`|` literal, `>` folded), and `#` comments.
 - `id` is auto-generated on first sync if missing, written back to the file.
 - `label` is required. Everything else is arbitrary.
 - Standard markdown links (`[text](path.md)`) become relationship edges.
@@ -69,7 +70,7 @@ No actors, no auth, no queues, no versioning. Schema in `src/schema/001-foundati
 
 - `src/server/lib/sync.ts` — `syncFile()`: the core primitive. Reads a file, parses frontmatter, upserts entity, resolves links to relationship edges.
 - `src/server/lib/fs-watcher.ts` — watches registered directories, debounces changes, calls `syncFile()` / `removeByPath()`.
-- `src/server/lib/frontmatter.ts` — parse/serialize JSON frontmatter.
+- `src/server/lib/frontmatter.ts` — parse/serialize YAML frontmatter.
 - `src/server/lib/markdown-links.ts` — extract and resolve markdown links.
 
 ## API endpoints

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,9 +52,12 @@ He worked at [Bell Labs](../organization/bell-labs.md).
 
 - YAML between `---` fences. Parsed with js-yaml's `JSON_SCHEMA` so values map cleanly to JSON-compatible types (no Norway problem — `country: NO` stays the string `"NO"`). Properties are serialized to JSON text in SQLite.
 - Supports nested mappings, sequences, multi-line strings (`|` literal, `>` folded), and `#` comments.
+- **Quote numeric-looking strings** you want to keep as strings (e.g. `version: "1.10"` — unquoted `1.10` becomes the float `1.1`). The serializer is defensive on the way out — IDs and digit-only strings are auto-quoted on write — but on read, what you write is what you get.
 - `id` is auto-generated on first sync if missing, written back to the file.
 - `label` is required. Everything else is arbitrary.
 - Standard markdown links (`[text](path.md)`) become relationship edges.
+
+YAML is a superset of JSON, so wikis written with the old JSON-style frontmatter (`---\n{ ... }\n---`) still parse correctly. The first sync that writes back a generated `id` will rewrite the file in YAML form — heads-up if you have uncommitted changes to a wiki that was authored with JSON frontmatter.
 
 ## Schema
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arkeon Wiki
 
-A knowledge graph that lives in your filesystem. Point it at a directory, and it watches for changes, indexes files into Postgres, and builds a connected graph from markdown links between them.
+A knowledge graph that lives in your filesystem. Point it at a directory, and it watches for changes, indexes files into SQLite, and builds a connected graph from markdown links between them.
 
 ## Quick start
 
@@ -11,7 +11,7 @@ npm install -g arkeon-wiki
 arkeon-wiki start
 ```
 
-First run downloads embedded Postgres (~50MB, cached). The daemon runs in the foreground — `Ctrl+C` to stop.
+The daemon runs in the foreground — `Ctrl+C` to stop. State (SQLite database, pidfile, log) lives in `~/.arkeon-wiki/`.
 
 **2. Register a directory**
 
@@ -41,7 +41,7 @@ He worked at [Bell Labs](../organization/bell-labs.md).
 The system automatically:
 - Detects new files and indexes them
 - Generates stable IDs and writes them back to the frontmatter
-- Resolves markdown links between files into relationship edges in Postgres
+- Resolves markdown links between files into relationship edges in SQLite
 - Detects edits and re-syncs
 - Detects deletions and cleans up
 
@@ -57,32 +57,35 @@ curl http://localhost:8000/entities?type=wiki     # filter by type
 
 ## How it works
 
-The filesystem is the source of truth. Postgres is an index.
+The filesystem is the source of truth. SQLite is an index.
 
 - **Spaces** are directories registered with the daemon
 - **Entities** are files on disk — wikis (under `wiki/`) have YAML frontmatter, everything else is a source file
-- **Relationships** are standard markdown links (`[text](path.md)`) resolved into edges in Postgres
+- **Relationships** are standard markdown links (`[text](path.md)`) resolved into edges in SQLite
 - A file watcher detects changes in real-time; a reconciliation pass on startup catches anything missed
 
 ## CLI
 
 ```bash
-arkeon-wiki start              # start the daemon (Postgres + API)
-arkeon-wiki stop               # stop it
+arkeon-wiki up                 # start the daemon detached (SQLite + API)
+arkeon-wiki down               # stop it
 arkeon-wiki status             # check if running
+arkeon-wiki ls                 # list running instances
+arkeon-wiki logs [-f]          # print/tail the daemon log
 arkeon-wiki init [name]        # register current directory as a space
+arkeon-wiki start              # foreground (for use under pm2/launchd/etc.)
 ```
 
 ## Configuration
 
-All state lives in `~/.arkeon-wiki/` (override with `ARKEON_WIKI_HOME`).
+All state lives in `~/.arkeon-wiki/` (override with `ARKEON_WIKI_HOME` or `--data-dir`).
 
 | Config | Purpose |
 |--------|---------|
-| `DATABASE_URL` env var | Use external Postgres instead of embedded |
 | `ARKEON_WIKI_HOME` env var | Override state directory |
+| `--data-dir <path>` flag | Per-invocation override |
 | `--port <port>` flag | API port (default: 8000) |
-| `--pg-port <port>` flag | Embedded Postgres port (default: 5433) |
+| `--name <name>` flag | Run a named instance side-by-side with others |
 
 ## Development
 
@@ -98,7 +101,7 @@ npx tsx packages/arkeon/src/index.ts start
 ```bash
 npm run typecheck -w packages/arkeon    # type checking
 npm test -w packages/arkeon             # unit tests
-npm run test:e2e -w packages/arkeon     # e2e tests (spins up its own Postgres)
+npm run test:e2e -w packages/arkeon     # e2e tests (spins up SQLite + API in-process)
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -24,15 +24,13 @@ This registers the directory as a space. The daemon immediately starts watching 
 
 **3. Add wiki files**
 
-Create markdown files with JSON frontmatter under `wiki/`:
+Create markdown files with YAML frontmatter under `wiki/`:
 
 ```markdown
 ---
-{
-  "label": "Claude Shannon",
-  "subject_type": "person",
-  "birth_year": 1916
-}
+label: Claude Shannon
+subject_type: person
+birth_year: 1916
 ---
 
 Claude Shannon was the father of information theory.
@@ -62,7 +60,7 @@ curl http://localhost:8000/entities?type=wiki     # filter by type
 The filesystem is the source of truth. Postgres is an index.
 
 - **Spaces** are directories registered with the daemon
-- **Entities** are files on disk — wikis (under `wiki/`) have JSON frontmatter, everything else is a source file
+- **Entities** are files on disk — wikis (under `wiki/`) have YAML frontmatter, everything else is a source file
 - **Relationships** are standard markdown links (`[text](path.md)`) resolved into edges in Postgres
 - A file watcher detects changes in real-time; a reconciliation pass on startup catches anything missed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1561,6 +1561,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
@@ -1779,6 +1786,12 @@
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/arkeon-wiki": {
       "resolved": "packages/arkeon",
@@ -2564,6 +2577,18 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -4737,6 +4762,7 @@
         "conf": "^13.0.1",
         "dotenv": "^17.3.1",
         "hono": "^4.12.9",
+        "js-yaml": "^4.1.1",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -4744,6 +4770,7 @@
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^24.6.0",
         "tsup": "^8.5.0",
         "tsx": "^4.20.5",
@@ -4762,12 +4789,14 @@
         "graphology": "^0.25.4",
         "graphology-layout-forceatlas2": "^0.10.1",
         "graphology-types": "^0.24.7",
+        "js-yaml": "^4.1.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "sigma": "^3.0.0"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
+        "@types/js-yaml": "^4.0.9",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.0.0",

--- a/packages/arkeon/package.json
+++ b/packages/arkeon/package.json
@@ -41,10 +41,12 @@
     "conf": "^13.0.1",
     "dotenv": "^17.3.1",
     "hono": "^4.12.9",
+    "js-yaml": "^4.1.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.6.0",
     "tsup": "^8.5.0",
     "tsx": "^4.20.5",

--- a/packages/arkeon/src/server/lib/frontmatter.ts
+++ b/packages/arkeon/src/server/lib/frontmatter.ts
@@ -2,20 +2,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * JSON frontmatter parser/serializer.
+ * YAML frontmatter parser/serializer.
  *
- * Wiki files use JSON between --- fences for structured metadata:
+ * Wiki files use YAML between --- fences for structured metadata:
  *
  *   ---
- *   {
- *     "id": "01JSG...",
- *     "label": "Claude Shannon",
- *     "subject_type": "person"
- *   }
+ *   id: 01JSG...
+ *   label: Claude Shannon
+ *   subject_type: person
+ *   fields:
+ *     - mathematics
+ *     - information theory
  *   ---
  *
  *   Markdown body here...
+ *
+ * We use js-yaml's JSON_SCHEMA so values map cleanly to JSON-compatible types
+ * (string, number, bool, null, array, object) and we don't get the "Norway
+ * problem" where `country: NO` becomes the boolean false.
  */
+
+import yaml from "js-yaml";
 
 export interface ParsedWiki {
   /** Frontmatter properties (id, label, and arbitrary metadata). */
@@ -25,19 +32,17 @@ export interface ParsedWiki {
 }
 
 /**
- * Parse a markdown file with JSON frontmatter.
+ * Parse a markdown file with YAML frontmatter.
  * Returns the parsed properties and the body content.
- * Throws if the frontmatter is not valid JSON.
+ * Throws if the frontmatter is not valid YAML or is not a mapping.
  */
 export function parseFrontmatter(content: string): ParsedWiki {
   const trimmed = content.trimStart();
 
   if (!trimmed.startsWith("---")) {
-    // No frontmatter — treat entire content as body, no properties
     return { properties: {}, body: content };
   }
 
-  // Find the closing ---
   const firstNewline = trimmed.indexOf("\n");
   if (firstNewline === -1) {
     return { properties: {}, body: content };
@@ -47,33 +52,41 @@ export function parseFrontmatter(content: string): ParsedWiki {
   const closingIndex = rest.indexOf("\n---");
 
   if (closingIndex === -1) {
-    // No closing fence — treat as no frontmatter
     return { properties: {}, body: content };
   }
 
-  const jsonStr = rest.slice(0, closingIndex).trim();
-  const body = rest.slice(closingIndex + 4).replace(/^\n/, ""); // skip the \n--- and optional leading newline
+  const yamlStr = rest.slice(0, closingIndex);
+  const body = rest.slice(closingIndex + 4).replace(/^\n/, "");
 
-  let properties: Record<string, unknown>;
+  let parsed: unknown;
   try {
-    properties = JSON.parse(jsonStr);
+    parsed = yaml.load(yamlStr, { schema: yaml.JSON_SCHEMA });
   } catch (err) {
-    throw new Error(`Invalid JSON in frontmatter: ${(err as Error).message}`);
+    throw new Error(`Invalid YAML in frontmatter: ${(err as Error).message}`);
   }
 
-  if (typeof properties !== "object" || properties === null || Array.isArray(properties)) {
-    throw new Error("Frontmatter JSON must be an object");
+  if (parsed === null || parsed === undefined) {
+    return { properties: {}, body };
   }
 
-  return { properties, body };
+  if (typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Frontmatter YAML must be a mapping (key: value pairs)");
+  }
+
+  return { properties: parsed as Record<string, unknown>, body };
 }
 
 /**
- * Serialize properties and body back into a markdown file with JSON frontmatter.
+ * Serialize properties and body back into a markdown file with YAML frontmatter.
+ * Uses block style for readability; preserves insertion order of keys.
  */
 export function serializeFrontmatter(properties: Record<string, unknown>, body: string): string {
-  const json = JSON.stringify(properties, null, 2);
-  // Ensure body has exactly one leading newline after the closing fence
+  const yamlStr = yaml.dump(properties, {
+    schema: yaml.JSON_SCHEMA,
+    lineWidth: 100,
+    noRefs: true,
+    sortKeys: false,
+  }).trimEnd();
   const normalizedBody = body.startsWith("\n") ? body : `\n${body}`;
-  return `---\n${json}\n---\n${normalizedBody}`;
+  return `---\n${yamlStr}\n---\n${normalizedBody}`;
 }

--- a/packages/arkeon/test/e2e/fs-sync.test.ts
+++ b/packages/arkeon/test/e2e/fs-sync.test.ts
@@ -25,6 +25,7 @@ import {
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomBytes } from "node:crypto";
+import yaml from "js-yaml";
 
 // Port that won't collide with other services
 const API_PORT = 18787;
@@ -45,8 +46,8 @@ function writeWiki(
   const absPath = join(testDir, relativePath);
   const dir = absPath.substring(0, absPath.lastIndexOf("/"));
   mkdirSync(dir, { recursive: true });
-  const json = JSON.stringify(properties, null, 2);
-  writeFileSync(absPath, `---\n${json}\n---\n\n${body}\n`);
+  const fm = yaml.dump(properties, { schema: yaml.JSON_SCHEMA, sortKeys: false }).trimEnd();
+  writeFileSync(absPath, `---\n${fm}\n---\n\n${body}\n`);
 }
 
 function writeSourceFile(relativePath: string, content: string): void {
@@ -215,7 +216,7 @@ describe("space registration + auto-sync", () => {
 
     // Read the file and check frontmatter has the ID
     const content = readFile("wiki/person/alan-turing.md");
-    expect(content).toContain(`"id": "${turing.id}"`);
+    expect(content).toContain(`id: ${turing.id}`);
   });
 
   it("auto-detects file modifications", async () => {
@@ -392,7 +393,7 @@ describe("space registration + auto-sync", () => {
     expect(props.edit_count).toBe(5);
   });
 
-  it("handles complex JSON properties", async () => {
+  it("handles complex nested properties", async () => {
     writeWiki("wiki/concept/complex-props.md", {
       label: "Complex Properties Test",
       subject_type: "concept",

--- a/packages/arkeon/test/unit/frontmatter.test.ts
+++ b/packages/arkeon/test/unit/frontmatter.test.ts
@@ -162,6 +162,29 @@ describe("serializeFrontmatter", () => {
     expect(parsed.body).toBe(body);
   });
 
+  it("auto-quotes ID-shaped strings so they round-trip as strings", () => {
+    // ULIDs (e.g. 01JSG…), digit-only strings, and YAML 1.1 boolean-likes
+    // must always round-trip as strings. js-yaml's dump handles this
+    // defensively when it detects ambiguity.
+    const cases = [
+      "01JSG7H3K8FZ4PV6XAY5DR9MQT",
+      "0123456789",
+      "99999999999",
+      "01234",
+      "YES",
+      "no",
+      "on",
+      "true",
+      "null",
+    ];
+    for (const id of cases) {
+      const serialized = serializeFrontmatter({ id, label: "T" }, "\nbody");
+      const parsed = parseFrontmatter(serialized);
+      expect(typeof parsed.properties.id).toBe("string");
+      expect(parsed.properties.id).toBe(id);
+    }
+  });
+
   it("preserves key insertion order", () => {
     const result = serializeFrontmatter(
       { id: "01ABC", label: "Test", subject_type: "person" },

--- a/packages/arkeon/test/unit/frontmatter.test.ts
+++ b/packages/arkeon/test/unit/frontmatter.test.ts
@@ -5,12 +5,10 @@ import { describe, it, expect } from "vitest";
 import { parseFrontmatter, serializeFrontmatter } from "../../src/server/lib/frontmatter.js";
 
 describe("parseFrontmatter", () => {
-  it("parses valid JSON frontmatter", () => {
+  it("parses valid YAML frontmatter", () => {
     const content = `---
-{
-  "label": "Test",
-  "count": 42
-}
+label: Test
+count: 42
 ---
 
 Body content here.`;
@@ -29,14 +27,15 @@ Body content here.`;
 
   it("handles complex nested properties", () => {
     const content = `---
-{
-  "label": "Complex",
-  "tags": ["a", "b", "c"],
-  "metadata": {
-    "source": "test",
-    "nested": { "deep": true }
-  }
-}
+label: Complex
+tags:
+  - a
+  - b
+  - c
+metadata:
+  source: test
+  nested:
+    deep: true
 ---
 
 Body.`;
@@ -46,29 +45,68 @@ Body.`;
     expect((result.properties.metadata as any).nested.deep).toBe(true);
   });
 
-  it("throws on invalid JSON", () => {
+  it("does not fall into the Norway problem (NO stays a string)", () => {
+    // Under YAML 1.1's default schema, `country: NO` would coerce to false.
+    // We use JSON_SCHEMA, which keeps unquoted "NO" as a string.
     const content = `---
-{ not valid json
+country: NO
+language: no
+---
+
+Body.`;
+    const result = parseFrontmatter(content);
+    expect(result.properties.country).toBe("NO");
+    expect(result.properties.language).toBe("no");
+  });
+
+  it("preserves version-like strings as strings", () => {
+    const content = `---
+version: "1.10"
+---
+
+Body.`;
+    const result = parseFrontmatter(content);
+    expect(result.properties.version).toBe("1.10");
+  });
+
+  it("supports multi-line strings via block scalar", () => {
+    const content = `---
+label: Test
+bio: |
+  Line one.
+  Line two.
+---
+
+Body.`;
+    const result = parseFrontmatter(content);
+    expect(result.properties.bio).toBe("Line one.\nLine two.\n");
+  });
+
+  it("throws on invalid YAML", () => {
+    const content = `---
+label: "unterminated
 ---
 
 Body.`;
 
-    expect(() => parseFrontmatter(content)).toThrow("Invalid JSON in frontmatter");
+    expect(() => parseFrontmatter(content)).toThrow("Invalid YAML in frontmatter");
   });
 
-  it("throws when frontmatter is an array", () => {
+  it("throws when frontmatter is a sequence", () => {
     const content = `---
-[1, 2, 3]
+- one
+- two
+- three
 ---
 
 Body.`;
 
-    expect(() => parseFrontmatter(content)).toThrow("Frontmatter JSON must be an object");
+    expect(() => parseFrontmatter(content)).toThrow("Frontmatter YAML must be a mapping");
   });
 
-  it("handles empty properties object", () => {
+  it("handles empty frontmatter (blank line between fences)", () => {
     const content = `---
-{}
+
 ---
 
 Body.`;
@@ -80,7 +118,7 @@ Body.`;
 
   it("handles no closing fence", () => {
     const content = `---
-{ "label": "Test" }
+label: Test
 No closing fence here`;
 
     const result = parseFrontmatter(content);
@@ -90,9 +128,7 @@ No closing fence here`;
 
   it("handles leading whitespace before frontmatter", () => {
     const content = `  ---
-{
-  "label": "Test"
-}
+label: Test
 ---
 
 Body.`;
@@ -100,28 +136,14 @@ Body.`;
     const result = parseFrontmatter(content);
     expect(result.properties.label).toBe("Test");
   });
-
-  it("preserves special characters in values", () => {
-    const content = `---
-{
-  "label": "Test with \\"quotes\\" and\\nnewlines",
-  "emoji": "Hello"
-}
----
-
-Body.`;
-
-    const result = parseFrontmatter(content);
-    expect(result.properties.label).toBe('Test with "quotes" and\nnewlines');
-  });
 });
 
 describe("serializeFrontmatter", () => {
   it("serializes properties and body", () => {
     const result = serializeFrontmatter({ label: "Test", count: 42 }, "\nBody content.");
-    expect(result).toContain("---\n");
-    expect(result).toContain('"label": "Test"');
-    expect(result).toContain('"count": 42');
+    expect(result.startsWith("---\n")).toBe(true);
+    expect(result).toContain("label: Test");
+    expect(result).toContain("count: 42");
     expect(result).toContain("Body content.");
   });
 
@@ -138,6 +160,18 @@ describe("serializeFrontmatter", () => {
 
     expect(parsed.properties).toEqual(original);
     expect(parsed.body).toBe(body);
+  });
+
+  it("preserves key insertion order", () => {
+    const result = serializeFrontmatter(
+      { id: "01ABC", label: "Test", subject_type: "person" },
+      "\nbody",
+    );
+    const idIdx = result.indexOf("id:");
+    const labelIdx = result.indexOf("label:");
+    const typeIdx = result.indexOf("subject_type:");
+    expect(idIdx).toBeLessThan(labelIdx);
+    expect(labelIdx).toBeLessThan(typeIdx);
   });
 
   it("adds leading newline to body if missing", () => {

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -15,18 +15,20 @@
     "graphology": "^0.25.4",
     "graphology-layout-forceatlas2": "^0.10.1",
     "graphology-types": "^0.24.7",
+    "js-yaml": "^4.1.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "sigma": "^3.0.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.0.0",
+    "playwright": "^1.59.1",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0",
-    "playwright": "^1.59.1",
     "vite": "^6.0.0"
   }
 }

--- a/packages/explorer/src/lib/frontmatter.ts
+++ b/packages/explorer/src/lib/frontmatter.ts
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Browser-side frontmatter parser. Strips JSON frontmatter from wiki
+ * Browser-side frontmatter parser. Strips YAML frontmatter from wiki
  * content so the EntityPanel can render just the body.
  */
+
+import yaml from 'js-yaml'
 
 export function parseFrontmatter(content: string): { properties: Record<string, unknown>; body: string } {
   const trimmed = content.trimStart()
@@ -20,15 +22,18 @@ export function parseFrontmatter(content: string): { properties: Record<string, 
   const closingIndex = rest.indexOf('\n---')
   if (closingIndex === -1) return { properties: {}, body: content }
 
-  const jsonStr = rest.slice(0, closingIndex).trim()
+  const yamlStr = rest.slice(0, closingIndex)
   const body = rest.slice(closingIndex + 4).replace(/^\n/, '')
 
-  let properties: Record<string, unknown>
+  let parsed: unknown
   try {
-    properties = JSON.parse(jsonStr)
+    parsed = yaml.load(yamlStr, { schema: yaml.JSON_SCHEMA })
   } catch {
     return { properties: {}, body: content }
   }
 
-  return { properties, body }
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    return { properties: parsed as Record<string, unknown>, body }
+  }
+  return { properties: {}, body }
 }


### PR DESCRIPTION
## Summary
- Wiki files now use YAML frontmatter instead of JSON. Same `---` fences, same on-disk JSON storage in SQLite — only the surface syntax users hand-edit changes.
- Parser uses **js-yaml's `JSON_SCHEMA`** so values map cleanly to JSON-compatible types and avoid the "Norway problem" (`country: NO` stays the string `"NO"` instead of coercing to `false`). Version-like strings keep their form too.
- Behavior on invalid YAML matches the old behavior on invalid JSON: the sync engine logs the parse error and skips the file. No partial acceptance.

## Why
JSON frontmatter is awkward for hand-editing — quoted keys, no comments, no multi-line strings, trailing-comma errors. YAML is the convention in Obsidian, Jekyll, Hugo, and Pandoc, so it's what users coming to a markdown-based knowledge graph expect. YAML also adds nested mappings, sequences, multi-line strings (`|` literal, `>` folded), and `#` comments without changing the storage layer.

## Before / after

```diff
 ---
-{
-  "label": "Claude Shannon",
-  "subject_type": "person",
-  "birth_year": 1916,
-  "fields": ["mathematics", "information theory"]
-}
+label: Claude Shannon
+subject_type: person
+birth_year: 1916
+fields:
+  - mathematics
+  - information theory
 ---
```

## Test plan
- [x] `npm run typecheck -w packages/arkeon` (passes)
- [x] `npm run typecheck -w packages/explorer` (passes)
- [x] `npm test -w packages/arkeon` — 31/31 unit tests pass (added Norway-problem, version-string, and block-scalar coverage)
- [x] `npm run test:e2e -w packages/arkeon` — 33/33 pass, including ID round-trip through YAML serializer + watcher re-sync
- [ ] Spot-check on a real wiki directory with hand-authored files

🤖 Generated with [Claude Code](https://claude.com/claude-code)