### PR TITLE
feat: add ripgrep-backed keyword search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,9 +83,21 @@ No actors, no auth, no queues, no versioning. Schema in `src/schema/001-foundati
 - `GET /entities?space_id=...&type=...` — list entities (filterable, paginated)
 - `GET /entities/{id}` — entity properties + relationships (no content)
 - `DELETE /entities/{id}` — remove entity
+- `GET /search?q=...&space_id=...&limit=...&snippets=...&regex=...` — keyword search via ripgrep against the watched directory; returns ranked entity hits with line snippets
 - `GET /health` / `GET /ready`
 
 No auth required. Content lives on disk — the API returns metadata and relationships only.
+
+## Search
+
+Keyword search is filesystem-first: there is no keyword index in SQLite. The
+`/search` endpoint and `arkeon-wiki search` CLI spawn ripgrep (bundled via
+`@vscode/ripgrep`, cross-platform) against each space's `watch_dir`, parse
+`--json` output, and join the matched paths back to entities. Results are
+ranked by `matched_lines` count.
+
+Vector / semantic search is planned next (sqlite-vec + EmbeddingGemma-300M)
+and will be fused with ripgrep results via reciprocal rank fusion.
 
 ## Commands
 
@@ -96,6 +108,7 @@ arkeon-wiki status              # is it running?
 arkeon-wiki ls                  # list all running instances
 arkeon-wiki logs [-f]           # print/tail the daemon log
 arkeon-wiki init                # register cwd as a space
+arkeon-wiki search <query>      # keyword search (defaults to bound space)
 arkeon-wiki start               # foreground (for use under pm2/launchd/etc.)
 ```
 
@@ -139,8 +152,8 @@ Single file: `001-foundation.sql`. Must be idempotent (all `IF NOT EXISTS`). Run
 
 ## What's NOT here (yet)
 
-- No vector search (sqlite-vec planned)
-- No Meilisearch / full-text search
+- No vector search (sqlite-vec + EmbeddingGemma planned, hybrid RRF with ripgrep)
+- No FTS5 / BM25 ranking (ripgrep gives substring matching only)
 - No auth / API keys
 - No workers (extract, draft, enrich)
 - No explorer (needs updating for new API)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1734,6 +1734,18 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vscode/ripgrep": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.17.1.tgz",
