### PR TITLE
feat: agent runtime foundation (FileEdit applicator + provider-agnostic runtime)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,84 @@
         "packages/explorer"
       ]
     },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.71",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.71.tgz",
+      "integrity": "sha512-bUWOzrzR0gJKJO/PLGMR4uH2dqEgqGhrsCV+sSpk4KtOEnUQlfjZI/F7BFlqSvVpFbjdgYRRLysAeEZpJ6S1lg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.104",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.104.tgz",
+      "integrity": "sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.53",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.53.tgz",
+      "integrity": "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/@arkeon-wiki/explorer": {
       "resolved": "packages/explorer",
       "link": true
@@ -801,6 +879,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@react-sigma/core": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@react-sigma/core/-/core-5.0.6.tgz",
@@ -1168,6 +1255,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
@@ -1558,6 +1651,15 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -1726,6 +1828,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.168",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.168.tgz",
+      "integrity": "sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.104",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -2325,6 +2445,15 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -2613,6 +2742,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -4763,8 +4898,11 @@
       "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.71",
+        "@ai-sdk/openai": "^3.0.53",
         "@hono/node-server": "^1.19.11",
         "@vscode/ripgrep": "^1.17.1",
+        "ai": "^6.0.168",
         "better-sqlite3": "^12.9.0",
         "commander": "^14.0.1",
         "conf": "^13.0.1",

--- a/packages/arkeon/package.json
+++ b/packages/arkeon/package.json
@@ -30,8 +30,11 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.71",
+    "@ai-sdk/openai": "^3.0.53",
     "@hono/node-server": "^1.19.11",
     "@vscode/ripgrep": "^1.17.1",
+    "ai": "^6.0.168",
     "better-sqlite3": "^12.9.0",
     "commander": "^14.0.1",
     "conf": "^13.0.1",

--- a/packages/arkeon/src/schema/001-foundation.sql
+++ b/packages/arkeon/src/schema/001-foundation.sql
@@ -59,3 +59,16 @@ CREATE TABLE IF NOT EXISTS contributions (
 CREATE INDEX IF NOT EXISTS idx_contributions_wiki ON contributions(wiki_id);
 CREATE INDEX IF NOT EXISTS idx_contributions_pending
   ON contributions(wiki_id) WHERE consumed_at IS NULL;
+
+-- Agent runs: idempotency tracking for the agent runtime. Keyed by
+-- (role, idempotency_key); the input_hash lets the runtime decide
+-- whether a re-trigger of the same key represents new work or a replay.
+CREATE TABLE IF NOT EXISTS agent_runs (
+  role TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  input_hash TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('completed', 'failed')),
+  finished_at TEXT NOT NULL DEFAULT (datetime('now')),
+  error TEXT,
+  PRIMARY KEY (role, idempotency_key)
+);

--- a/packages/arkeon/src/schema/001-foundation.sql
+++ b/packages/arkeon/src/schema/001-foundation.sql
@@ -72,3 +72,9 @@ CREATE TABLE IF NOT EXISTS agent_runs (
   error TEXT,
   PRIMARY KEY (role, idempotency_key)
 );
+
+-- Supports recency queries: "recent failed runs" for diagnostics,
+-- "runs in the last hour" for monitoring. Cheap insurance while the
+-- schema is fresh.
+CREATE INDEX IF NOT EXISTS idx_agent_runs_finished
+  ON agent_runs(role, finished_at);

--- a/packages/arkeon/src/server/agents/define-tool.ts
+++ b/packages/arkeon/src/server/agents/define-tool.ts
@@ -23,9 +23,6 @@ import type { AgentContext } from "./runtime.js";
 export interface DefineToolOptions<TInput, TOutput> {
   description: string;
   inputSchema: z.ZodType<TInput>;
-  /** Mutating tools must be opted into — useful when (later) gating
-   *  read-only review modes. Defaults to false (mutating). */
-  readOnly?: boolean;
   /** What actually runs. Receives the validated input and the agent
    *  context (space, applyEdit, log, ...). */
   call: (input: TInput, ctx: AgentContext) => Promise<TOutput> | TOutput;
@@ -53,6 +50,12 @@ export function defineTool<TInput, TOutput>(
         }
       },
     };
+    // The AI SDK's Tool type carries a tangle of provider-specific
+    // generics (FlexibleSchema, ToolOutputProperties, ...) that don't
+    // infer cleanly from our user-facing DefineToolOptions shape. The
+    // double cast skips that inference dance — the runtime contract
+    // (description + inputSchema + execute) is what the SDK actually
+    // calls, and that's what `definition` provides.
     return definition as unknown as Tool;
   };
 }

--- a/packages/arkeon/src/server/agents/define-tool.ts
+++ b/packages/arkeon/src/server/agents/define-tool.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `defineTool` — the boilerplate-eating helper that turns a regular
+ * library function into an AI-SDK-compatible tool factory.
+ *
+ * Each tool defined with this helper:
+ *   - has its description and input schema in one place
+ *   - auto-binds the AgentContext (so `space` is wired without effort)
+ *   - logs every invocation through ctx.log
+ *   - is reused across roles by name (see ./tools.ts)
+ *
+ * Adding a new tool is one entry in tools.ts; the bottlenecks
+ * (description quality, schema design) are forced into the open.
+ */
+
+import type { Tool } from "ai";
+import { z } from "zod";
+
+import type { AgentContext } from "./runtime.js";
+
+export interface DefineToolOptions<TInput, TOutput> {
+  description: string;
+  inputSchema: z.ZodType<TInput>;
+  /** Mutating tools must be opted into — useful when (later) gating
+   *  read-only review modes. Defaults to false (mutating). */
+  readOnly?: boolean;
+  /** What actually runs. Receives the validated input and the agent
+   *  context (space, applyEdit, log, ...). */
+  call: (input: TInput, ctx: AgentContext) => Promise<TOutput> | TOutput;
+}
+
+/** A function that, given a context, returns the AI-SDK tool. */
+export type ToolFactory = (ctx: AgentContext) => Tool;
+
+export function defineTool<TInput, TOutput>(
+  name: string,
+  opts: DefineToolOptions<TInput, TOutput>,
+): ToolFactory {
+  return (ctx: AgentContext): Tool => {
+    const definition = {
+      description: opts.description,
+      inputSchema: opts.inputSchema,
+      execute: async (input: TInput) => {
+        ctx.log("info", `tool/${name}`, { input });
+        try {
+          return await opts.call(input, ctx);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          ctx.log("error", `tool/${name} failed`, { error: message });
+          throw err;
+        }
+      },
+    };
+    return definition as unknown as Tool;
+  };
+}

--- a/packages/arkeon/src/server/agents/model.ts
+++ b/packages/arkeon/src/server/agents/model.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Provider-agnostic model selection for the agent runtime.
+ *
+ * Three providers cover everything we care about today:
+ *   - "anthropic"          @ai-sdk/anthropic, native (Claude + caching)
+ *   - "openai"             @ai-sdk/openai, official OpenAI endpoint
+ *   - "openai-compatible"  @ai-sdk/openai with custom baseURL — covers
+ *                          Ollama (http://localhost:11434/v1), LM Studio,
+ *                          llama.cpp's --server, vLLM, OpenRouter, Groq,
+ *                          Together, and anything else that speaks
+ *                          OpenAI's chat/completions shape.
+ *
+ * Roles take a ModelConfig; resolveModel returns the AI SDK
+ * LanguageModel they hand to generateText. Swapping cloud-Anthropic for
+ * local-Ollama is a config change, not a code change.
+ */
+
+import type { LanguageModel } from "ai";
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createOpenAI } from "@ai-sdk/openai";
+
+export type ModelConfig =
+  | { provider: "anthropic"; id: string; apiKey?: string }
+  | { provider: "openai"; id: string; apiKey?: string }
+  | {
+      provider: "openai-compatible";
+      id: string;
+      baseURL: string;
+      apiKey?: string;
+    };
+
+export function resolveModel(config: ModelConfig): LanguageModel {
+  switch (config.provider) {
+    case "anthropic": {
+      const provider = createAnthropic({ apiKey: config.apiKey });
+      return provider(config.id);
+    }
+    case "openai": {
+      const provider = createOpenAI({ apiKey: config.apiKey });
+      return provider(config.id);
+    }
+    case "openai-compatible": {
+      // Local servers (Ollama, LM Studio, etc.) typically don't require
+      // a real key but the SDK demands the field be present.
+      const provider = createOpenAI({
+        baseURL: config.baseURL,
+        apiKey: config.apiKey ?? "not-required",
+      });
+      return provider(config.id);
+    }
+  }
+}

--- a/packages/arkeon/src/server/agents/runtime.ts
+++ b/packages/arkeon/src/server/agents/runtime.ts
@@ -77,12 +77,22 @@ export interface AgentRunResult {
   usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number };
 }
 
