### PR TITLE
docs: refresh stale references (search command, fs-first quickstart)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Two npm workspaces. Only one is published.
 - `packages/arkeon/` — the main package, published as `arkeon-wiki` on npm. CLI binary, Hono API server, schema migrations, sync engine.
   - `src/index.ts` — CLI entry (commander)
   - `src/cli/commands/local/` — daemon lifecycle (up, down, start, stop, status, ls, logs)
-  - `src/cli/commands/repo/` — directory-scoped commands (init)
+  - `src/cli/commands/repo/` — directory-scoped commands (init, search)
   - `src/cli/lib/local-runtime.ts` — paths, pidfile, named-instance helpers
   - `src/cli/lib/instances.ts` — running-instance registry
   - `src/server/` — Hono API server, routes, sync engine, file watcher
@@ -75,6 +75,7 @@ No actors, no auth, no queues, no versioning. Schema in `src/schema/001-foundati
 - `src/server/lib/fs-watcher.ts` — watches registered directories, debounces changes, calls `syncFile()` / `removeByPath()`.
 - `src/server/lib/frontmatter.ts` — parse/serialize YAML frontmatter.
 - `src/server/lib/markdown-links.ts` — extract and resolve markdown links.
+- `src/server/lib/search.ts` — ripgrep adapter: spawns `rg --json` per space, parses match events, joins paths back to entities, ranks by `match_count`.
 
 ## API endpoints
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ A knowledge graph that lives in your filesystem. Point it at a directory, and it
 
 ```bash
 npm install -g arkeon-wiki
-arkeon-wiki start
+arkeon-wiki up
 ```
 
-The daemon runs in the foreground — `Ctrl+C` to stop. State (SQLite database, pidfile, log) lives in `~/.arkeon-wiki/`.
+This starts the daemon as a detached background process — it survives your terminal closing. Stop it with `arkeon-wiki down`. State (SQLite database, pidfile, log) lives in `~/.arkeon-wiki/`.
 
 **2. Register a directory**
 
@@ -53,7 +53,10 @@ No manual sync commands. Just save files.
 curl http://localhost:8000/entities              # list all entities
 curl http://localhost:8000/entities/{id}          # get properties + relationships
 curl http://localhost:8000/entities?type=wiki     # filter by type
+curl "http://localhost:8000/search?q=shannon"    # keyword search (ripgrep)
 ```
+
+Or from the CLI: `arkeon-wiki search shannon`.
 
 ## How it works
 
@@ -73,6 +76,7 @@ arkeon-wiki status             # check if running
 arkeon-wiki ls                 # list running instances
 arkeon-wiki logs [-f]          # print/tail the daemon log
 arkeon-wiki init [name]        # register current directory as a space
+arkeon-wiki search <query>     # keyword search (ripgrep, defaults to bound space)
 arkeon-wiki start              # foreground (for use under pm2/launchd/etc.)
 ```
 

--- a/packages/arkeon/README.md
+++ b/packages/arkeon/README.md
@@ -4,6 +4,6 @@ Filesystem-first knowledge graph. See the [root README](../../README.md) for det
 
 ```bash
 npm install -g arkeon-wiki
-arkeon-wiki start
+arkeon-wiki up
 arkeon-wiki init
 ```


### PR DESCRIPTION
## Summary

Audit pass on top-level docs against current code. Three files had drifted:

- **CLAUDE.md** — `src/cli/commands/repo/` was listed as containing only `init`, but `search.ts` was added in #46. "Key modules" was missing `src/server/lib/search.ts`.
- **README.md** — quick-start used `arkeon-wiki start` (foreground), inconsistent with the `up`-as-recommended-entry-point guidance in CLAUDE.md and AGENTS.md. Also missing `search` from the CLI table and missing a `/search` example in the "query the graph" snippet.
- **packages/arkeon/README.md** — same `start` → `up` swap.

Other docs verified clean and not touched: AGENTS.md, docs/user/API.md, docs/dev/TESTING.md, docs/dev/ERROR_CONTRACT.md, every CLI `--help`. No `llms.txt` exists; not adding one in this PR.

## Test plan

- [ ] Read the rendered diffs on GitHub to sanity-check formatting
- [ ] Verify quick-start commands actually work for a new user (`npm install -g arkeon-wiki && arkeon-wiki up && arkeon-wiki init`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)