+      "integrity": "sha512-xTs7DGyAO3IsJYOCTBP8LnTvPiYVKEuyv8s0xyJDBXfs8rhBfqnZPvb6xDT+RnwWzcXqW27xLS/aGrkjX7lNWw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "https-proxy-agent": "^7.0.2",
+        "proxy-from-env": "^1.1.0",
+        "yauzl": "^2.9.2"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1745,6 +1757,15 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -1942,6 +1963,15 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bundle-require": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
@@ -2132,7 +2162,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2377,6 +2406,15 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2517,6 +2555,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ieee754": {
@@ -3002,7 +3053,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -3123,6 +3173,12 @@
       "engines": {
         "node": ">= 14.16"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3296,6 +3352,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.4",
@@ -4741,6 +4803,16 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
     "node_modules/zod": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
@@ -4757,6 +4829,7 @@
       "dependencies": {
         "@hono/node-server": "^1.19.11",
         "@hono/zod-openapi": "^1.2.3",
+        "@vscode/ripgrep": "^1.17.1",
         "better-sqlite3": "^12.9.0",
         "commander": "^14.0.1",
         "conf": "^13.0.1",

--- a/packages/arkeon/package.json
+++ b/packages/arkeon/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@hono/node-server": "^1.19.11",
     "@hono/zod-openapi": "^1.2.3",
+    "@vscode/ripgrep": "^1.17.1",
     "better-sqlite3": "^12.9.0",
     "commander": "^14.0.1",
     "conf": "^13.0.1",

--- a/packages/arkeon/src/cli/commands/repo/search.ts
+++ b/packages/arkeon/src/cli/commands/repo/search.ts
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `arkeon-wiki search <query>` — keyword search across registered spaces.
+ *
+ * Calls `GET /search` on the running daemon. By default scopes to the
+ * space bound to the current directory (via `.arkeon/state.json`); pass
+ * `--all` to search every registered space, or `--space <id>` for a
+ * specific one.
+ */
+
+import type { Command } from "commander";
+
+import { DEFAULT_API_PORT } from "../../lib/local-runtime.js";
+import { output } from "../../lib/output.js";
+import { loadRepoState } from "../../lib/repo-state.js";
+
+interface SearchOptions {
+  apiUrl?: string;
+  space?: string;
+  all?: boolean;
+  limit?: string;
+  snippets?: string;
+  regex?: boolean;
+}
+
+export function registerSearchCommand(program: Command): void {
+  program
+    .command("search")
+    .argument("<query>", "Search query (literal substring by default)")
+    .description("Keyword search across registered spaces (via ripgrep)")
+    .option("--api-url <url>", "API URL (default: http://localhost:8000)")
+    .option("--space <id>", "Space ID to search (default: bound space, or all)")
+    .option("--all", "Search every registered space")
+    .option("--limit <n>", "Max results to return (default 20, max 200)")
+    .option("--snippets <n>", "Max snippets per result (default 3)")
+    .option("--regex", "Treat query as a regular expression")
+    .action(async (query: string, options: SearchOptions) => {
+      try {
+        await runSearch(query, options);
+      } catch (error) {
+        output.error(error, { operation: "search" });
+        process.exitCode = 1;
+      }
+    });
+}
+
+async function runSearch(query: string, options: SearchOptions): Promise<void> {
+  const repoState = loadRepoState();
+  const apiUrl =
+    options.apiUrl ??
+    repoState?.api_url ??
+    process.env.ARKE_API_URL ??
+    `http://localhost:${DEFAULT_API_PORT}`;
+
+  const params = new URLSearchParams({ q: query });
+  if (!options.all) {
+    const spaceId = options.space ?? repoState?.space_id;
+    if (spaceId) params.set("space_id", spaceId);
+  }
+  if (options.limit) params.set("limit", options.limit);
+  if (options.snippets) params.set("snippets", options.snippets);
+  if (options.regex) params.set("regex", "true");
+
+  const res = await fetch(`${apiUrl}/search?${params.toString()}`);
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    const message =
+      (body as { error?: { message?: string } }).error?.message ?? res.statusText;
+    throw new Error(`Search failed: ${res.status} ${message}`);
+  }
+
+  const result = (await res.json()) as {
+    query: string;
+    hits: Array<{
+      entity_id: string;
+      space_id: string;
+      type: string;
+      label: string;
+      source_path: string;
+      match_count: number;
+      snippets: { line_number: number; text: string }[];
+    }>;
+    unmatched_files: number;
+  };
+
+  output.result({
+    operation: "search",
+    query: result.query,
+    hit_count: result.hits.length,
+    unmatched_files: result.unmatched_files,
+    hits: result.hits,
+  });
+}

--- a/packages/arkeon/src/index.ts
+++ b/packages/arkeon/src/index.ts
@@ -9,6 +9,7 @@ import { Command } from "commander";
 
 import { registerLocalCommands } from "./cli/commands/local/index.js";
 import { registerInitCommand } from "./cli/commands/repo/init.js";
+import { registerSearchCommand } from "./cli/commands/repo/search.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf-8")) as { version: string };
@@ -40,5 +41,6 @@ program.hook("preAction", (command) => {
 
 registerLocalCommands(program);
 registerInitCommand(program);
+registerSearchCommand(program);
 
 program.parse();

--- a/packages/arkeon/src/server/app.ts
+++ b/packages/arkeon/src/server/app.ts
@@ -10,6 +10,7 @@ import { mapDatabaseError } from "./lib/db-errors.js";
 import { createSql } from "./lib/sql.js";
 import { spacesRouter } from "./routes/spaces.js";
 import { entitiesRouter } from "./routes/entities.js";
+import { searchRouter } from "./routes/search.js";
 
 export function createApp() {
   const app = new Hono<AppBindings>();
@@ -37,6 +38,7 @@ export function createApp() {
 
   app.route("/spaces", spacesRouter);
   app.route("/entities", entitiesRouter);
+  app.route("/search", searchRouter);
 
   app.notFound((c) => {
     const requestId = c.get("requestId");

--- a/packages/arkeon/src/server/lib/search.ts
+++ b/packages/arkeon/src/server/lib/search.ts
@@ -1,0 +1,267 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Filesystem keyword search via ripgrep.
+ *
+ * For each registered space, spawns ripgrep against the space's watch_dir
+ * with --json output, parses the stream into per-file match counts and
+ * snippets, then joins the results to entities in SQLite by source_path.
+ *
+ * Filesystem-first: there is no keyword index in SQLite — the filesystem
+ * (queried by ripgrep) is the index. Vector search will be layered on top
+ * of this in a follow-up (sqlite-vec + EmbeddingGemma).
+ */
+
+import { spawn } from "node:child_process";
+import { rgPath } from "@vscode/ripgrep";
+
+import { createSql } from "./sql.js";
+
+const SNIPPET_MAX_LEN = 240;
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 200;
+const DEFAULT_SNIPPETS_PER_FILE = 3;
+
+export interface SearchOptions {
+  query: string;
+  spaceId?: string;
+  limit?: number;
+  maxSnippetsPerFile?: number;
+  regex?: boolean;
+}
+
+export interface SearchSnippet {
+  line_number: number;
+  text: string;
+}
+
+export interface SearchHit {
+  entity_id: string;
+  space_id: string;
+  type: string;
+  label: string;
+  source_path: string;
+  match_count: number;
+  snippets: SearchSnippet[];
+}
+
+export interface SearchResult {
+  query: string;
+  hits: SearchHit[];
+  /** Files matched by ripgrep that had no entity mapping (e.g., excluded
+   *  extensions) and were therefore skipped. Useful for diagnostics. */
+  unmatched_files: number;
+}
+
+interface FileResult {
+  path: string;
+  match_count: number;
+  snippets: SearchSnippet[];
+}
+
+/**
+ * Parse newline-delimited ripgrep --json output into per-file results.
+ *
+ * ripgrep emits one JSON event per line. We care about `match` (one line
+ * with submatches) and `end` (per-file stats). Other event types
+ * (begin, summary, context) are ignored.
+ *
+ * Exported for unit testing.
+ */
+export function parseRipgrepJson(
+  stdout: string,
+  maxSnippetsPerFile: number,
+): FileResult[] {
+  const byPath = new Map<string, FileResult>();
+
+  const ensure = (path: string): FileResult => {
+    let entry = byPath.get(path);
+    if (!entry) {
+      entry = { path, match_count: 0, snippets: [] };
+      byPath.set(path, entry);
+    }
+    return entry;
+  };
+
+  for (const line of stdout.split("\n")) {
+    if (!line) continue;
+    let event: unknown;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!event || typeof event !== "object") continue;
+    const ev = event as { type?: string; data?: Record<string, unknown> };
+
+    if (ev.type === "match") {
+      const path = readPath(ev.data);
+      if (!path) continue;
+      const lineText = readLineText(ev.data);
+      const lineNumber = ev.data?.line_number;
+      const entry = ensure(path);
+      if (
+        entry.snippets.length < maxSnippetsPerFile &&
+        typeof lineText === "string" &&
+        typeof lineNumber === "number"
+      ) {
+        entry.snippets.push({
+          line_number: lineNumber,
+          text: truncateSnippet(lineText.replace(/\n$/, "")),
+        });
+      }
+    } else if (ev.type === "end") {
+      const path = readPath(ev.data);
+      if (!path) continue;
+      const stats = ev.data?.stats as { matched_lines?: number } | undefined;
+      const entry = ensure(path);
+      if (typeof stats?.matched_lines === "number") {
+        entry.match_count = stats.matched_lines;
+      }
+    }
+  }
+
+  return [...byPath.values()];
+}
+
+function readPath(data: Record<string, unknown> | undefined): string | null {
+  const path = data?.path as { text?: string } | undefined;
+  if (typeof path?.text !== "string") return null;
+  // ripgrep emits "./file.md" or "file.md" depending on how we invoked it
+  return path.text.replace(/^\.\//, "");
+}
+
+function readLineText(data: Record<string, unknown> | undefined): string | null {
+  const lines = data?.lines as { text?: string } | undefined;
+  return typeof lines?.text === "string" ? lines.text : null;
+}
+
+function truncateSnippet(text: string): string {
+  if (text.length <= SNIPPET_MAX_LEN) return text;
+  return text.slice(0, SNIPPET_MAX_LEN) + "…";
+}
+
+/**
+ * Spawn ripgrep against `cwd` with the given query and return parsed file
+ * results. Exit codes: 0 = matches found, 1 = no matches, 2+ = error.
+ */
+export function runRipgrep(opts: {
+  cwd: string;
+  query: string;
+  regex: boolean;
+  maxSnippetsPerFile: number;
+}): Promise<FileResult[]> {
+  return new Promise((resolve, reject) => {
+    const args: string[] = ["--json", "--smart-case"];
+    if (!opts.regex) args.push("--fixed-strings");
+    // Exclude our own state dir. .git and node_modules are already skipped
+    // by ripgrep's default gitignore behaviour, but we set them explicitly
+    // so this works in directories without a .gitignore.
+    args.push("--glob", "!.arkeon");
+    args.push("--glob", "!.git");
+    args.push("--glob", "!node_modules");
+    // Restrict to the file types we index.
+    args.push("--type-add", "arkeon:*.{md,txt,json,csv,xml,html,rst}");
+    args.push("--type", "arkeon");
+    args.push("--", opts.query, ".");
+
+    const child = spawn(rgPath, args, {
+      cwd: opts.cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => {
+      stdout += d.toString("utf-8");
+    });
+    child.stderr.on("data", (d) => {
+      stderr += d.toString("utf-8");
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0 || code === 1) {
+        resolve(parseRipgrepJson(stdout, opts.maxSnippetsPerFile));
+      } else {
+        reject(new Error(`ripgrep exited ${code}: ${stderr.trim()}`));
+      }
+    });
+  });
+}
+
+/**
+ * Run a keyword search across one or all registered spaces.
+ */
+export async function search(opts: SearchOptions): Promise<SearchResult> {
+  const query = opts.query;
+  const limit = Math.min(opts.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+  const maxSnippets = Math.max(0, opts.maxSnippetsPerFile ?? DEFAULT_SNIPPETS_PER_FILE);
+
+  const sql = createSql();
+  const spaces = await (opts.spaceId
+    ? sql`SELECT id, watch_dir FROM spaces WHERE id = ${opts.spaceId}`
+    : sql`SELECT id, watch_dir FROM spaces`);
+
+  if (spaces.length === 0) {
+    return { query, hits: [], unmatched_files: 0 };
+  }
+
+  let unmatched = 0;
+  const hits: SearchHit[] = [];
+
+  for (const space of spaces) {
+    const watchDir = space.watch_dir as string | null;
+    const spaceId = space.id as string;
+    if (!watchDir) continue;
+
+    const fileResults = await runRipgrep({
+      cwd: watchDir,
+      query,
+      regex: !!opts.regex,
+      maxSnippetsPerFile: maxSnippets,
+    });
+
+    if (fileResults.length === 0) continue;
+
+    const paths = fileResults.map((r) => r.path);
+    const placeholders = paths.map(() => "?").join(",");
+    const entityRows = await sql.query(
+      `SELECT id, space_id, type, label, source_path
+       FROM entities
+       WHERE space_id = ? AND source_path IN (${placeholders})`,
+      [spaceId, ...paths],
+    );
+    const entityByPath = new Map<string, Record<string, unknown>>();
+    for (const e of entityRows) entityByPath.set(e.source_path as string, e);
+
+    for (const fileResult of fileResults) {
+      const entity = entityByPath.get(fileResult.path);
+      if (!entity) {
+        unmatched++;
+        continue;
+      }
+      hits.push({
+        entity_id: entity.id as string,
+        space_id: entity.space_id as string,
+        type: entity.type as string,
+        label: entity.label as string,
+        source_path: entity.source_path as string,
+        match_count: fileResult.match_count,
+        snippets: fileResult.snippets,
+      });
+    }
+  }
+
+  // Rank by match count desc, tiebreak by entity_id for determinism.
+  hits.sort(
+    (a, b) =>
+      b.match_count - a.match_count || a.entity_id.localeCompare(b.entity_id),
+  );
+
+  return {
+    query,
+    hits: hits.slice(0, limit),
+    unmatched_files: unmatched,
+  };
+}

--- a/packages/arkeon/src/server/routes/search.ts
+++ b/packages/arkeon/src/server/routes/search.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Hono } from "hono";
+
+import type { AppBindings } from "../types.js";
+import { ApiError } from "../lib/errors.js";
+import { search } from "../lib/search.js";
+
+export const searchRouter = new Hono<AppBindings>();
+
+// GET /search?q=...&space_id=...&limit=20&snippets=3&regex=false
+//
+// Filesystem keyword search via ripgrep. Returns ranked entity matches
+// with line-level snippets. If `space_id` is omitted, searches every
+// registered space.
+searchRouter.get("/", async (c) => {
+  const query = c.req.query("q");
+  if (!query) {
+    throw new ApiError(400, "validation_error", "q is required");
+  }
+
+  const spaceId = c.req.query("space_id");
+  const limitParam = c.req.query("limit");
+  const snippetsParam = c.req.query("snippets");
+  const regex = c.req.query("regex") === "true";
+
+  const limit = limitParam ? Number(limitParam) : undefined;
+  const maxSnippetsPerFile = snippetsParam ? Number(snippetsParam) : undefined;
+
+  if (limit !== undefined && (!Number.isFinite(limit) || limit < 1)) {
+    throw new ApiError(400, "validation_error", "limit must be a positive integer");
+  }
+  if (maxSnippetsPerFile !== undefined && (!Number.isFinite(maxSnippetsPerFile) || maxSnippetsPerFile < 0)) {
+    throw new ApiError(400, "validation_error", "snippets must be >= 0");
+  }
+
+  const result = await search({
+    query,
+    spaceId,
+    limit,
+    maxSnippetsPerFile,
+    regex,
+  });
+
+  return c.json(result);
+});

--- a/packages/arkeon/test/e2e/search.test.ts
+++ b/packages/arkeon/test/e2e/search.test.ts
@@ -14,6 +14,7 @@ import { mkdirSync, writeFileSync, existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomBytes } from "node:crypto";
+import yaml from "js-yaml";
 
 const API_PORT = 18791;
 const BASE_URL = `http://localhost:${API_PORT}`;
@@ -31,8 +32,10 @@ function writeWiki(
   const absPath = join(testDir, relativePath);
   const dir = absPath.substring(0, absPath.lastIndexOf("/"));
   mkdirSync(dir, { recursive: true });
-  const json = JSON.stringify(properties, null, 2);
-  writeFileSync(absPath, `---\n${json}\n---\n\n${body}\n`);
+  const fm = yaml
+    .dump(properties, { schema: yaml.JSON_SCHEMA, sortKeys: false })
+    .trimEnd();
+  writeFileSync(absPath, `---\n${fm}\n---\n\n${body}\n`);
 }
 
 async function api(path: string): Promise<any> {

--- a/packages/arkeon/test/e2e/search.test.ts
+++ b/packages/arkeon/test/e2e/search.test.ts
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * End-to-end test for the ripgrep-backed search endpoint.
+ *
+ * Spins up a SQLite DB + API server in-process, registers a temp
+ * directory as a space, writes a few wiki files, and asserts that
+ * GET /search returns ranked entity hits with snippets.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdirSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+
+const API_PORT = 18791;
+const BASE_URL = `http://localhost:${API_PORT}`;
+
+let testDir: string;
+let stateDir: string;
+let serverHandle: { stop: () => Promise<void> } | null = null;
+let spaceId: string;
+
+function writeWiki(
+  relativePath: string,
+  properties: Record<string, unknown>,
+  body: string,
+): void {
+  const absPath = join(testDir, relativePath);
+  const dir = absPath.substring(0, absPath.lastIndexOf("/"));
+  mkdirSync(dir, { recursive: true });
+  const json = JSON.stringify(properties, null, 2);
+  writeFileSync(absPath, `---\n${json}\n---\n\n${body}\n`);
+}
+
+async function api(path: string): Promise<any> {
+  const res = await fetch(`${BASE_URL}${path}`);
+  if (res.headers.get("content-type")?.includes("json")) {
+    return res.json();
+  }
+  return res.text();
+}
+
+async function waitForEntityCount(
+  expected: number,
+  spaceId: string,
+  timeoutMs = 5000,
+): Promise<any[]> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const data = await api(`/entities?space_id=${spaceId}`);
+    if ((data.entities ?? []).length === expected) return data.entities;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  const data = await api(`/entities?space_id=${spaceId}`);
+  return data.entities ?? [];
+}
+
+beforeAll(async () => {
+  const base = join(tmpdir(), `arkeon-search-test-${randomBytes(4).toString("hex")}`);
+  testDir = join(base, "repo");
+  stateDir = join(base, "state");
+  mkdirSync(testDir, { recursive: true });
+  mkdirSync(join(stateDir, "data"), { recursive: true });
+  mkdirSync(join(testDir, "wiki"), { recursive: true });
+
+  process.env.ARKEON_WIKI_HOME = stateDir;
+
+  const dbFile = join(stateDir, "data", "arke.db");
+  const { runMigrations } = await import("../../src/schema/index.js");
+  await runMigrations({ dbPath: dbFile });
+
+  const { startApi } = await import("../../src/server/server.js");
+  const apiHandle = await startApi({ port: API_PORT, dbPath: dbFile });
+  serverHandle = { stop: async () => apiHandle.stop() };
+
+  // Seed files BEFORE creating the space so reconciliation picks them up.
+  writeWiki(
+    "wiki/person/alan-turing.md",
+    { label: "Alan Turing", subject_type: "person" },
+    "Alan Turing was a British mathematician. Turing pioneered computer science.",
+  );
+  writeWiki(
+    "wiki/person/claude-shannon.md",
+    { label: "Claude Shannon", subject_type: "person" },
+    "Claude Shannon was an American mathematician and the father of information theory.",
+  );
+  writeWiki(
+    "wiki/concept/computability.md",
+    { label: "Computability", subject_type: "concept" },
+    "Computability theory was advanced by Alan Turing.",
+  );
+
+  const created = await fetch(`${BASE_URL}/spaces`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: "search-space", watch_dir: testDir }),
+  });
+  const space = (await created.json()) as { id: string };
+  spaceId = space.id;
+
+  await waitForEntityCount(3, spaceId);
+}, 30_000);
+
+afterAll(async () => {
+  if (serverHandle) await serverHandle.stop();
+  if (testDir && existsSync(testDir)) {
+    rmSync(testDir.substring(0, testDir.lastIndexOf("/")), {
+      recursive: true,
+      force: true,
+    });
+  }
+}, 30_000);
+
+describe("GET /search", () => {
+  it("returns 400 when q is missing", async () => {
+    const data = await api(`/search?space_id=${spaceId}`);
+    expect(data.error?.code).toBe("validation_error");
+  });
+
+  it("finds wikis matching a literal query", async () => {
+    const data = await api(`/search?space_id=${spaceId}&q=Turing`);
+    expect(data.query).toBe("Turing");
+    expect(data.hits.length).toBeGreaterThanOrEqual(2);
+
+    const labels = data.hits.map((h: any) => h.label);
+    expect(labels).toContain("Alan Turing");
+    expect(labels).toContain("Computability");
+  });
+
+  it("ranks hits by match count", async () => {
+    const data = await api(`/search?space_id=${spaceId}&q=Turing`);
+    // Alan Turing's wiki mentions "Turing" at least twice (frontmatter + body),
+    // Computability mentions it once.
+    const turing = data.hits.find((h: any) => h.label === "Alan Turing");
+    const computability = data.hits.find((h: any) => h.label === "Computability");
+    expect(turing.match_count).toBeGreaterThan(computability.match_count);
+
+    // First hit should be the higher-count one.
+    expect(data.hits[0].label).toBe("Alan Turing");
+  });
+
+  it("returns snippets with line numbers", async () => {
+    const data = await api(`/search?space_id=${spaceId}&q=mathematician`);
+    expect(data.hits.length).toBeGreaterThan(0);
+    for (const hit of data.hits) {
+      expect(Array.isArray(hit.snippets)).toBe(true);
+      for (const snippet of hit.snippets) {
+        expect(typeof snippet.line_number).toBe("number");
+        expect(typeof snippet.text).toBe("string");
+        expect(snippet.text.toLowerCase()).toContain("mathematician");
+      }
+    }
+  });
+
+  it("respects the limit parameter", async () => {
+    const data = await api(`/search?space_id=${spaceId}&q=mathematician&limit=1`);
+    expect(data.hits).toHaveLength(1);
+  });
+
+  it("respects the snippets parameter", async () => {
+    const data = await api(`/search?space_id=${spaceId}&q=Turing&snippets=1`);
+    for (const hit of data.hits) {
+      expect(hit.snippets.length).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("returns no hits for queries with no matches", async () => {
+    const data = await api(`/search?space_id=${spaceId}&q=zzznotpresentzzz`);
+    expect(data.hits).toEqual([]);
+  });
+
+  it("searches all spaces when space_id is omitted", async () => {
+    const data = await api(`/search?q=Shannon`);
+    expect(data.hits.length).toBeGreaterThan(0);
+    expect(data.hits.some((h: any) => h.label === "Claude Shannon")).toBe(true);
+  });
+
+  it("searches case-insensitively when query is lowercase (smart-case)", async () => {
+    const data = await api(`/search?space_id=${spaceId}&q=turing`);
+    expect(data.hits.some((h: any) => h.label === "Alan Turing")).toBe(true);
+  });
+});

--- a/packages/arkeon/test/unit/search.test.ts
+++ b/packages/arkeon/test/unit/search.test.ts
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { parseRipgrepJson } from "../../src/server/lib/search.js";
+
+const beginEvent = (path: string) =>
+  JSON.stringify({ type: "begin", data: { path: { text: path } } });
+
+const matchEvent = (
+  path: string,
+  lineNumber: number,
+  lineText: string,
+  matchText: string,
+) =>
+  JSON.stringify({
+    type: "match",
+    data: {
+      path: { text: path },
+      lines: { text: `${lineText}\n` },
+      line_number: lineNumber,
+      absolute_offset: 0,
+      submatches: [{ match: { text: matchText }, start: 0, end: matchText.length }],
+    },
+  });
+
+const endEvent = (path: string, matchedLines: number) =>
+  JSON.stringify({
+    type: "end",
+    data: {
+      path: { text: path },
+      binary_offset: null,
+      stats: {
+        elapsed: { secs: 0, nanos: 1, human: "0s" },
+        searches: 1,
+        searches_with_match: 1,
+        bytes_searched: 100,
+        bytes_printed: 50,
+        matched_lines: matchedLines,
+        matches: matchedLines,
+      },
+    },
+  });
+
+describe("parseRipgrepJson", () => {
+  it("parses a single-file match stream", () => {
+    const stdout = [
+      beginEvent("wiki/foo.md"),
+      matchEvent("wiki/foo.md", 3, "Alan Turing was a mathematician.", "Turing"),
+      matchEvent("wiki/foo.md", 7, "Alan Turing later moved to Bell Labs.", "Turing"),
+      endEvent("wiki/foo.md", 2),
+      "",
+    ].join("\n");
+
+    const result = parseRipgrepJson(stdout, 5);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      path: "wiki/foo.md",
+      match_count: 2,
+    });
+    expect(result[0]!.snippets).toHaveLength(2);
+    expect(result[0]!.snippets[0]).toEqual({
+      line_number: 3,
+      text: "Alan Turing was a mathematician.",
+    });
+  });
+
+  it("strips a leading './' from paths", () => {
+    const stdout = [
+      matchEvent("./wiki/foo.md", 1, "hello", "hello"),
+      endEvent("./wiki/foo.md", 1),
+    ].join("\n");
+
+    const result = parseRipgrepJson(stdout, 3);
+    expect(result[0]!.path).toBe("wiki/foo.md");
+  });
+
+  it("caps snippets at maxSnippetsPerFile but keeps full match count", () => {
+    const lines = [beginEvent("a.md")];
+    for (let i = 1; i <= 10; i++) {
+      lines.push(matchEvent("a.md", i, `line ${i} matches`, "matches"));
+    }
+    lines.push(endEvent("a.md", 10));
+
+    const result = parseRipgrepJson(lines.join("\n"), 3);
+    expect(result[0]!.snippets).toHaveLength(3);
+    expect(result[0]!.match_count).toBe(10);
+  });
+
+  it("groups matches across multiple files", () => {
+    const stdout = [
+      matchEvent("a.md", 1, "alpha", "alpha"),
+      endEvent("a.md", 1),
+      matchEvent("b.md", 5, "beta", "beta"),
+      matchEvent("b.md", 6, "beta again", "beta"),
+      endEvent("b.md", 2),
+    ].join("\n");
+
+    const result = parseRipgrepJson(stdout, 5);
+    expect(result).toHaveLength(2);
+    const byPath = Object.fromEntries(result.map((r) => [r.path, r]));
+    expect(byPath["a.md"]!.match_count).toBe(1);
+    expect(byPath["b.md"]!.match_count).toBe(2);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(parseRipgrepJson("", 3)).toEqual([]);
+  });
+
+  it("ignores malformed JSON lines without throwing", () => {
+    const stdout = [
+      "not json",
+      matchEvent("a.md", 1, "hello", "hello"),
+      "{not really json",
+      endEvent("a.md", 1),
+    ].join("\n");
+
+    const result = parseRipgrepJson(stdout, 3);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.match_count).toBe(1);
+  });
+
+  it("truncates very long snippet lines", () => {
+    const longLine = "x".repeat(500) + "needle" + "y".repeat(500);
+    const stdout = [
+      matchEvent("a.md", 1, longLine, "needle"),
+      endEvent("a.md", 1),
+    ].join("\n");
+
+    const result = parseRipgrepJson(stdout, 3);
+    expect(result[0]!.snippets[0]!.text.length).toBeLessThanOrEqual(241);
+    expect(result[0]!.snippets[0]!.text.endsWith("…")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- New `GET /search` endpoint and `arkeon-wiki search <query>` CLI, backed by `@vscode/ripgrep`
- Filesystem-first: no keyword index in SQLite. Per-space, we spawn `rg --json` against `watch_dir`, parse match events into per-file snippets, and join hits to entities by `source_path`
- Hits are ranked by `matched_lines` count; tiebreak by entity_id for determinism
- Cross-platform: `@vscode/ripgrep` bundles prebuilt binaries for macOS, Linux, and Windows

## API

```
GET /search?q=...&space_id=...&limit=20&snippets=3&regex=false
```

Returns:

```json
{
  "query": "Turing",
  "hits": [
    {
      "entity_id": "01J...",
      "space_id": "01J...",
      "type": "wiki",
      "label": "Alan Turing",
      "source_path": "wiki/person/alan-turing.md",
      "match_count": 2,
      "snippets": [
        { "line_number": 5, "text": "Alan Turing was a British mathematician." }
      ]
    }
  ],
  "unmatched_files": 0
}
```

## CLI

```bash
arkeon-wiki search "Turing"          # bound space (from .arkeon/state.json)
arkeon-wiki search "foo" --all       # all registered spaces
arkeon-wiki search "f.." --regex     # regex mode
arkeon-wiki search "x" --snippets 1  # 1 snippet per result
```

## What's next

Vector / semantic search via `sqlite-vec` + EmbeddingGemma-300M, fused with these ripgrep results via reciprocal rank fusion. Tracked in a follow-up issue.

## Test plan

- [x] Unit tests on the rg `--json` parser (paths, snippets cap, malformed lines, truncation)
- [x] E2e tests against a live API: literal queries, ranking by match count, snippets shape, limit/snippets params, no-match queries, all-spaces fallback, smart-case
- [x] `npm run typecheck`, `npm test`, `npm run test:e2e` all pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)