+export interface RunAgentOptions {
+  /**
+   * Pre-resolved language model to use instead of resolveModel(role.model).
+   * Useful for tests (mock models) and for per-call routing where the
+   * caller has already chosen a model based on input shape.
+   */
+  modelOverride?: LanguageModel;
+}
+
 // ── Public entry point ────────────────────────────────────────────
 
 export async function runAgent(
   role: AgentRole,
   input: AgentInput,
   registry: ToolRegistry,
+  options: RunAgentOptions = {},
 ): Promise<AgentRunResult> {
   return withPathLock(role.concurrencyKey(input), async () => {
     const idem = role.idempotencyKey(input);
@@ -102,9 +112,11 @@ export async function runAgent(
       tools[name] = factory(ctx);
     }
 
+    const model = options.modelOverride ?? (resolveModel(role.model) as LanguageModel);
+
     try {
       const result = await generateText({
-        model: resolveModel(role.model) as LanguageModel,
+        model,
         system,
         prompt,
         tools,

--- a/packages/arkeon/src/server/agents/runtime.ts
+++ b/packages/arkeon/src/server/agents/runtime.ts
@@ -129,7 +129,7 @@ export async function runAgent(
         skipped: false,
         edits: ctx.edits,
         text: result.text,
-        steps: result.steps?.length ?? 1,
+        steps: result.steps.length,
         usage: {
           inputTokens: result.totalUsage?.inputTokens,
           outputTokens: result.totalUsage?.outputTokens,
@@ -167,11 +167,32 @@ export function makeContext(space: Space, role: string): AgentContext {
 /**
  * Deterministic hash of an arbitrary JSON-serializable value. Used to
  * decide whether a re-trigger represents new work.
+ *
+ * Object keys are sorted recursively before hashing so two objects that
+ * are logically equal but built in different key orders produce the
+ * same digest — without this, role-defined idempotencyKey functions
+ * could spuriously re-trigger when callers happen to assemble the input
+ * in a different order.
  */
 export function hashInput(input: unknown): string {
-  return createHash("sha256")
-    .update(JSON.stringify(input ?? null))
-    .digest("hex");
+  return createHash("sha256").update(stableStringify(input)).digest("hex");
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || value === undefined) return "null";
+  if (typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return "[" + value.map(stableStringify).join(",") + "]";
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return (
+    "{" +
+    keys
+      .map((k) => JSON.stringify(k) + ":" + stableStringify(obj[k]))
+      .join(",") +
+    "}"
+  );
 }
 
 // ── Idempotency table ─────────────────────────────────────────────

--- a/packages/arkeon/src/server/agents/runtime.ts
+++ b/packages/arkeon/src/server/agents/runtime.ts
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Agent runtime: the shared loop that powers the contributor, editor,
+ * and any future role.
+ *
+ * A role describes:
+ *   - which model to call          (ModelConfig)
+ *   - what prompt to send          (buildPrompt)
+ *   - what tools the LLM can use   (a list of names from the registry)
+ *   - how to key idempotency       (so re-triggers on the same input
+ *                                    with the same hash are skipped)
+ *   - how to key concurrency       (so two runs targeting the same
+ *                                    wiki/source serialize)
+ *
+ * The runtime owns: locking, idempotency lookup, tool wiring, the AI
+ * SDK call, and persistence of the run record. Roles stay tiny.
+ */
+
+import { createHash } from "node:crypto";
+
+import { generateText, stepCountIs, type LanguageModel, type Tool } from "ai";
+
+import { applyEdit, type ApplyEditResult, type FileEdit } from "../lib/file-edits.js";
+import { withPathLock } from "../lib/path-lock.js";
+import { createSql } from "../lib/sql.js";
+import { type Space } from "../lib/sync.js";
+
+import { resolveModel, type ModelConfig } from "./model.js";
+
+// ── Types ─────────────────────────────────────────────────────────
+
+export interface AgentContext {
+  space: Space;
+  role: string;
+  edits: ApplyEditResult[];
+  applyEdit(edit: FileEdit): Promise<ApplyEditResult>;
+  log(level: "info" | "warn" | "error", msg: string, meta?: Record<string, unknown>): void;
+}
+
+export type ToolFactory = (ctx: AgentContext) => Tool;
+export type ToolRegistry = Record<string, ToolFactory>;
+
+export interface AgentInput {
+  space: Space;
+  triggerPath?: string;
+  triggerEntityId?: string;
+  meta?: Record<string, unknown>;
+}
+
+export interface IdempotencyKey {
+  /** Stable identifier for "what was triggered" (e.g. a wiki id, source path). */
+  key: string;
+  /** Hash of the inputs the agent will see. Detects "same trigger, new content". */
+  hash: string;
+}
+
+export interface AgentRole {
+  name: string;
+  model: ModelConfig;
+  /** Tool names looked up in the registry passed to runAgent. */
+  tools: string[];
+  /** Default 10. Caps the tool-use loop so a runaway agent can't churn forever. */
+  maxSteps?: number;
+  buildPrompt(input: AgentInput): Promise<{ system: string; prompt: string }>;
+  idempotencyKey(input: AgentInput): IdempotencyKey;
+  concurrencyKey(input: AgentInput): string;
+}
+
+export interface AgentRunResult {
+  skipped: boolean;
+  reason?: string;
+  edits: ApplyEditResult[];
+  text: string;
+  steps: number;
+  usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number };
+}
+
+// ── Public entry point ────────────────────────────────────────────
+
+export async function runAgent(
+  role: AgentRole,
+  input: AgentInput,
+  registry: ToolRegistry,
+): Promise<AgentRunResult> {
+  return withPathLock(role.concurrencyKey(input), async () => {
+    const idem = role.idempotencyKey(input);
+    if (await alreadyProcessed(role.name, idem)) {
+      return { skipped: true, reason: "already_processed", edits: [], text: "", steps: 0 };
+    }
+
+    const ctx = makeContext(input.space, role.name);
+    const { system, prompt } = await role.buildPrompt(input);
+
+    const tools: Record<string, Tool> = {};
+    for (const name of role.tools) {
+      const factory = registry[name];
+      if (!factory) {
+        throw new Error(`Unknown tool '${name}' requested by role '${role.name}'`);
+      }
+      tools[name] = factory(ctx);
+    }
+
+    try {
+      const result = await generateText({
+        model: resolveModel(role.model) as LanguageModel,
+        system,
+        prompt,
+        tools,
+        stopWhen: stepCountIs(role.maxSteps ?? 10),
+      });
+
+      await markProcessed(role.name, idem, "completed", null);
+
+      return {
+        skipped: false,
+        edits: ctx.edits,
+        text: result.text,
+        steps: result.steps?.length ?? 1,
+        usage: {
+          inputTokens: result.totalUsage?.inputTokens,
+          outputTokens: result.totalUsage?.outputTokens,
+          totalTokens: result.totalUsage?.totalTokens,
+        },
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await markProcessed(role.name, idem, "failed", msg);
+      throw err;
+    }
+  });
+}
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+export function makeContext(space: Space, role: string): AgentContext {
+  const edits: ApplyEditResult[] = [];
+  return {
+    space,
+    role,
+    edits,
+    applyEdit: async (edit) => {
+      const result = await applyEdit(space, edit);
+      edits.push(result);
+      return result;
+    },
+    log: (level, msg, meta) => {
+      const tail = meta ? ` ${JSON.stringify(meta)}` : "";
+      console.log(`[agent/${role}/${level}] ${msg}${tail}`);
+    },
+  };
+}
+
+/**
+ * Deterministic hash of an arbitrary JSON-serializable value. Used to
+ * decide whether a re-trigger represents new work.
+ */
+export function hashInput(input: unknown): string {
+  return createHash("sha256")
+    .update(JSON.stringify(input ?? null))
+    .digest("hex");
+}
+
+// ── Idempotency table ─────────────────────────────────────────────
+
+export async function alreadyProcessed(
+  role: string,
+  idem: IdempotencyKey,
+): Promise<boolean> {
+  const sql = createSql();
+  const rows = await sql`
+    SELECT input_hash, status FROM agent_runs
+    WHERE role = ${role} AND idempotency_key = ${idem.key}
+  `;
+  if (rows.length === 0) return false;
+  const row = rows[0];
+  return row.status === "completed" && row.input_hash === idem.hash;
+}
+
+export async function markProcessed(
+  role: string,
+  idem: IdempotencyKey,
+  status: "completed" | "failed",
+  error: string | null,
+): Promise<void> {
+  const sql = createSql();
+  await sql`
+    INSERT INTO agent_runs (role, idempotency_key, input_hash, status, error)
+    VALUES (${role}, ${idem.key}, ${idem.hash}, ${status}, ${error})
+    ON CONFLICT(role, idempotency_key) DO UPDATE SET
+      input_hash = excluded.input_hash,
+      status = excluded.status,
+      finished_at = datetime('now'),
+      error = excluded.error
+  `;
+}

--- a/packages/arkeon/src/server/agents/tools.ts
+++ b/packages/arkeon/src/server/agents/tools.ts
@@ -12,12 +12,12 @@
  * the Zod input schema, not the registration line.
  */
 
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync, statSync } from "node:fs";
 
 import { z } from "zod";
 
 import { contribute } from "../lib/contributions.js";
+import { safeResolve } from "../lib/file-edits.js";
 import { parseFrontmatter } from "../lib/frontmatter.js";
 import { search as ripgrepSearch } from "../lib/search.js";
 
@@ -34,9 +34,12 @@ const readFileTool = defineTool("read_file", {
     path: z.string().describe("Relative path inside the space's watch_dir."),
   }),
   call: ({ path }, ctx) => {
-    const absPath = join(ctx.space.watch_dir, path);
+    const absPath = safeResolve(ctx.space.watch_dir, path);
     if (!existsSync(absPath)) {
       throw new Error(`read_file: ${path} does not exist`);
+    }
+    if (statSync(absPath).isDirectory()) {
+      throw new Error(`read_file: ${path} is a directory`);
     }
     const content = readFileSync(absPath, "utf-8");
     if (path.endsWith(".md")) {
@@ -153,6 +156,9 @@ const contributeTool = defineTool("contribute", {
       subject,
       excerpt,
       claim,
+      // Route the resulting write through the context's applyEdit so the
+      // new/updated wiki shows up in ctx.edits alongside other tool edits.
+      applyEdit: ctx.applyEdit,
     }),
 });
 

--- a/packages/arkeon/src/server/agents/tools.ts
+++ b/packages/arkeon/src/server/agents/tools.ts
@@ -29,7 +29,6 @@ const readFileTool = defineTool("read_file", {
   description:
     "Read a file from the current space. Path is relative to the space's watch_dir. " +
     "For markdown files, parsed YAML frontmatter is returned alongside the body.",
-  readOnly: true,
   inputSchema: z.object({
     path: z.string().describe("Relative path inside the space's watch_dir."),
   }),
@@ -61,7 +60,6 @@ const searchTool = defineTool("search", {
     "Keyword-search markdown content in the current space using ripgrep. " +
     "Returns ranked entity hits with line snippets. Use this to find related " +
     "wikis or source files before deciding what to contribute or edit.",
-  readOnly: true,
   inputSchema: z.object({
     query: z.string().describe("The substring or regex to search for."),
     regex: z.boolean().optional().describe("Treat query as a regex (default false)."),

--- a/packages/arkeon/src/server/agents/tools.ts
+++ b/packages/arkeon/src/server/agents/tools.ts
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The shared tool registry.
+ *
+ * Each entry wires a library function (or a deterministic helper like
+ * `contribute`) into the agent runtime. Roles list tool names; the
+ * runtime instantiates each named factory with the AgentContext.
+ *
+ * Adding a new tool: one entry here. The cost is the description and
+ * the Zod input schema, not the registration line.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { z } from "zod";
+
+import { contribute } from "../lib/contributions.js";
+import { parseFrontmatter } from "../lib/frontmatter.js";
+import { search as ripgrepSearch } from "../lib/search.js";
+
+import { defineTool, type ToolFactory } from "./define-tool.js";
+
+// ── read_file ─────────────────────────────────────────────────────
+
+const readFileTool = defineTool("read_file", {
+  description:
+    "Read a file from the current space. Path is relative to the space's watch_dir. " +
+    "For markdown files, parsed YAML frontmatter is returned alongside the body.",
+  readOnly: true,
+  inputSchema: z.object({
+    path: z.string().describe("Relative path inside the space's watch_dir."),
+  }),
+  call: ({ path }, ctx) => {
+    const absPath = join(ctx.space.watch_dir, path);
+    if (!existsSync(absPath)) {
+      throw new Error(`read_file: ${path} does not exist`);
+    }
+    const content = readFileSync(absPath, "utf-8");
+    if (path.endsWith(".md")) {
+      const parsed = parseFrontmatter(content);
+      return {
+        path,
+        frontmatter: parsed.properties,
+        body: parsed.body,
+      };
+    }
+    return { path, content };
+  },
+});
+
+// ── search ────────────────────────────────────────────────────────
+
+const searchTool = defineTool("search", {
+  description:
+    "Keyword-search markdown content in the current space using ripgrep. " +
+    "Returns ranked entity hits with line snippets. Use this to find related " +
+    "wikis or source files before deciding what to contribute or edit.",
+  readOnly: true,
+  inputSchema: z.object({
+    query: z.string().describe("The substring or regex to search for."),
+    regex: z.boolean().optional().describe("Treat query as a regex (default false)."),
+    limit: z.number().int().positive().optional().describe("Max hits (default 20)."),
+    max_snippets_per_file: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe("Max line snippets per matching file (default 3)."),
+  }),
+  call: ({ query, regex, limit, max_snippets_per_file }, ctx) =>
+    ripgrepSearch({
+      query,
+      spaceId: ctx.space.id,
+      regex,
+      limit,
+      maxSnippetsPerFile: max_snippets_per_file,
+    }),
+});
+
+// ── edit_file ─────────────────────────────────────────────────────
+
+const editFileTool = defineTool("edit_file", {
+  description:
+    "Replace a unique span in an existing file (Aider-style SEARCH/REPLACE). " +
+    "The `search` string MUST appear exactly once in the file. " +
+    "Use the smallest unique anchor; copy whitespace verbatim.",
+  inputSchema: z.object({
+    path: z.string().describe("Relative path inside the space's watch_dir."),
+    search: z.string().describe("The exact span to replace; must match exactly once."),
+    replace: z.string().describe("The text that replaces the matched span."),
+  }),
+  call: async ({ path, search, replace }, ctx) => {
+    const result = await ctx.applyEdit({ kind: "edit", path, search, replace });
+    return { path: result.path, applied: true };
+  },
+});
+
+// ── write_file ────────────────────────────────────────────────────
+
+const writeFileTool = defineTool("write_file", {
+  description:
+    "Create or overwrite a file with the given content. Use for net-new files " +
+    "(e.g. a fresh placeholder wiki); prefer edit_file for modifying existing ones.",
+  inputSchema: z.object({
+    path: z.string().describe("Relative path inside the space's watch_dir."),
+    content: z.string().describe("Full file contents."),
+  }),
+  call: async ({ path, content }, ctx) => {
+    const result = await ctx.applyEdit({ kind: "write", path, content });
+    return { path: result.path, applied: true };
+  },
+});
+
+// ── contribute ────────────────────────────────────────────────────
+
+const contributeTool = defineTool("contribute", {
+  description:
+    "Route a (subject, excerpt, claim) triple to the right wiki. Matches an " +
+    "existing wiki by exact label/alias if one exists; otherwise creates a " +
+    "placeholder under wiki/{subject_type}/{slug}.md. The contribution is " +
+    "appended to the target wiki's frontmatter `contributions[]` array.",
+  inputSchema: z.object({
+    subject: z.object({
+      label: z.string().describe("Canonical subject name, e.g. 'Claude Shannon'."),
+      subject_type: z
+        .string()
+        .optional()
+        .describe("Semantic type, e.g. 'person', 'organization', 'concept'."),
+      aliases: z
+        .array(z.string())
+        .optional()
+        .describe("Alternate forms to try when matching existing wikis."),
+    }),
+    excerpt: z
+      .string()
+      .describe("Verbatim or near-verbatim quote from the source."),
+    claim: z
+      .string()
+      .optional()
+      .describe("Optional one-line summary of what the excerpt establishes."),
+    source_id: z
+      .string()
+      .optional()
+      .describe("Entity id of the source file this excerpt came from."),
+  }),
+  call: ({ subject, excerpt, claim, source_id }, ctx) =>
+    contribute({
+      space_id: ctx.space.id,
+      source_id: source_id ?? null,
+      subject,
+      excerpt,
+      claim,
+    }),
+});
+
+// ── Registry ──────────────────────────────────────────────────────
+
+export const ALL_TOOLS: Record<string, ToolFactory> = {
+  read_file: readFileTool,
+  search: searchTool,
+  edit_file: editFileTool,
+  write_file: writeFileTool,
+  contribute: contributeTool,
+};

--- a/packages/arkeon/src/server/lib/contributions.ts
+++ b/packages/arkeon/src/server/lib/contributions.ts
@@ -13,14 +13,15 @@
  * contributors edit wiki files on disk; the watcher does the rest.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 
 import { createSql } from "./sql.js";
 import { generateUlid } from "./ids.js";
 import { ApiError } from "./errors.js";
+import { applyEdit } from "./file-edits.js";
 import { parseFrontmatter, serializeFrontmatter } from "./frontmatter.js";
-import { syncFile, type Space } from "./sync.js";
+import { type Space } from "./sync.js";
 
 export interface MatchedWiki {
   id: string;
@@ -243,8 +244,11 @@ export async function contribute(input: ContributeInput): Promise<ContributeResu
         ...parsed.properties,
         contributions: [...existing, contribution],
       };
-      writeFileSync(absPath, serializeFrontmatter(updated, parsed.body), "utf-8");
-      await syncFile(space, wikiPath);
+      await applyEdit(space, {
+        kind: "write",
+        path: wikiPath,
+        content: serializeFrontmatter(updated, parsed.body),
+      });
 
       return {
         wiki_id: match.id,
@@ -257,8 +261,6 @@ export async function contribute(input: ContributeInput): Promise<ContributeResu
     const wikiId = generateUlid();
     const desiredPath = placeholderPath(input.subject.subject_type, input.subject.label);
     const wikiPath = findFreePath(space.watch_dir, desiredPath);
-    const absPath = join(space.watch_dir, wikiPath);
-    mkdirSync(dirname(absPath), { recursive: true });
 
     const props: Record<string, unknown> = {
       id: wikiId,
@@ -269,8 +271,11 @@ export async function contribute(input: ContributeInput): Promise<ContributeResu
     props.status = "placeholder";
     props.contributions = [contribution];
 
-    writeFileSync(absPath, serializeFrontmatter(props, ""), "utf-8");
-    await syncFile(space, wikiPath);
+    await applyEdit(space, {
+      kind: "write",
+      path: wikiPath,
+      content: serializeFrontmatter(props, ""),
+    });
 
     return {
       wiki_id: wikiId,

--- a/packages/arkeon/src/server/lib/contributions.ts
+++ b/packages/arkeon/src/server/lib/contributions.ts
@@ -19,7 +19,7 @@ import { join } from "node:path";
 import { createSql } from "./sql.js";
 import { generateUlid } from "./ids.js";
 import { ApiError } from "./errors.js";
-import { applyEdit } from "./file-edits.js";
+import { applyEdit, type ApplyEditResult, type FileEdit } from "./file-edits.js";
 import { parseFrontmatter, serializeFrontmatter } from "./frontmatter.js";
 import { withPathLock } from "./path-lock.js";
 import { type Space } from "./sync.js";
@@ -136,6 +136,13 @@ export interface ContributeInput {
   };
   excerpt: string;
   claim?: string;
+  /**
+   * Override the function used to apply the resulting FileEdit. The agent
+   * runtime passes its context-bound applyEdit so the new wiki/contribution
+   * shows up in `ctx.edits`. External callers can omit this and get the
+   * default lib `applyEdit(space, edit)` behavior.
+   */
+  applyEdit?: (edit: FileEdit) => Promise<ApplyEditResult>;
 }
 
 export interface ContributeResult {
@@ -201,6 +208,8 @@ export async function contribute(input: ContributeInput): Promise<ContributeResu
     added_at: new Date().toISOString(),
   };
 
+  const apply = input.applyEdit ?? ((edit: FileEdit) => applyEdit(space, edit));
+
   // Serialize on the space so the lookup-and-act sequence is atomic with
   // respect to other contributions in the same space. Different spaces
   // proceed in parallel.
@@ -223,7 +232,7 @@ export async function contribute(input: ContributeInput): Promise<ContributeResu
         ...parsed.properties,
         contributions: [...existing, contribution],
       };
-      await applyEdit(space, {
+      await apply({
         kind: "write",
         path: wikiPath,
         content: serializeFrontmatter(updated, parsed.body),
@@ -250,7 +259,7 @@ export async function contribute(input: ContributeInput): Promise<ContributeResu
     props.status = "placeholder";
     props.contributions = [contribution];
 
-    await applyEdit(space, {
+    await apply({
       kind: "write",
       path: wikiPath,
       content: serializeFrontmatter(props, ""),

--- a/packages/arkeon/src/server/lib/contributions.ts
+++ b/packages/arkeon/src/server/lib/contributions.ts
@@ -21,6 +21,7 @@ import { generateUlid } from "./ids.js";
 import { ApiError } from "./errors.js";
 import { applyEdit } from "./file-edits.js";
 import { parseFrontmatter, serializeFrontmatter } from "./frontmatter.js";
+import { withPathLock } from "./path-lock.js";
 import { type Space } from "./sync.js";
 
 export interface MatchedWiki {
@@ -121,28 +122,6 @@ export async function findMatchingWiki(
   }
 
   return null;
-}
-
-// ── Keyed write serialization ───────────────────────────────────────
-//
-// Two contribute() calls that race on the same key would interleave
-// findMatchingWiki / findFreePath / writeFile — both could decide to
-// create the same wiki, then one would overwrite the other's entity
-// row. We serialize the full lookup-and-act sequence on a key (the
-// space id, in practice) so each operation observes the previous one's
-// committed state. In-process only; cross-process locking is out of
-// scope.
-
-const _keyQueues = new Map<string, Promise<unknown>>();
-
-export function withPathLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
-  const previous = _keyQueues.get(key) ?? Promise.resolve();
-  const next = previous.then(fn, fn);
-  _keyQueues.set(
-    key,
-    next.catch(() => {}),
-  );
-  return next;
 }
 
 // ── Orchestration ───────────────────────────────────────────────────

--- a/packages/arkeon/src/server/lib/file-edits.ts
+++ b/packages/arkeon/src/server/lib/file-edits.ts
@@ -22,7 +22,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, resolve, sep } from "node:path";
 
 import { removeByPath, syncFile, type Space, type SyncResult } from "./sync.js";
 
@@ -30,6 +30,28 @@ export type FileEdit =
   | { kind: "write"; path: string; content: string }
   | { kind: "edit"; path: string; search: string; replace: string }
   | { kind: "delete"; path: string };
+
+/**
+ * Resolve a relative path against a watch dir, rejecting absolute paths
+ * and `..` escapes. The returned path is guaranteed to be inside the
+ * watch dir. Used wherever path strings cross a trust boundary (LLM
+ * tool input, HTTP body, etc.).
+ */
+export function safeResolve(watchDir: string, relativePath: string): string {
+  if (isAbsolute(relativePath)) {
+    throw new Error(
+      `path '${relativePath}' is absolute; must be relative to the watch dir`,
+    );
+  }
+  const baseAbs = resolve(watchDir);
+  const candidate = resolve(baseAbs, relativePath);
+  if (candidate !== baseAbs && !candidate.startsWith(baseAbs + sep)) {
+    throw new Error(
+      `path '${relativePath}' escapes the space's watch directory`,
+    );
+  }
+  return candidate;
+}
 
 export type ApplyEditResult =
   | { path: string; kind: "write" | "edit"; sync: SyncResult }
@@ -42,7 +64,7 @@ export type ApplyEditResult =
  * and SEARCH that doesn't match exactly once for `edit`.
  */
 export async function applyEdit(space: Space, edit: FileEdit): Promise<ApplyEditResult> {
-  const absPath = join(space.watch_dir, edit.path);
+  const absPath = safeResolve(space.watch_dir, edit.path);
 
   if (edit.kind === "write") {
     mkdirSync(dirname(absPath), { recursive: true });

--- a/packages/arkeon/src/server/lib/file-edits.ts
+++ b/packages/arkeon/src/server/lib/file-edits.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Universal mutation primitive for wiki files.
+ *
+ * Every routing helper (contribute) and every agent emits `FileEdit`s
+ * and runs them through `applyEdit`. One chokepoint gives us one place
+ * to wire post-mutation indexing, future audit logging, and the rule
+ * that the SQLite mirror is rebuilt from disk after every change.
+ *
+ * Three kinds:
+ *   - write   create or overwrite a file with full content
+ *   - edit    SEARCH/REPLACE a unique span in an existing file (Aider-style)
+ *   - delete  remove a file from disk and the index
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+import { removeByPath, syncFile, type Space, type SyncResult } from "./sync.js";
+
+export type FileEdit =
+  | { kind: "write"; path: string; content: string }
+  | { kind: "edit"; path: string; search: string; replace: string }
+  | { kind: "delete"; path: string };
+
+export type ApplyEditResult =
+  | { path: string; kind: "write" | "edit"; sync: SyncResult }
+  | { path: string; kind: "delete"; removedEntityId: string | null };
+
+/**
+ * Apply a single edit and propagate the change into the SQLite index.
+ *
+ * Throws on edit semantics violations: missing files for `edit`/`delete`,
+ * and SEARCH that doesn't match exactly once for `edit`.
+ */
+export async function applyEdit(space: Space, edit: FileEdit): Promise<ApplyEditResult> {
+  const absPath = join(space.watch_dir, edit.path);
+
+  if (edit.kind === "write") {
+    mkdirSync(dirname(absPath), { recursive: true });
+    writeFileSync(absPath, edit.content, "utf-8");
+    const sync = await syncFile(space, edit.path);
+    return { path: edit.path, kind: "write", sync };
+  }
+
+  if (edit.kind === "edit") {
+    if (!existsSync(absPath)) {
+      throw new Error(`edit_file: ${edit.path} does not exist`);
+    }
+    if (edit.search.length === 0) {
+      throw new Error(`edit_file: search must be non-empty`);
+    }
+    const original = readFileSync(absPath, "utf-8");
+    const matches = countOccurrences(original, edit.search);
+    if (matches === 0) {
+      throw new Error(`edit_file: search did not match in ${edit.path}`);
+    }
+    if (matches > 1) {
+      throw new Error(
+        `edit_file: search matched ${matches} times in ${edit.path} (must be unique)`,
+      );
+    }
+    const updated = original.replace(edit.search, edit.replace);
+    writeFileSync(absPath, updated, "utf-8");
+    const sync = await syncFile(space, edit.path);
+    return { path: edit.path, kind: "edit", sync };
+  }
+
+  if (!existsSync(absPath)) {
+    throw new Error(`delete_file: ${edit.path} does not exist`);
+  }
+  unlinkSync(absPath);
+  const removedEntityId = await removeByPath(space.id, edit.path);
+  return { path: edit.path, kind: "delete", removedEntityId };
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  let count = 0;
+  let pos = 0;
+  while ((pos = haystack.indexOf(needle, pos)) !== -1) {
+    count++;
+    pos += needle.length;
+  }
+  return count;
+}

--- a/packages/arkeon/src/server/lib/path-lock.ts
+++ b/packages/arkeon/src/server/lib/path-lock.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Keyed in-process serialization. Wrap a critical section in
+ * `withPathLock(key, fn)` and concurrent callers sharing the same key
+ * run sequentially; different keys proceed in parallel.
+ *
+ * Used by `contribute()` (per-space) and the agent runtime
+ * (per-role-and-target). In-process only — cross-process locking is
+ * out of scope for the single-daemon model.
+ */
+
+const _keyQueues = new Map<string, Promise<unknown>>();
+
+export function withPathLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const previous = _keyQueues.get(key) ?? Promise.resolve();
+  const next = previous.then(fn, fn);
+  _keyQueues.set(
+    key,
+    next.catch(() => {}),
+  );
+  return next;
+}

--- a/packages/arkeon/test/e2e/agent-runtime-mockmodel.test.ts
+++ b/packages/arkeon/test/e2e/agent-runtime-mockmodel.test.ts
@@ -1,0 +1,394 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Layer 2: scripted-LLM tests for the agent runtime.
+ *
+ * Uses MockLanguageModelV3 from `ai/test` to drive runAgent through
+ * deterministic tool-call sequences without an API key. Validates the
+ * runtime contract: tool wiring, edit accumulation, idempotency lookup
+ * and write, retry-on-failure, and the step-count cap.
+ *
+ * Together with agent-tools.test.ts (Layer 1, per-tool edge cases),
+ * this gives the contributor (#49) and editor (#50) workers a runtime
+ * they can build on without retesting the plumbing.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+
+import { MockLanguageModelV3 } from "ai/test";
+import type {
+  LanguageModelV3GenerateResult,
+  LanguageModelV3Usage,
+} from "@ai-sdk/provider";
+
+import { runAgent, type AgentRole } from "../../src/server/agents/runtime.js";
+import { ALL_TOOLS } from "../../src/server/agents/tools.js";
+import { createSql } from "../../src/server/lib/sql.js";
+import type { Space } from "../../src/server/lib/sync.js";
+
+const API_PORT = 18798;
+
+let testDir: string;
+let stateDir: string;
+let serverHandle: { stop: () => Promise<void> } | null = null;
+let space: Space;
+
+beforeAll(async () => {
+  const base = join(tmpdir(), `arkeon-mockmodel-${randomBytes(4).toString("hex")}`);
+  testDir = join(base, "repo");
+  stateDir = join(base, "state");
+  mkdirSync(testDir, { recursive: true });
+  mkdirSync(join(stateDir, "data"), { recursive: true });
+  mkdirSync(join(testDir, "wiki"), { recursive: true });
+
+  process.env.ARKEON_WIKI_HOME = stateDir;
+
+  const dbFile = join(stateDir, "data", "arke.db");
+  const { runMigrations } = await import("../../src/schema/index.js");
+  await runMigrations({ dbPath: dbFile });
+
+  const { startApi } = await import("../../src/server/server.js");
+  const apiHandle = await startApi({ port: API_PORT, dbPath: dbFile });
+  serverHandle = { stop: async () => apiHandle.stop() };
+
+  const spaceRes = await fetch(`http://localhost:${API_PORT}/spaces`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: "mockmodel-space", watch_dir: testDir }),
+  });
+  const json = (await spaceRes.json()) as { id: string };
+  space = { id: json.id, name: "mockmodel-space", watch_dir: testDir };
+}, 30_000);
+
+afterAll(async () => {
+  if (serverHandle) await serverHandle.stop();
+  if (testDir && existsSync(testDir)) {
+    rmSync(testDir.substring(0, testDir.lastIndexOf("/")), {
+      recursive: true,
+      force: true,
+    });
+  }
+}, 30_000);
+
+afterEach(async () => {
+  // Reset idempotency table between tests so each starts fresh.
+  const sql = createSql();
+  await sql`DELETE FROM agent_runs`;
+});
+
+// ── Mock helpers ──────────────────────────────────────────────────
+
+function makeUsage(): LanguageModelV3Usage {
+  return {
+    inputTokens: { total: 10, noCache: 10, cacheRead: 0, cacheWrite: 0 },
+    outputTokens: { total: 5, text: 5, reasoning: 0 },
+  };
+}
+
+function textStep(text: string): LanguageModelV3GenerateResult {
+  return {
+    content: [{ type: "text", text }],
+    finishReason: "stop",
+    usage: makeUsage(),
+    warnings: [],
+  };
+}
+
+function toolCallStep(
+  toolName: string,
+  input: object,
+  callId?: string,
+): LanguageModelV3GenerateResult {
+  return {
+    content: [
+      {
+        type: "tool-call",
+        toolCallId: callId ?? `call-${randomBytes(3).toString("hex")}`,
+        toolName,
+        input: JSON.stringify(input),
+      },
+    ],
+    finishReason: "tool-calls",
+    usage: makeUsage(),
+    warnings: [],
+  };
+}
+
+/**
+ * Drive the model with a scripted sequence of generate results. Each
+ * call to doGenerate returns the next step; running off the end throws.
+ */
+function scriptModel(steps: LanguageModelV3GenerateResult[]): MockLanguageModelV3 {
+  let i = 0;
+  return new MockLanguageModelV3({
+    doGenerate: async () => {
+      const step = steps[i++];
+      if (!step) {
+        throw new Error(`mock model: no scripted response for call ${i}`);
+      }
+      return step;
+    },
+  });
+}
+
+// ── A reusable role for the runtime under test ────────────────────
+
+function makeTestRole(overrides: Partial<AgentRole> = {}): AgentRole {
+  return {
+    name: "mock-test-role",
+    model: { provider: "anthropic", id: "claude-test" }, // ignored: modelOverride wins
+    tools: ["read_file", "write_file", "edit_file", "search", "contribute"],
+    buildPrompt: async () => ({ system: "you are a test", prompt: "do the thing" }),
+    idempotencyKey: ({ triggerPath, meta }) => ({
+      key: triggerPath ?? "default-key",
+      hash: (meta?.hash as string) ?? "default-hash",
+    }),
+    concurrencyKey: ({ space: s }) => `mock-test-role::${s.id}`,
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+describe("runAgent — single-step text response", () => {
+  it("completes with no edits when the model returns plain text", async () => {
+    const model = scriptModel([textStep("nothing to do here")]);
+    const result = await runAgent(makeTestRole(), { space }, ALL_TOOLS, {
+      modelOverride: model,
+    });
+
+    expect(result.skipped).toBe(false);
+    expect(result.text).toBe("nothing to do here");
+    expect(result.edits).toEqual([]);
+    expect(result.steps).toBe(1);
+  });
+
+  it("writes an agent_runs row with status='completed'", async () => {
+    const model = scriptModel([textStep("ok")]);
+    await runAgent(
+      makeTestRole(),
+      { space, triggerPath: "src/a", meta: { hash: "h-completed" } },
+      ALL_TOOLS,
+      { modelOverride: model },
+    );
+
+    const sql = createSql();
+    const rows = await sql`
+      SELECT status, input_hash FROM agent_runs
+      WHERE role = ${"mock-test-role"} AND idempotency_key = ${"src/a"}
+    `;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("completed");
+    expect(rows[0].input_hash).toBe("h-completed");
+  });
+});
+
+describe("runAgent — tool-call loop", () => {
+  it("dispatches one tool call, accumulates the edit, and finishes on text", async () => {
+    const model = scriptModel([
+      toolCallStep("write_file", {
+        path: "wiki/concept/from-mock.md",
+        content: "---\nlabel: From Mock\n---\n\nbody\n",
+      }),
+      textStep("file written"),
+    ]);
+
+    const result = await runAgent(makeTestRole(), { space }, ALL_TOOLS, {
+      modelOverride: model,
+    });
+
+    expect(result.steps).toBe(2);
+    expect(result.edits).toHaveLength(1);
+    expect(result.edits[0].path).toBe("wiki/concept/from-mock.md");
+    expect(existsSync(join(testDir, "wiki/concept/from-mock.md"))).toBe(true);
+  });
+
+  it("composes multiple tools across steps (search → read → contribute → text)", async () => {
+    mkdirSync(join(testDir, "wiki/person"), { recursive: true });
+    writeFileSync(
+      join(testDir, "wiki/person/galois.md"),
+      "---\nlabel: Évariste Galois\nsubject_type: person\n---\n\nGroup theory.\n",
+    );
+
+    // wait for watcher
+    const sql = createSql();
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      const rows = await sql`SELECT id FROM entities WHERE space_id = ${space.id} AND label = ${"Évariste Galois"}`;
+      if (rows.length > 0) break;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+
+    const model = scriptModel([
+      toolCallStep("search", { query: "Group theory" }),
+      toolCallStep("read_file", { path: "wiki/person/galois.md" }),
+      toolCallStep("contribute", {
+        subject: { label: "Évariste Galois", subject_type: "person" },
+        excerpt: "Founded group theory before age 20.",
+        claim: "founded group theory",
+      }),
+      textStep("contributed"),
+    ]);
+
+    const result = await runAgent(makeTestRole(), { space }, ALL_TOOLS, {
+      modelOverride: model,
+    });
+
+    expect(result.steps).toBe(4);
+    // contribute writes the wiki via applyEdit; search and read don't mutate
+    expect(result.edits).toHaveLength(1);
+    expect(result.edits[0].path).toBe("wiki/person/galois.md");
+
+    // Verify the contribution actually landed
+    const fm = readFileSync(join(testDir, "wiki/person/galois.md"), "utf-8");
+    expect(fm).toContain("Founded group theory before age 20.");
+  });
+
+  it("continues the loop even when a tool errors — error becomes a tool result", async () => {
+    // The first tool call targets a missing file; the LLM should see
+    // the error and recover. The runtime must not abort the run.
+    const model = scriptModel([
+      toolCallStep("read_file", { path: "wiki/does-not-exist.md" }),
+      textStep("recovered: file was missing"),
+    ]);
+
+    const result = await runAgent(makeTestRole(), { space }, ALL_TOOLS, {
+      modelOverride: model,
+    });
+
+    expect(result.skipped).toBe(false);
+    expect(result.steps).toBe(2);
+    expect(result.text).toContain("recovered");
+  });
+});
+
+describe("runAgent — idempotency", () => {
+  it("skips on replay (same key + same hash, previous status='completed')", async () => {
+    const role = makeTestRole();
+    const input = { space, triggerPath: "src/idem-1", meta: { hash: "h-1" } };
+
+    await runAgent(role, input, ALL_TOOLS, {
+      modelOverride: scriptModel([textStep("first")]),
+    });
+
+    // The replay shouldn't even reach the (single-shot) mock model.
+    const result = await runAgent(role, input, ALL_TOOLS, {
+      modelOverride: scriptModel([]),
+    });
+
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe("already_processed");
+  });
+
+  it("re-runs on a new hash for the same key (content changed)", async () => {
+    const role = makeTestRole();
+    const trigger = "src/idem-2";
+
+    await runAgent(role, { space, triggerPath: trigger, meta: { hash: "v1" } }, ALL_TOOLS, {
+      modelOverride: scriptModel([textStep("v1")]),
+    });
+
+    const result = await runAgent(
+      role,
+      { space, triggerPath: trigger, meta: { hash: "v2" } },
+      ALL_TOOLS,
+      { modelOverride: scriptModel([textStep("v2")]) },
+    );
+
+    expect(result.skipped).toBe(false);
+    expect(result.text).toBe("v2");
+  });
+
+  it("retries when the previous run is recorded as 'failed'", async () => {
+    const role = makeTestRole();
+    const input = { space, triggerPath: "src/idem-3", meta: { hash: "h-3" } };
+
+    // First: model throws, run is marked failed.
+    await expect(
+      runAgent(role, input, ALL_TOOLS, {
+        modelOverride: new MockLanguageModelV3({
+          doGenerate: async () => {
+            throw new Error("simulated provider error");
+          },
+        }),
+      }),
+    ).rejects.toThrow(/simulated provider/);
+
+    const sql = createSql();
+    let rows = await sql`
+      SELECT status FROM agent_runs
+      WHERE role = ${role.name} AND idempotency_key = ${"src/idem-3"}
+    `;
+    expect(rows[0].status).toBe("failed");
+
+    // Second: succeed; the failed row should not block the retry.
+    const result = await runAgent(role, input, ALL_TOOLS, {
+      modelOverride: scriptModel([textStep("retry succeeded")]),
+    });
+
+    expect(result.skipped).toBe(false);
+    expect(result.text).toBe("retry succeeded");
+
+    rows = await sql`
+      SELECT status FROM agent_runs
+      WHERE role = ${role.name} AND idempotency_key = ${"src/idem-3"}
+    `;
+    expect(rows[0].status).toBe("completed");
+  });
+});
+
+describe("runAgent — provider error handling", () => {
+  it("marks the run failed and re-throws when the model errors", async () => {
+    const role = makeTestRole();
+    const input = { space, triggerPath: "src/err", meta: { hash: "h-err" } };
+
+    await expect(
+      runAgent(role, input, ALL_TOOLS, {
+        modelOverride: new MockLanguageModelV3({
+          doGenerate: async () => {
+            throw new Error("provider went pop");
+          },
+        }),
+      }),
+    ).rejects.toThrow(/provider went pop/);
+
+    const sql = createSql();
+    const rows = await sql`
+      SELECT status, error FROM agent_runs
+      WHERE role = ${role.name} AND idempotency_key = ${"src/err"}
+    `;
+    expect(rows[0].status).toBe("failed");
+    expect((rows[0].error as string) ?? "").toMatch(/provider went pop/);
+  });
+});
+
+describe("runAgent — step cap", () => {
+  it("stops after maxSteps when the model never emits a stop", async () => {
+    // Model that never stops calling write_file with unique paths.
+    let i = 0;
+    const model = new MockLanguageModelV3({
+      doGenerate: async () => {
+        i++;
+        return toolCallStep("write_file", {
+          path: `wiki/concept/loop-${i}.md`,
+          content: `---\nlabel: Loop ${i}\n---\n\nbody\n`,
+        });
+      },
+    });
+
+    const role = makeTestRole({ maxSteps: 3 });
+    const result = await runAgent(role, { space, triggerPath: "src/cap" }, ALL_TOOLS, {
+      modelOverride: model,
+    });
+
+    // The loop is bounded: at most maxSteps model calls.
+    expect(result.steps).toBeLessThanOrEqual(3);
+    // And the edits accumulated reflect that bound.
+    expect(result.edits.length).toBeLessThanOrEqual(3);
+  });
+});

--- a/packages/arkeon/test/e2e/agent-runtime.test.ts
+++ b/packages/arkeon/test/e2e/agent-runtime.test.ts
@@ -1,0 +1,259 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * End-to-end tests for the agent runtime infrastructure: tool registry
+ * (each tool's execute path) and the idempotency table.
+ *
+ * These tests don't call an LLM. They exercise the parts of the runtime
+ * that the AI SDK doesn't already test: our tool wiring, our SQLite
+ * roundtrip for agent_runs, and the integration between tools and
+ * applyEdit.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { mkdirSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+
+import { ALL_TOOLS } from "../../src/server/agents/tools.js";
+import {
+  alreadyProcessed,
+  hashInput,
+  makeContext,
+  markProcessed,
+} from "../../src/server/agents/runtime.js";
+import { createSql } from "../../src/server/lib/sql.js";
+import type { Space } from "../../src/server/lib/sync.js";
+
+const API_PORT = 18796;
+
+let testDir: string;
+let stateDir: string;
+let serverHandle: { stop: () => Promise<void> } | null = null;
+let space: Space;
+
+interface ExecutableTool {
+  execute: (input: unknown) => Promise<unknown>;
+}
+
+beforeAll(async () => {
+  const base = join(tmpdir(), `arkeon-agent-rt-${randomBytes(4).toString("hex")}`);
+  testDir = join(base, "repo");
+  stateDir = join(base, "state");
+  mkdirSync(testDir, { recursive: true });
+  mkdirSync(join(stateDir, "data"), { recursive: true });
+  mkdirSync(join(testDir, "wiki"), { recursive: true });
+
+  process.env.ARKEON_WIKI_HOME = stateDir;
+
+  const dbFile = join(stateDir, "data", "arke.db");
+  const { runMigrations } = await import("../../src/schema/index.js");
+  await runMigrations({ dbPath: dbFile });
+
+  const { startApi } = await import("../../src/server/server.js");
+  const apiHandle = await startApi({ port: API_PORT, dbPath: dbFile });
+  serverHandle = { stop: async () => apiHandle.stop() };
+
+  const spaceRes = await fetch(`http://localhost:${API_PORT}/spaces`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: "agent-rt-space", watch_dir: testDir }),
+  });
+  const json = (await spaceRes.json()) as { id: string };
+
+  space = { id: json.id, name: "agent-rt-space", watch_dir: testDir };
+}, 30_000);
+
+afterAll(async () => {
+  if (serverHandle) await serverHandle.stop();
+  if (testDir && existsSync(testDir)) {
+    rmSync(testDir.substring(0, testDir.lastIndexOf("/")), {
+      recursive: true,
+      force: true,
+    });
+  }
+}, 30_000);
+
+describe("agent_runs idempotency table", () => {
+  beforeEach(async () => {
+    const sql = createSql();
+    await sql`DELETE FROM agent_runs`;
+  });
+
+  it("alreadyProcessed returns false when no row exists", async () => {
+    const seen = await alreadyProcessed("any-role", { key: "k1", hash: "h1" });
+    expect(seen).toBe(false);
+  });
+
+  it("markProcessed + alreadyProcessed roundtrip", async () => {
+    await markProcessed("contributor", { key: "src/a.md", hash: "abc" }, "completed", null);
+    expect(
+      await alreadyProcessed("contributor", { key: "src/a.md", hash: "abc" }),
+    ).toBe(true);
+  });
+
+  it("returns false when the hash differs (same key, new content)", async () => {
+    await markProcessed("contributor", { key: "src/a.md", hash: "abc" }, "completed", null);
+    expect(
+      await alreadyProcessed("contributor", { key: "src/a.md", hash: "DIFFERENT" }),
+    ).toBe(false);
+  });
+
+  it("returns false when the previous run failed (so we'll retry)", async () => {
+    await markProcessed("editor", { key: "wiki-1", hash: "h" }, "failed", "boom");
+    expect(await alreadyProcessed("editor", { key: "wiki-1", hash: "h" })).toBe(false);
+  });
+
+  it("upserts: a successful run after a failure flips to completed", async () => {
+    await markProcessed("editor", { key: "wiki-1", hash: "h" }, "failed", "boom");
+    await markProcessed("editor", { key: "wiki-1", hash: "h" }, "completed", null);
+    expect(await alreadyProcessed("editor", { key: "wiki-1", hash: "h" })).toBe(true);
+  });
+});
+
+describe("hashInput integration", () => {
+  it("matches the same logical input regardless of object key order", () => {
+    expect(hashInput({ a: 1, b: 2 })).toBe(hashInput({ a: 1, b: 2 }));
+  });
+});
+
+describe("read_file tool", () => {
+  it("reads a markdown file and returns parsed frontmatter", async () => {
+    mkdirSync(join(testDir, "wiki/person"), { recursive: true });
+    writeFileSync(
+      join(testDir, "wiki/person/turing.md"),
+      "---\nlabel: Alan Turing\nsubject_type: person\n---\n\nMathematician.\n",
+    );
+
+    const ctx = makeContext(space, "test");
+    const tool = ALL_TOOLS.read_file(ctx) as ExecutableTool;
+    const result = (await tool.execute({ path: "wiki/person/turing.md" })) as {
+      path: string;
+      frontmatter: { label: string; subject_type: string };
+      body: string;
+    };
+
+    expect(result.path).toBe("wiki/person/turing.md");
+    expect(result.frontmatter.label).toBe("Alan Turing");
+    expect(result.frontmatter.subject_type).toBe("person");
+    expect(result.body).toContain("Mathematician.");
+  });
+
+  it("throws when the file does not exist", async () => {
+    const ctx = makeContext(space, "test");
+    const tool = ALL_TOOLS.read_file(ctx) as ExecutableTool;
+    await expect(tool.execute({ path: "wiki/missing.md" })).rejects.toThrow(/does not exist/);
+  });
+});
+
+describe("write_file tool", () => {
+  it("creates a new file and accumulates the edit on the context", async () => {
+    const ctx = makeContext(space, "test");
+    const tool = ALL_TOOLS.write_file(ctx) as ExecutableTool;
+    const result = (await tool.execute({
+      path: "wiki/concept/note.md",
+      content: "---\nlabel: Note\nsubject_type: concept\n---\n\nbody\n",
+    })) as { path: string; applied: boolean };
+
+    expect(result.applied).toBe(true);
+    expect(existsSync(join(testDir, "wiki/concept/note.md"))).toBe(true);
+    expect(ctx.edits).toHaveLength(1);
+    expect(ctx.edits[0].path).toBe("wiki/concept/note.md");
+  });
+});
+
+describe("edit_file tool", () => {
+  it("applies a SEARCH/REPLACE that matches exactly once", async () => {
+    mkdirSync(join(testDir, "wiki/person"), { recursive: true });
+    writeFileSync(
+      join(testDir, "wiki/person/lovelace.md"),
+      "---\nlabel: Ada Lovelace\nsubject_type: person\n---\n\nA mathematician.\n",
+    );
+
+    const ctx = makeContext(space, "test");
+    const tool = ALL_TOOLS.edit_file(ctx) as ExecutableTool;
+    await tool.execute({
+      path: "wiki/person/lovelace.md",
+      search: "A mathematician.",
+      replace: "A mathematician who wrote the first algorithm.",
+    });
+
+    const updated = readFileSync(join(testDir, "wiki/person/lovelace.md"), "utf-8");
+    expect(updated).toContain("first algorithm");
+  });
+
+  it("rejects an edit whose SEARCH matches multiple times", async () => {
+    mkdirSync(join(testDir, "wiki/concept"), { recursive: true });
+    writeFileSync(
+      join(testDir, "wiki/concept/dup.md"),
+      "---\nlabel: Dup\n---\n\nfoo\nfoo\n",
+    );
+
+    const ctx = makeContext(space, "test");
+    const tool = ALL_TOOLS.edit_file(ctx) as ExecutableTool;
+    await expect(
+      tool.execute({ path: "wiki/concept/dup.md", search: "foo", replace: "bar" }),
+    ).rejects.toThrow(/matched 2 times/);
+  });
+
+  it("rejects an edit whose SEARCH does not match", async () => {
+    mkdirSync(join(testDir, "wiki/concept"), { recursive: true });
+    writeFileSync(
+      join(testDir, "wiki/concept/miss.md"),
+      "---\nlabel: Miss\n---\n\nbody\n",
+    );
+
+    const ctx = makeContext(space, "test");
+    const tool = ALL_TOOLS.edit_file(ctx) as ExecutableTool;
+    await expect(
+      tool.execute({ path: "wiki/concept/miss.md", search: "absent", replace: "x" }),
+    ).rejects.toThrow(/did not match/);
+  });
+});
+
+describe("contribute tool", () => {
+  it("routes a contribution to a fresh placeholder", async () => {
+    const ctx = makeContext(space, "test");
+    const tool = ALL_TOOLS.contribute(ctx) as ExecutableTool;
+    const result = (await tool.execute({
+      subject: { label: "Grace Hopper", subject_type: "person" },
+      excerpt: "Hopper popularised the term 'debugging'.",
+      claim: "popularised the term debugging",
+    })) as { wiki_path: string; was_created: boolean };
+
+    expect(result.was_created).toBe(true);
+    expect(result.wiki_path).toBe("wiki/person/grace-hopper.md");
+    expect(existsSync(join(testDir, result.wiki_path))).toBe(true);
+  });
+});
+
+describe("search tool", () => {
+  it("returns hits for matching content in the space", async () => {
+    mkdirSync(join(testDir, "wiki/person"), { recursive: true });
+    writeFileSync(
+      join(testDir, "wiki/person/curie.md"),
+      "---\nlabel: Marie Curie\nsubject_type: person\n---\n\nDiscovered radium and polonium.\n",
+    );
+
+    // Wait briefly for watcher to sync.
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      const sql = createSql();
+      const rows =
+        await sql`SELECT id FROM entities WHERE space_id = ${space.id} AND source_path = ${"wiki/person/curie.md"}`;
+      if (rows.length > 0) break;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+
+    const ctx = makeContext(space, "test");
+    const tool = ALL_TOOLS.search(ctx) as ExecutableTool;
+    const result = (await tool.execute({ query: "polonium" })) as {
+      hits: Array<{ label: string; source_path: string }>;
+    };
+
+    expect(result.hits.length).toBeGreaterThan(0);
+    expect(result.hits[0].label).toBe("Marie Curie");
+  });
+});

--- a/packages/arkeon/test/e2e/agent-runtime.test.ts
+++ b/packages/arkeon/test/e2e/agent-runtime.test.ts
@@ -115,7 +115,7 @@ describe("agent_runs idempotency table", () => {
 
 describe("hashInput integration", () => {
   it("matches the same logical input regardless of object key order", () => {
-    expect(hashInput({ a: 1, b: 2 })).toBe(hashInput({ a: 1, b: 2 }));
+    expect(hashInput({ a: 1, b: 2 })).toBe(hashInput({ b: 2, a: 1 }));
   });
 });
 

--- a/packages/arkeon/test/e2e/agent-tools.test.ts
+++ b/packages/arkeon/test/e2e/agent-tools.test.ts
@@ -1,0 +1,503 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Layer 1: deep edge-case coverage for each tool, invoked directly
+ * (no LLM, no AI SDK loop). Pairs with agent-runtime.test.ts which
+ * covers the happy paths.
+ *
+ * Goals:
+ *   - Every documented failure mode produces a recognizable error
+ *   - Path traversal / absolute-path inputs are rejected uniformly
+ *   - Tools compose: write → read, write → edit, search → read
+ *   - Idempotent operations are actually idempotent
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+
+import { ALL_TOOLS } from "../../src/server/agents/tools.js";
+import { makeContext } from "../../src/server/agents/runtime.js";
+import { createSql } from "../../src/server/lib/sql.js";
+import type { Space } from "../../src/server/lib/sync.js";
+
+const API_PORT = 18797;
+
+let testDir: string;
+let stateDir: string;
+let serverHandle: { stop: () => Promise<void> } | null = null;
+let space: Space;
+
+interface ExecutableTool {
+  execute: (input: unknown) => Promise<unknown>;
+}
+
+beforeAll(async () => {
+  const base = join(tmpdir(), `arkeon-tools-${randomBytes(4).toString("hex")}`);
+  testDir = join(base, "repo");
+  stateDir = join(base, "state");
+  mkdirSync(testDir, { recursive: true });
+  mkdirSync(join(stateDir, "data"), { recursive: true });
+  mkdirSync(join(testDir, "wiki"), { recursive: true });
+
+  process.env.ARKEON_WIKI_HOME = stateDir;
+
+  const dbFile = join(stateDir, "data", "arke.db");
+  const { runMigrations } = await import("../../src/schema/index.js");
+  await runMigrations({ dbPath: dbFile });
+
+  const { startApi } = await import("../../src/server/server.js");
+  const apiHandle = await startApi({ port: API_PORT, dbPath: dbFile });
+  serverHandle = { stop: async () => apiHandle.stop() };
+
+  const spaceRes = await fetch(`http://localhost:${API_PORT}/spaces`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: "tools-space", watch_dir: testDir }),
+  });
+  const json = (await spaceRes.json()) as { id: string };
+  space = { id: json.id, name: "tools-space", watch_dir: testDir };
+}, 30_000);
+
+afterAll(async () => {
+  if (serverHandle) await serverHandle.stop();
+  if (testDir && existsSync(testDir)) {
+    rmSync(testDir.substring(0, testDir.lastIndexOf("/")), {
+      recursive: true,
+      force: true,
+    });
+  }
+}, 30_000);
+
+function tool(name: keyof typeof ALL_TOOLS): ExecutableTool {
+  const ctx = makeContext(space, "tool-test");
+  return ALL_TOOLS[name](ctx) as ExecutableTool;
+}
+
+function toolWithCtx(name: keyof typeof ALL_TOOLS) {
+  const ctx = makeContext(space, "tool-test");
+  return { tool: ALL_TOOLS[name](ctx) as ExecutableTool, ctx };
+}
+
+// ── path safety (cross-tool) ──────────────────────────────────────
+
+describe("path safety", () => {
+  it.each([
+    ["../etc/passwd"],
+    ["../../something"],
+    ["wiki/../../../escape"],
+  ])("read_file rejects path '%s' that escapes the watch dir", async (path) => {
+    await expect(tool("read_file").execute({ path })).rejects.toThrow(/escapes/);
+  });
+
+  it.each([
+    ["/etc/passwd"],
+    ["/Users/anyone/file.md"],
+  ])("read_file rejects absolute path '%s'", async (path) => {
+    await expect(tool("read_file").execute({ path })).rejects.toThrow(/absolute/);
+  });
+
+  it("write_file rejects path that escapes the watch dir", async () => {
+    await expect(
+      tool("write_file").execute({ path: "../leak.txt", content: "x" }),
+    ).rejects.toThrow(/escapes/);
+  });
+
+  it("write_file rejects absolute path", async () => {
+    await expect(
+      tool("write_file").execute({ path: "/tmp/leak.txt", content: "x" }),
+    ).rejects.toThrow(/absolute/);
+  });
+
+  it("edit_file rejects path that escapes the watch dir", async () => {
+    await expect(
+      tool("edit_file").execute({
+        path: "../leak.txt",
+        search: "x",
+        replace: "y",
+      }),
+    ).rejects.toThrow(/escapes/);
+  });
+});
+
+// ── read_file ─────────────────────────────────────────────────────
+
+describe("read_file edge cases", () => {
+  it("returns raw content for non-markdown files", async () => {
+    mkdirSync(join(testDir, "sources"), { recursive: true });
+    writeFileSync(join(testDir, "sources/article.txt"), "plain text body");
+
+    const result = (await tool("read_file").execute({
+      path: "sources/article.txt",
+    })) as { path: string; content: string };
+
+    expect(result.content).toBe("plain text body");
+    expect((result as { frontmatter?: unknown }).frontmatter).toBeUndefined();
+  });
+
+  it("returns empty frontmatter for markdown without a frontmatter block", async () => {
+    mkdirSync(join(testDir, "wiki/concept"), { recursive: true });
+    writeFileSync(join(testDir, "wiki/concept/no-fm.md"), "just a body\n");
+
+    const result = (await tool("read_file").execute({
+      path: "wiki/concept/no-fm.md",
+    })) as { frontmatter: Record<string, unknown>; body: string };
+
+    expect(result.frontmatter).toEqual({});
+    expect(result.body).toContain("just a body");
+  });
+
+  it("throws when the path is a directory", async () => {
+    await expect(tool("read_file").execute({ path: "wiki" })).rejects.toThrow(
+      /is a directory/,
+    );
+  });
+
+  it("reads an empty file as empty content", async () => {
+    writeFileSync(join(testDir, "sources/empty.txt"), "");
+    const result = (await tool("read_file").execute({
+      path: "sources/empty.txt",
+    })) as { content: string };
+    expect(result.content).toBe("");
+  });
+});
+
+// ── write_file ────────────────────────────────────────────────────
+
+describe("write_file edge cases", () => {
+  it("overwrites an existing file", async () => {
+    mkdirSync(join(testDir, "wiki/concept"), { recursive: true });
+    writeFileSync(join(testDir, "wiki/concept/over.md"), "old");
+
+    await tool("write_file").execute({
+      path: "wiki/concept/over.md",
+      content: "---\nlabel: Over\n---\n\nnew body\n",
+    });
+
+    expect(readFileSync(join(testDir, "wiki/concept/over.md"), "utf-8")).toContain(
+      "new body",
+    );
+  });
+
+  it("creates intermediate directories", async () => {
+    await tool("write_file").execute({
+      path: "wiki/deep/nested/new.md",
+      content: "---\nlabel: Deep\n---\n\nbody\n",
+    });
+    expect(existsSync(join(testDir, "wiki/deep/nested/new.md"))).toBe(true);
+  });
+
+  it("accumulates edits on the context across multiple writes", async () => {
+    const { tool: t, ctx } = toolWithCtx("write_file");
+    await t.execute({ path: "wiki/concept/a.md", content: "---\nlabel: A\n---\n" });
+    await t.execute({ path: "wiki/concept/b.md", content: "---\nlabel: B\n---\n" });
+    expect(ctx.edits).toHaveLength(2);
+    expect(ctx.edits.map((e) => e.path)).toEqual([
+      "wiki/concept/a.md",
+      "wiki/concept/b.md",
+    ]);
+  });
+});
+
+// ── edit_file ─────────────────────────────────────────────────────
+
+describe("edit_file edge cases", () => {
+  it("handles multi-line SEARCH/REPLACE", async () => {
+    mkdirSync(join(testDir, "wiki/person"), { recursive: true });
+    writeFileSync(
+      join(testDir, "wiki/person/multi.md"),
+      "---\nlabel: Multi\n---\n\nLine one.\nLine two.\nLine three.\n",
+    );
+
+    await tool("edit_file").execute({
+      path: "wiki/person/multi.md",
+      search: "Line one.\nLine two.",
+      replace: "Lines one and two, merged.",
+    });
+
+    const updated = readFileSync(
+      join(testDir, "wiki/person/multi.md"),
+      "utf-8",
+    );
+    expect(updated).toContain("Lines one and two, merged.");
+    expect(updated).not.toContain("Line one.");
+  });
+
+  it("treats regex special characters in SEARCH as literal", async () => {
+    mkdirSync(join(testDir, "wiki/concept"), { recursive: true });
+    writeFileSync(
+      join(testDir, "wiki/concept/special.md"),
+      "---\nlabel: S\n---\n\nUse a.+regex? pattern here.\n",
+    );
+
+    await tool("edit_file").execute({
+      path: "wiki/concept/special.md",
+      search: "a.+regex? pattern",
+      replace: "a literal phrase",
+    });
+
+    expect(
+      readFileSync(join(testDir, "wiki/concept/special.md"), "utf-8"),
+    ).toContain("a literal phrase");
+  });
+
+  it("can delete a span by replacing with the empty string", async () => {
+    mkdirSync(join(testDir, "wiki/concept"), { recursive: true });
+    writeFileSync(
+      join(testDir, "wiki/concept/del.md"),
+      "---\nlabel: D\n---\n\nKeep this. DELETE THIS. Keep this too.\n",
+    );
+
+    await tool("edit_file").execute({
+      path: "wiki/concept/del.md",
+      search: " DELETE THIS.",
+      replace: "",
+    });
+
+    const updated = readFileSync(join(testDir, "wiki/concept/del.md"), "utf-8");
+    expect(updated).not.toContain("DELETE THIS");
+    expect(updated).toContain("Keep this. Keep this too.");
+  });
+
+  it("rejects an empty SEARCH", async () => {
+    mkdirSync(join(testDir, "wiki/concept"), { recursive: true });
+    writeFileSync(
+      join(testDir, "wiki/concept/empty-search.md"),
+      "---\nlabel: E\n---\n\nbody\n",
+    );
+
+    await expect(
+      tool("edit_file").execute({
+        path: "wiki/concept/empty-search.md",
+        search: "",
+        replace: "x",
+      }),
+    ).rejects.toThrow(/non-empty/);
+  });
+
+  it("throws when the file does not exist", async () => {
+    await expect(
+      tool("edit_file").execute({
+        path: "wiki/missing.md",
+        search: "x",
+        replace: "y",
+      }),
+    ).rejects.toThrow(/does not exist/);
+  });
+
+  it("applies two consecutive edits on the same file", async () => {
+    mkdirSync(join(testDir, "wiki/concept"), { recursive: true });
+    writeFileSync(
+      join(testDir, "wiki/concept/two-edits.md"),
+      "---\nlabel: TE\n---\n\nfirst SECOND third.\n",
+    );
+
+    const { tool: t } = toolWithCtx("edit_file");
+    await t.execute({
+      path: "wiki/concept/two-edits.md",
+      search: "first",
+      replace: "FIRST",
+    });
+    await t.execute({
+      path: "wiki/concept/two-edits.md",
+      search: "third",
+      replace: "THIRD",
+    });
+
+    expect(
+      readFileSync(join(testDir, "wiki/concept/two-edits.md"), "utf-8"),
+    ).toContain("FIRST SECOND THIRD.");
+  });
+});
+
+// ── contribute ────────────────────────────────────────────────────
+
+describe("contribute edge cases", () => {
+  it("routes to an existing wiki via alias match", async () => {
+    mkdirSync(join(testDir, "wiki/person"), { recursive: true });
+    writeFileSync(
+      join(testDir, "wiki/person/feynman.md"),
+      `---\nlabel: Richard Feynman\nsubject_type: person\naliases:\n  - Dick Feynman\n  - R.P. Feynman\n---\n\nPhysicist.\n`,
+    );
+
+    // wait for watcher
+    const sql = createSql();
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      const rows = await sql`SELECT id FROM entities WHERE space_id = ${space.id} AND label = ${"Richard Feynman"}`;
+      if (rows.length > 0) break;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+
+    const result = (await tool("contribute").execute({
+      subject: { label: "R.P. Feynman", subject_type: "person" },
+      excerpt: "Diagrams.",
+    })) as { was_created: boolean; wiki_path: string };
+
+    expect(result.was_created).toBe(false);
+    expect(result.wiki_path).toBe("wiki/person/feynman.md");
+  });
+
+  it("propagates source_id into the frontmatter contribution", async () => {
+    mkdirSync(join(testDir, "sources"), { recursive: true });
+    writeFileSync(
+      join(testDir, "sources/origin.txt"),
+      "An interesting article.",
+    );
+
+    const sql = createSql();
+    const deadline = Date.now() + 5000;
+    let sourceId: string | null = null;
+    while (Date.now() < deadline) {
+      const rows = await sql`SELECT id FROM entities WHERE space_id = ${space.id} AND source_path = ${"sources/origin.txt"}`;
+      if (rows.length > 0) {
+        sourceId = rows[0].id as string;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    expect(sourceId).toBeTruthy();
+
+    const result = (await tool("contribute").execute({
+      subject: { label: "Sourced Subject", subject_type: "concept" },
+      excerpt: "From a real source.",
+      source_id: sourceId!,
+    })) as { wiki_path: string };
+
+    const fm = readFileSync(join(testDir, result.wiki_path), "utf-8");
+    expect(fm).toContain(`source_id: ${sourceId}`);
+  });
+
+  it("does not lose entries when ten parallel contribute calls hit the same new label", async () => {
+    const calls = Array.from({ length: 10 }, (_, i) =>
+      tool("contribute").execute({
+        subject: { label: "Tool Layer Race", subject_type: "person" },
+        excerpt: `tool-excerpt-${i}`,
+      }),
+    );
+
+    const results = (await Promise.all(calls)) as Array<{
+      wiki_path: string;
+      was_created: boolean;
+    }>;
+
+    const created = results.filter((r) => r.was_created).length;
+    expect(created).toBe(1);
+
+    const wikiPath = results[0].wiki_path;
+    const fm = readFileSync(join(testDir, wikiPath), "utf-8");
+    for (let i = 0; i < 10; i++) {
+      expect(fm).toContain(`tool-excerpt-${i}`);
+    }
+  });
+});
+
+// ── search ────────────────────────────────────────────────────────
+
+describe("search edge cases", () => {
+  beforeAll(async () => {
+    mkdirSync(join(testDir, "wiki/concept"), { recursive: true });
+    writeFileSync(
+      join(testDir, "wiki/concept/redox.md"),
+      `---\nlabel: Redox Reactions\nsubject_type: concept\n---\n\nElectron transfer in chemistry.\n`,
+    );
+    writeFileSync(
+      join(testDir, "wiki/concept/oxidation.md"),
+      `---\nlabel: Oxidation\nsubject_type: concept\n---\n\nLoss of electrons.\n`,
+    );
+
+    // wait for watcher to index both
+    const sql = createSql();
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      const rows = await sql`SELECT id FROM entities WHERE space_id = ${space.id} AND source_path IN (${"wiki/concept/redox.md"}, ${"wiki/concept/oxidation.md"})`;
+      if (rows.length === 2) break;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  }, 15_000);
+
+  it("returns an empty hits array when nothing matches", async () => {
+    const result = (await tool("search").execute({
+      query: "definitely-not-present-in-any-file-xyzzy",
+    })) as { hits: unknown[] };
+    expect(result.hits).toEqual([]);
+  });
+
+  it("supports regex mode", async () => {
+    const result = (await tool("search").execute({
+      query: "electron[s]?",
+      regex: true,
+    })) as { hits: Array<{ source_path: string }> };
+
+    const paths = result.hits.map((h) => h.source_path).sort();
+    expect(paths).toContain("wiki/concept/oxidation.md");
+    expect(paths).toContain("wiki/concept/redox.md");
+  });
+
+  it("honours the limit parameter", async () => {
+    const result = (await tool("search").execute({
+      query: "electron",
+      limit: 1,
+    })) as { hits: unknown[] };
+    expect(result.hits.length).toBeLessThanOrEqual(1);
+  });
+});
+
+// ── cross-tool composition ────────────────────────────────────────
+
+describe("cross-tool composition", () => {
+  it("write → read returns the content we just wrote", async () => {
+    const { tool: w } = toolWithCtx("write_file");
+    await w.execute({
+      path: "wiki/concept/wr-read.md",
+      content: "---\nlabel: WR-Read\n---\n\nbody from compose test\n",
+    });
+
+    const r = tool("read_file");
+    const result = (await r.execute({ path: "wiki/concept/wr-read.md" })) as {
+      frontmatter: { label: string };
+      body: string;
+    };
+    expect(result.frontmatter.label).toBe("WR-Read");
+    expect(result.body).toContain("body from compose test");
+  });
+
+  it("write → edit modifies what we just wrote", async () => {
+    await tool("write_file").execute({
+      path: "wiki/concept/wr-edit.md",
+      content: "---\nlabel: WR-Edit\n---\n\noriginal phrase here\n",
+    });
+    await tool("edit_file").execute({
+      path: "wiki/concept/wr-edit.md",
+      search: "original phrase",
+      replace: "amended phrase",
+    });
+
+    expect(
+      readFileSync(join(testDir, "wiki/concept/wr-edit.md"), "utf-8"),
+    ).toContain("amended phrase");
+  });
+
+  it("contribute → read shows the appended frontmatter entry", async () => {
+    const c = (await tool("contribute").execute({
+      subject: { label: "Compose Subject", subject_type: "concept" },
+      excerpt: "first excerpt",
+    })) as { wiki_path: string };
+
+    const r = (await tool("read_file").execute({ path: c.wiki_path })) as {
+      frontmatter: { contributions: Array<{ excerpt: string }> };
+    };
+
+    expect(r.frontmatter.contributions).toHaveLength(1);
+    expect(r.frontmatter.contributions[0].excerpt).toBe("first excerpt");
+  });
+});

--- a/packages/arkeon/test/unit/agents.test.ts
+++ b/packages/arkeon/test/unit/agents.test.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from "vitest";
+import { z } from "zod";
+
+import { defineTool } from "../../src/server/agents/define-tool.js";
+import { resolveModel } from "../../src/server/agents/model.js";
+import type { AgentContext } from "../../src/server/agents/runtime.js";
+import { hashInput } from "../../src/server/agents/runtime.js";
+
+function makeFakeContext(): AgentContext {
+  return {
+    space: { id: "test-space", name: "test", watch_dir: "/tmp/nope" },
+    role: "test-role",
+    edits: [],
+    applyEdit: vi.fn(async () => {
+      throw new Error("not used in this test");
+    }),
+    log: vi.fn(),
+  };
+}
+
+describe("defineTool", () => {
+  it("validates input via Zod and forwards to call()", async () => {
+    const fn = vi.fn(async (input: { x: number }) => ({ doubled: input.x * 2 }));
+    const factory = defineTool("double", {
+      description: "Double a number.",
+      inputSchema: z.object({ x: z.number() }),
+      call: fn,
+    });
+
+    const ctx = makeFakeContext();
+    const t = factory(ctx) as { execute: (input: unknown) => Promise<unknown> };
+    const result = await t.execute({ x: 21 });
+
+    expect(result).toEqual({ doubled: 42 });
+    expect(fn).toHaveBeenCalledWith({ x: 21 }, ctx);
+  });
+
+  it("logs invocations through ctx.log", async () => {
+    const factory = defineTool("noop", {
+      description: "no-op",
+      inputSchema: z.object({}),
+      call: () => ({ ok: true }),
+    });
+    const ctx = makeFakeContext();
+    const t = factory(ctx) as { execute: (input: unknown) => Promise<unknown> };
+    await t.execute({});
+    expect(ctx.log).toHaveBeenCalledWith("info", "tool/noop", { input: {} });
+  });
+
+  it("rethrows after logging failures", async () => {
+    const factory = defineTool("boom", {
+      description: "always throws",
+      inputSchema: z.object({}),
+      call: () => {
+        throw new Error("kaboom");
+      },
+    });
+    const ctx = makeFakeContext();
+    const t = factory(ctx) as { execute: (input: unknown) => Promise<unknown> };
+
+    await expect(t.execute({})).rejects.toThrow("kaboom");
+    expect(ctx.log).toHaveBeenCalledWith(
+      "error",
+      "tool/boom failed",
+      { error: "kaboom" },
+    );
+  });
+});
+
+describe("resolveModel", () => {
+  it("returns a model for the anthropic provider", () => {
+    const model = resolveModel({
+      provider: "anthropic",
+      id: "claude-opus-4-7",
+      apiKey: "sk-ant-test",
+    });
+    expect(model).toBeDefined();
+    // provider field reflects the underlying SDK's identifier for telemetry
+    expect((model as { provider?: string }).provider).toMatch(/anthropic/i);
+  });
+
+  it("returns a model for the openai provider", () => {
+    const model = resolveModel({
+      provider: "openai",
+      id: "gpt-5",
+      apiKey: "sk-test",
+    });
+    expect(model).toBeDefined();
+    expect((model as { provider?: string }).provider).toMatch(/openai/i);
+  });
+
+  it("returns a model for openai-compatible (e.g. Ollama, OpenRouter)", () => {
+    const model = resolveModel({
+      provider: "openai-compatible",
+      id: "llama3.1:70b",
+      baseURL: "http://localhost:11434/v1",
+    });
+    expect(model).toBeDefined();
+  });
+});
+
+describe("hashInput", () => {
+  it("is deterministic", () => {
+    expect(hashInput({ a: 1, b: "x" })).toBe(hashInput({ a: 1, b: "x" }));
+  });
+
+  it("differs for different inputs", () => {
+    expect(hashInput({ a: 1 })).not.toBe(hashInput({ a: 2 }));
+  });
+
+  it("treats null and undefined as equivalent", () => {
+    expect(hashInput(null)).toBe(hashInput(undefined));
+  });
+});

--- a/packages/arkeon/test/unit/agents.test.ts
+++ b/packages/arkeon/test/unit/agents.test.ts
@@ -114,4 +114,18 @@ describe("hashInput", () => {
   it("treats null and undefined as equivalent", () => {
     expect(hashInput(null)).toBe(hashInput(undefined));
   });
+
+  it("matches the same logical input regardless of object key order", () => {
+    expect(hashInput({ a: 1, b: 2 })).toBe(hashInput({ b: 2, a: 1 }));
+  });
+
+  it("is order-independent for nested objects", () => {
+    expect(hashInput({ x: { p: 1, q: 2 }, y: 3 })).toBe(
+      hashInput({ y: 3, x: { q: 2, p: 1 } }),
+    );
+  });
+
+  it("preserves array order (arrays are ordered, objects are not)", () => {
+    expect(hashInput([1, 2, 3])).not.toBe(hashInput([3, 2, 1]));
+  });
 });

--- a/packages/arkeon/test/unit/contributions.test.ts
+++ b/packages/arkeon/test/unit/contributions.test.ts
@@ -11,8 +11,8 @@ import {
   slugify,
   placeholderPath,
   findFreePath,
-  withPathLock,
 } from "../../src/server/lib/contributions.js";
+import { withPathLock } from "../../src/server/lib/path-lock.js";
 
 describe("normalizeLabel", () => {
   it("lowercases and trims", () => {


### PR DESCRIPTION
## Summary

Lays the shared infrastructure that the contributor (#49) and editor (#50) workers will plug into. No consumers in this PR — pure infra, ready for the next round.

Two commits:

1. **`refactor:`** route `contribute()` writes through a single `applyEdit` chokepoint. Adds `lib/file-edits.ts` (`FileEdit = write | edit | delete`, `applyEdit()` writes + auto-runs `syncFile`/`removeByPath`). Behavior-preserving — all existing contribute tests pass.
2. **`feat:`** add the agent runtime, model resolver, tool registry, and idempotency table.

## What's in the runtime

- **Provider-agnostic model selection.** `resolveModel({ provider, id })` returns a Vercel AI SDK `LanguageModel` for `"anthropic"`, `"openai"`, or `"openai-compatible"`. The last one covers Ollama (`baseURL: "http://localhost:11434/v1"`), LM Studio, llama.cpp's `--server`, vLLM, OpenRouter, Groq, Together — anything OpenAI-compatible. Local-model support drops out for free.
- **`runAgent(role, input, registry)`** acquires a per-key lock, checks `agent_runs` for a matching idempotency hash, instantiates the role's tools with an `AgentContext`, and hands them to `generateText` with `stepCountIs(maxSteps)`. Errors get surfaced after marking the run `failed` so the next trigger retries.
- **`defineTool` + central registry.** Each tool is one entry in `agents/tools.ts` (~5 lines): description, Zod input schema, typed `call()`. Roles opt in by name (`tools: ["search", "read_file", "contribute"]`). Initial set: `read_file`, `search`, `edit_file`, `write_file`, `contribute`. Vector search drops in as a sixth tool with the same shape when sqlite-vec lands.
- **`agent_runs` table.** `(role, idempotency_key)` primary key, `input_hash` to distinguish replays from new content, `status` so failed runs are retried.

## Why this shape

- **Single mutation chokepoint.** Every write — from `contribute()`, every tool, every future agent — goes through `applyEdit`. One audit point, one place to wire concurrency and (later) audit logging. The watcher still does the SQLite indexing.
- **Tool registry is explicit, not magic.** No import-side-effect global registry. Adding a tool = one entry in `tools.ts`. The real cost (description + schema design) is forced into the open; the mechanical "register" line is trivial.
- **Roles stay tiny.** A role is a `name`, a `model`, a `tools[]` list, a `buildPrompt`, and two key functions (idempotency + concurrency). Everything else is shared.

## Test plan

- [x] `npm run typecheck -w packages/arkeon` — clean
- [x] `npm test -w packages/arkeon` — 66 unit tests pass (was 57; +9 for `defineTool`/`resolveModel`/`hashInput`)
- [x] `npm run test:e2e -w packages/arkeon` — 70 e2e tests pass (was 56; +14 for `agent_runs` roundtrip and each tool's execute path against a real space)
- [x] All existing contribute behavior preserved (concurrency, alias matching, source-id provenance, frontmatter mirroring)

## What's NOT in this PR

- No contributor worker (#49)
- No editor worker (#50)
- No consumers of `runAgent` yet — that's the next PR set

## Deps added

`ai`, `@ai-sdk/anthropic`, `@ai-sdk/openai`. All small; provider packs are independent so swapping providers doesn't touch runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)