### PR TITLE
feat: add list_wikis agent tool

### DIFF
--- a/packages/arkeon/src/server/agents/tools.ts
+++ b/packages/arkeon/src/server/agents/tools.ts
@@ -20,6 +20,7 @@ import { contribute } from "../lib/contributions.js";
 import { safeResolve } from "../lib/file-edits.js";
 import { parseFrontmatter } from "../lib/frontmatter.js";
 import { search as ripgrepSearch } from "../lib/search.js";
+import { listWikis } from "../lib/wikis.js";
 
 import { defineTool, type ToolFactory } from "./define-tool.js";
 
@@ -78,6 +79,63 @@ const searchTool = defineTool("search", {
       regex,
       limit,
       maxSnippetsPerFile: max_snippets_per_file,
+    }),
+});
+
+// ── list_wikis ────────────────────────────────────────────────────
+
+const listWikisTool = defineTool("list_wikis", {
+  description:
+    "List wikis in the current space, with optional filters. Use this to " +
+    "enumerate existing wikis before contributing (so you can check if a " +
+    "subject already has a wiki) or to find wikis that need editing " +
+    "(filter by has_contributions or status='placeholder'). Returns " +
+    "{wikis, total, limit, offset}.",
+  inputSchema: z.object({
+    subject_type: z
+      .string()
+      .optional()
+      .describe("Filter on frontmatter `subject_type` (e.g. 'person', 'concept')."),
+    status: z
+      .string()
+      .optional()
+      .describe("Filter on frontmatter `status` (e.g. 'placeholder', 'published')."),
+    label_prefix: z
+      .string()
+      .optional()
+      .describe(
+        "Case-insensitive prefix match on the wiki's label. Useful for " +
+          "checking whether a subject already exists before creating one.",
+      ),
+    has_contributions: z
+      .boolean()
+      .optional()
+      .describe("If true, only wikis with at least one pending contribution."),
+    sort: z
+      .enum(["updated_at", "label"])
+      .optional()
+      .describe("Default 'updated_at' (newest first)."),
+    include_counts: z
+      .boolean()
+      .optional()
+      .describe(
+        "Attach contributions_pending + incoming/outgoing link counts " +
+          "per wiki. Useful for prioritisation.",
+      ),
+    limit: z.number().int().positive().optional().describe("Default 100, max 10000."),
+    offset: z.number().int().min(0).optional().describe("Pagination offset, default 0."),
+  }),
+  call: (input, ctx) =>
+    listWikis({
+      space_id: ctx.space.id,
+      subject_type: input.subject_type,
+      status: input.status,
+      label_prefix: input.label_prefix,
+      has_contributions: input.has_contributions,
+      sort: input.sort,
+      include_counts: input.include_counts,
+      limit: input.limit,
+      offset: input.offset,
     }),
 });
 
@@ -165,6 +223,7 @@ const contributeTool = defineTool("contribute", {
 export const ALL_TOOLS: Record<string, ToolFactory> = {
   read_file: readFileTool,
   search: searchTool,
+  list_wikis: listWikisTool,
   edit_file: editFileTool,
   write_file: writeFileTool,
   contribute: contributeTool,

--- a/packages/arkeon/src/server/lib/wikis.ts
+++ b/packages/arkeon/src/server/lib/wikis.ts
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Wiki listing as a library function.
+ *
+ * Hoisted out of `routes/wikis.ts` so the in-process agent runtime can
+ * call it directly (no HTTP roundtrip) and the route handler stays a
+ * thin wrapper. Behavior is the same as `GET /wikis`: same filters,
+ * same shape, same ordering.
+ */
+
+import { ApiError } from "./errors.js";
+import { createSql } from "./sql.js";
+
+export type WikiSort = "updated_at" | "label";
+
+export interface ListWikisOptions {
+  /** Restrict to a single space. Omitted → all spaces. */
+  space_id?: string;
+  /** Filter on `properties.subject_type`. */
+  subject_type?: string;
+  /** Filter on `properties.status` (e.g. `placeholder`, `published`). */
+  status?: string;
+  /** Case-insensitive prefix match on `label`. LIKE wildcards in the
+   *  caller's prefix are escaped so `%foo` matches literally. */
+  label_prefix?: string;
+  /** Only wikis that have ≥1 contribution with `consumed_at IS NULL`. */
+  has_contributions?: boolean;
+  /** `updated_at` (default, newest first) or `label` (case-insensitive A→Z). */
+  sort?: WikiSort;
+  /** Attach a `counts` object per wiki (pending contributions + link counts). */
+  include_counts?: boolean;
+  /** Attach a top-level `relationships` array of all edges touching the
+   *  matched wikis. Off by default since most callers don't need it. */
+  include_relationships?: boolean;
+  /** Default 100, capped at 10_000. */
+  limit?: number;
+  /** Default 0. */
+  offset?: number;
+}
+
+export interface WikiCounts {
+  contributions_pending: number;
+  incoming_links: number;
+  outgoing_links: number;
+}
+
+export interface WikiListRow {
+  id: string;
+  space_id: string;
+  label: string;
+  source_path: string;
+  properties: Record<string, unknown> | string;
+  created_at: string;
+  updated_at: string;
+  counts?: WikiCounts;
+}
+
+export interface WikiRelationshipRow {
+  id: string;
+  source_id: string;
+  target_id: string;
+  predicate: string;
+  link_text: string | null;
+  link_path: string | null;
+}
+
+export interface ListWikisResult {
+  wikis: WikiListRow[];
+  total: number;
+  limit: number;
+  offset: number;
+  relationships?: WikiRelationshipRow[];
+}
+
+const SORT_COLUMNS: Record<WikiSort, string> = {
+  updated_at: "e.updated_at DESC",
+  label: "e.label COLLATE NOCASE ASC",
+};
+
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 10_000;
+
+export async function listWikis(opts: ListWikisOptions = {}): Promise<ListWikisResult> {
+  const sortKey: WikiSort = opts.sort ?? "updated_at";
+  const sortClause = SORT_COLUMNS[sortKey];
+  if (!sortClause) {
+    throw new ApiError(
+      400,
+      "validation_error",
+      `Invalid sort: must be one of ${Object.keys(SORT_COLUMNS).join(", ")}`,
+    );
+  }
+
+  const limit = Math.min(opts.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+  const offset = opts.offset ?? 0;
+
+  const sql = createSql();
+  const conditions: string[] = [`e.type = 'wiki'`];
+  const params: unknown[] = [];
+
+  if (opts.space_id) {
+    params.push(opts.space_id);
+    conditions.push(`e.space_id = ?`);
+  }
+  if (opts.subject_type) {
+    params.push(opts.subject_type);
+    conditions.push(`json_extract(e.properties, '$.subject_type') = ?`);
+  }
+  if (opts.status) {
+    params.push(opts.status);
+    conditions.push(`json_extract(e.properties, '$.status') = ?`);
+  }
+  if (opts.label_prefix) {
+    const escaped = opts.label_prefix.replace(/[\\%_]/g, "\\$&");
+    params.push(`${escaped}%`);
+    conditions.push(`e.label LIKE ? ESCAPE '\\' COLLATE NOCASE`);
+  }
+  if (opts.has_contributions) {
+    conditions.push(
+      `EXISTS (SELECT 1 FROM contributions c
+               WHERE c.wiki_id = e.id AND c.consumed_at IS NULL)`,
+    );
+  }
+
+  const where = `WHERE ${conditions.join(" AND ")}`;
+
+  const wikis = (await sql.query(
+    `SELECT e.id, e.space_id, e.label, e.source_path, e.properties,
+            e.created_at, e.updated_at
+     FROM entities e
+     ${where}
+     ORDER BY ${sortClause}
+     LIMIT ? OFFSET ?`,
+    [...params, limit, offset],
+  )) as unknown as WikiListRow[];
+
+  const countResult = (await sql.query(
+    `SELECT COUNT(*) AS total FROM entities e ${where}`,
+    params,
+  )) as unknown as Array<{ total: number }>;
+
+  const result: ListWikisResult = {
+    wikis,
+    total: countResult[0]?.total ?? 0,
+    limit,
+    offset,
+  };
+
+  const ids = wikis.map((w) => w.id);
+
+  if (opts.include_counts && ids.length > 0) {
+    const placeholders = ids.map(() => "?").join(",");
+    const counts = (await sql.query(
+      `SELECT
+         e.id,
+         (SELECT COUNT(*) FROM contributions c
+          WHERE c.wiki_id = e.id AND c.consumed_at IS NULL) AS contributions_pending,
+         (SELECT COUNT(*) FROM relationships r WHERE r.target_id = e.id) AS incoming_links,
+         (SELECT COUNT(*) FROM relationships r WHERE r.source_id = e.id) AS outgoing_links
+       FROM entities e
+       WHERE e.id IN (${placeholders})`,
+      ids,
+    )) as unknown as Array<{
+      id: string;
+      contributions_pending: number;
+      incoming_links: number;
+      outgoing_links: number;
+    }>;
+    const byId = new Map(counts.map((row) => [row.id, row]));
+    for (const wiki of wikis) {
+      const c = byId.get(wiki.id);
+      wiki.counts = {
+        contributions_pending: c?.contributions_pending ?? 0,
+        incoming_links: c?.incoming_links ?? 0,
+        outgoing_links: c?.outgoing_links ?? 0,
+      };
+    }
+  }
+
+  if (opts.include_relationships) {
+    if (ids.length > 0) {
+      const placeholders = ids.map(() => "?").join(",");
+      result.relationships = (await sql.query(
+        `SELECT id, source_id, target_id, predicate, link_text, link_path
+         FROM relationships
+         WHERE source_id IN (${placeholders}) OR target_id IN (${placeholders})`,
+        [...ids, ...ids],
+      )) as unknown as WikiRelationshipRow[];
+    } else {
+      result.relationships = [];
+    }
+  }
+
+  return result;
+}

--- a/packages/arkeon/src/server/lib/wikis.ts
+++ b/packages/arkeon/src/server/lib/wikis.ts
@@ -27,8 +27,12 @@ export interface ListWikisOptions {
   label_prefix?: string;
   /** Only wikis that have ≥1 contribution with `consumed_at IS NULL`. */
   has_contributions?: boolean;
-  /** `updated_at` (default, newest first) or `label` (case-insensitive A→Z). */
-  sort?: WikiSort;
+  /** `updated_at` (default, newest first) or `label` (case-insensitive A→Z).
+   *  Typed loosely as `string` so HTTP callers can pass an unvalidated query
+   *  string directly; listWikis validates against SORT_COLUMNS and throws
+   *  ApiError(400) on unknown values. Typed callers can pass a `WikiSort`
+   *  literal — the union narrowing is enforced at the call site. */
+  sort?: string;
   /** Attach a `counts` object per wiki (pending contributions + link counts). */
   include_counts?: boolean;
   /** Attach a top-level `relationships` array of all edges touching the
@@ -83,8 +87,8 @@ const DEFAULT_LIMIT = 100;
 const MAX_LIMIT = 10_000;
 
 export async function listWikis(opts: ListWikisOptions = {}): Promise<ListWikisResult> {
-  const sortKey: WikiSort = opts.sort ?? "updated_at";
-  const sortClause = SORT_COLUMNS[sortKey];
+  const sortKey = opts.sort ?? "updated_at";
+  const sortClause = SORT_COLUMNS[sortKey as WikiSort];
   if (!sortClause) {
     throw new ApiError(
       400,

--- a/packages/arkeon/src/server/routes/wikis.ts
+++ b/packages/arkeon/src/server/routes/wikis.ts
@@ -7,141 +7,26 @@ import { join } from "node:path";
 import type { AppBindings } from "../types.js";
 import { createSql } from "../lib/sql.js";
 import { ApiError } from "../lib/errors.js";
+import { listWikis, type WikiSort } from "../lib/wikis.js";
 
 export const wikisRouter = new Hono<AppBindings>();
 
-const SORT_COLUMNS: Record<string, string> = {
-  updated_at: "e.updated_at DESC",
-  label: "e.label COLLATE NOCASE ASC",
-};
-
-// GET /wikis — list wiki entities with frontmatter-aware filters
-//
-// Query params:
-//   space_id          — filter by space
-//   subject_type      — filter on properties.subject_type
-//   status            — filter on properties.status (placeholder|published|...)
-//   label_prefix      — case-insensitive prefix match on label
-//   has_contributions — "true" → only wikis with pending contributions
-//   sort              — updated_at (default) | label
-//   include           — comma-separated: relationships, counts
-//   limit             — default 100, max 10000
-//   offset            — pagination offset
+// GET /wikis — list wiki entities with frontmatter-aware filters.
+// All filters and includes are documented on listWikis() in lib/wikis.ts.
 wikisRouter.get("/", async (c) => {
-  const spaceId = c.req.query("space_id");
-  const subjectType = c.req.query("subject_type");
-  const status = c.req.query("status");
-  const labelPrefix = c.req.query("label_prefix");
-  const hasContributions = c.req.query("has_contributions") === "true";
-  const sortKey = c.req.query("sort") ?? "updated_at";
   const include = (c.req.query("include") ?? "").split(",").map((s) => s.trim());
-  const includeRelationships = include.includes("relationships");
-  const includeCounts = include.includes("counts");
-  const limit = Math.min(Number(c.req.query("limit") ?? 100), 10_000);
-  const offset = Number(c.req.query("offset") ?? 0);
-
-  const sortClause = SORT_COLUMNS[sortKey];
-  if (!sortClause) {
-    throw new ApiError(
-      400,
-      "validation_error",
-      `Invalid sort: must be one of ${Object.keys(SORT_COLUMNS).join(", ")}`,
-    );
-  }
-
-  const sql = createSql();
-  const conditions: string[] = [`e.type = 'wiki'`];
-  const params: unknown[] = [];
-
-  if (spaceId) {
-    params.push(spaceId);
-    conditions.push(`e.space_id = ?`);
-  }
-  if (subjectType) {
-    params.push(subjectType);
-    conditions.push(`json_extract(e.properties, '$.subject_type') = ?`);
-  }
-  if (status) {
-    params.push(status);
-    conditions.push(`json_extract(e.properties, '$.status') = ?`);
-  }
-  if (labelPrefix) {
-    // Escape LIKE wildcards so the caller's prefix is matched literally.
-    const escaped = labelPrefix.replace(/[\\%_]/g, "\\$&");
-    params.push(`${escaped}%`);
-    conditions.push(`e.label LIKE ? ESCAPE '\\' COLLATE NOCASE`);
-  }
-  if (hasContributions) {
-    conditions.push(
-      `EXISTS (SELECT 1 FROM contributions c
-               WHERE c.wiki_id = e.id AND c.consumed_at IS NULL)`,
-    );
-  }
-
-  const where = `WHERE ${conditions.join(" AND ")}`;
-
-  const wikis = await sql.query(
-    `SELECT e.id, e.space_id, e.label, e.source_path, e.properties,
-            e.created_at, e.updated_at
-     FROM entities e
-     ${where}
-     ORDER BY ${sortClause}
-     LIMIT ? OFFSET ?`,
-    [...params, limit, offset],
-  );
-
-  const countResult = await sql.query(
-    `SELECT COUNT(*) AS total FROM entities e ${where}`,
-    params,
-  );
-
-  const result: Record<string, unknown> = {
-    wikis,
-    total: countResult[0]?.total ?? 0,
-    limit,
-    offset,
-  };
-
-  const ids = wikis.map((w) => w.id as string);
-
-  if (includeCounts && ids.length > 0) {
-    const placeholders = ids.map(() => "?").join(",");
-    const counts = await sql.query(
-      `SELECT
-         e.id,
-         (SELECT COUNT(*) FROM contributions c
-          WHERE c.wiki_id = e.id AND c.consumed_at IS NULL) AS contributions_pending,
-         (SELECT COUNT(*) FROM relationships r WHERE r.target_id = e.id) AS incoming_links,
-         (SELECT COUNT(*) FROM relationships r WHERE r.source_id = e.id) AS outgoing_links
-       FROM entities e
-       WHERE e.id IN (${placeholders})`,
-      ids,
-    );
-    const byId = new Map(counts.map((row) => [row.id as string, row]));
-    for (const wiki of wikis) {
-      const c = byId.get(wiki.id as string);
-      wiki.counts = {
-        contributions_pending: c?.contributions_pending ?? 0,
-        incoming_links: c?.incoming_links ?? 0,
-        outgoing_links: c?.outgoing_links ?? 0,
-      };
-    }
-  }
-
-  if (includeRelationships) {
-    if (ids.length > 0) {
-      const placeholders = ids.map(() => "?").join(",");
-      result.relationships = await sql.query(
-        `SELECT id, source_id, target_id, predicate, link_text, link_path
-         FROM relationships
-         WHERE source_id IN (${placeholders}) OR target_id IN (${placeholders})`,
-        [...ids, ...ids],
-      );
-    } else {
-      result.relationships = [];
-    }
-  }
-
+  const result = await listWikis({
+    space_id: c.req.query("space_id"),
+    subject_type: c.req.query("subject_type"),
+    status: c.req.query("status"),
+    label_prefix: c.req.query("label_prefix"),
+    has_contributions: c.req.query("has_contributions") === "true",
+    sort: (c.req.query("sort") ?? undefined) as WikiSort | undefined,
+    include_relationships: include.includes("relationships"),
+    include_counts: include.includes("counts"),
+    limit: c.req.query("limit") ? Number(c.req.query("limit")) : undefined,
+    offset: c.req.query("offset") ? Number(c.req.query("offset")) : undefined,
+  });
   return c.json(result);
 });
 

--- a/packages/arkeon/src/server/routes/wikis.ts
+++ b/packages/arkeon/src/server/routes/wikis.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 import type { AppBindings } from "../types.js";
 import { createSql } from "../lib/sql.js";
 import { ApiError } from "../lib/errors.js";
-import { listWikis, type WikiSort } from "../lib/wikis.js";
+import { listWikis } from "../lib/wikis.js";
 
 export const wikisRouter = new Hono<AppBindings>();
 
@@ -21,7 +21,7 @@ wikisRouter.get("/", async (c) => {
     status: c.req.query("status"),
     label_prefix: c.req.query("label_prefix"),
     has_contributions: c.req.query("has_contributions") === "true",
-    sort: (c.req.query("sort") ?? undefined) as WikiSort | undefined,
+    sort: c.req.query("sort"),
     include_relationships: include.includes("relationships"),
     include_counts: include.includes("counts"),
     limit: c.req.query("limit") ? Number(c.req.query("limit")) : undefined,

--- a/packages/arkeon/test/e2e/agent-tools.test.ts
+++ b/packages/arkeon/test/e2e/agent-tools.test.ts
@@ -452,6 +452,165 @@ describe("search edge cases", () => {
   });
 });
 
+// ── list_wikis ────────────────────────────────────────────────────
+
+describe("list_wikis edge cases", () => {
+  // Seed a small corpus the tool can filter against.
+  beforeAll(async () => {
+    mkdirSync(join(testDir, "wiki/person"), { recursive: true });
+    mkdirSync(join(testDir, "wiki/organization"), { recursive: true });
+
+    writeFileSync(
+      join(testDir, "wiki/person/babbage.md"),
+      `---\nlabel: Charles Babbage\nsubject_type: person\nstatus: published\n---\n\nMechanical engine pioneer.\n`,
+    );
+    writeFileSync(
+      join(testDir, "wiki/person/babb-noted.md"),
+      `---\nlabel: Babb Noted\nsubject_type: person\nstatus: placeholder\n---\n\n`,
+    );
+    writeFileSync(
+      join(testDir, "wiki/organization/bell-labs.md"),
+      `---\nlabel: Bell Labs\nsubject_type: organization\nstatus: published\n---\n\nResearch lab.\n`,
+    );
+
+    // Wait for watcher to index all three.
+    const sql = createSql();
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      const rows = await sql`
+        SELECT id FROM entities
+        WHERE space_id = ${space.id}
+          AND source_path IN (
+            ${"wiki/person/babbage.md"},
+            ${"wiki/person/babb-noted.md"},
+            ${"wiki/organization/bell-labs.md"}
+          )
+      `;
+      if (rows.length === 3) break;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  }, 15_000);
+
+  it("filters by subject_type", async () => {
+    const result = (await tool("list_wikis").execute({
+      subject_type: "organization",
+    })) as { wikis: Array<{ label: string }>; total: number };
+
+    const labels = result.wikis.map((w) => w.label);
+    expect(labels).toContain("Bell Labs");
+    expect(labels).not.toContain("Charles Babbage");
+  });
+
+  it("filters by status (placeholder vs published)", async () => {
+    const result = (await tool("list_wikis").execute({
+      status: "placeholder",
+    })) as { wikis: Array<{ label: string }> };
+
+    expect(result.wikis.map((w) => w.label)).toContain("Babb Noted");
+    expect(result.wikis.map((w) => w.label)).not.toContain("Charles Babbage");
+  });
+
+  it("matches label_prefix case-insensitively, prefix-anchored only", async () => {
+    // Prefix 'BABB' (all caps) should match 'Babb Noted' (case-insensitive,
+    // starts with Babb) but NOT 'Charles Babbage' (starts with Charles).
+    const result = (await tool("list_wikis").execute({
+      label_prefix: "BABB",
+    })) as { wikis: Array<{ label: string }> };
+
+    const labels = result.wikis.map((w) => w.label);
+    expect(labels).toContain("Babb Noted");
+    expect(labels).not.toContain("Charles Babbage");
+  });
+
+  it("escapes LIKE wildcards in label_prefix so '%' matches literally", async () => {
+    // No wikis whose label literally starts with '%', so the result must
+    // be empty — proves '%' is not interpreted as a wildcard.
+    const result = (await tool("list_wikis").execute({
+      label_prefix: "%",
+    })) as { wikis: unknown[] };
+    expect(result.wikis).toEqual([]);
+  });
+
+  it("returns has_contributions=true wikis when contributions are pending", async () => {
+    // Add a placeholder via contribute(), which leaves a pending contribution
+    // attached to a fresh wiki.
+    await tool("contribute").execute({
+      subject: { label: "List Wikis Pending", subject_type: "concept" },
+      excerpt: "demo excerpt",
+    });
+
+    const result = (await tool("list_wikis").execute({
+      has_contributions: true,
+    })) as { wikis: Array<{ label: string }> };
+
+    expect(result.wikis.map((w) => w.label)).toContain("List Wikis Pending");
+  });
+
+  it("attaches counts when include_counts is true", async () => {
+    const result = (await tool("list_wikis").execute({
+      label_prefix: "List Wikis Pending",
+      include_counts: true,
+    })) as {
+      wikis: Array<{
+        label: string;
+        counts?: { contributions_pending: number; incoming_links: number; outgoing_links: number };
+      }>;
+    };
+
+    const w = result.wikis.find((x) => x.label === "List Wikis Pending");
+    expect(w).toBeTruthy();
+    expect(w!.counts).toBeDefined();
+    expect(w!.counts!.contributions_pending).toBeGreaterThanOrEqual(1);
+  });
+
+  it("respects limit", async () => {
+    const result = (await tool("list_wikis").execute({
+      limit: 1,
+    })) as { wikis: unknown[]; total: number };
+
+    expect(result.wikis.length).toBeLessThanOrEqual(1);
+    expect(result.total).toBeGreaterThan(1);
+  });
+
+  it("respects offset for pagination", async () => {
+    const page1 = (await tool("list_wikis").execute({
+      limit: 1,
+      offset: 0,
+      sort: "label",
+    })) as { wikis: Array<{ id: string }> };
+
+    const page2 = (await tool("list_wikis").execute({
+      limit: 1,
+      offset: 1,
+      sort: "label",
+    })) as { wikis: Array<{ id: string }> };
+
+    expect(page1.wikis[0].id).not.toBe(page2.wikis[0].id);
+  });
+
+  it("does not return source files (only wikis)", async () => {
+    mkdirSync(join(testDir, "sources"), { recursive: true });
+    writeFileSync(
+      join(testDir, "sources/listwikis-source.txt"),
+      "should never appear in list_wikis",
+    );
+
+    const sql = createSql();
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      const rows = await sql`SELECT id FROM entities WHERE source_path = ${"sources/listwikis-source.txt"}`;
+      if (rows.length > 0) break;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+
+    const result = (await tool("list_wikis").execute({
+      label_prefix: "listwikis",
+    })) as { wikis: Array<{ source_path: string }> };
+
+    expect(result.wikis.find((w) => w.source_path?.startsWith("sources/"))).toBeUndefined();
+  });
+});
+
 // ── cross-tool composition ────────────────────────────────────────
 
 describe("cross-tool composition", () => {


### PR DESCRIPTION
## Summary

Adds a sixth agent tool — `list_wikis` — that exposes the frontmatter-aware listing landed in #57 to the agent runtime. Hoists the `GET /wikis` listing logic out of `routes/wikis.ts` into a reusable `lib/wikis.ts` so the in-process tool calls library code directly (no HTTP roundtrip) while external HTTP callers see identical behavior.

## Why list_wikis matters for the agents

- **Editor (#50)** — `has_contributions=true` is literally the polling query: find wikis with pending contributions, draft/edit, mark consumed. No need to design a separate trigger.
- **Contributor (#49)** — `label_prefix=...` lets the agent check whether a subject already has a wiki before creating a placeholder. Complements `contribute()`'s exact-match routing with a fuzzier "is something close already there?" lookup.
- **Future linker/disambiguator** — `subject_type=...` and `status=placeholder` for enumerating subjects of a kind.

## Tool surface

Zod-typed: `subject_type`, `status`, `label_prefix`, `has_contributions`, `sort` (`updated_at` | `label`), `include_counts` (adds `contributions_pending` + incoming/outgoing link counts), `limit`, `offset`. `space_id` auto-binds from the agent context.

## Refactor: route handler stays thin

`routes/wikis.ts` GET handler now just maps query params to `listWikis(opts)`. ~120 lines deleted from the route, ~210 lines added in the lib. The route's behavior is preserved (verified by all existing route tests staying green) and the lib function is independently usable by anything in-process — agents today, future schedulers, CLI commands.

## Test plan

- [x] `npm run typecheck -w packages/arkeon` clean
- [x] `npm test -w packages/arkeon` — 69 unit tests pass
- [x] `npm run test:e2e -w packages/arkeon` — 132 e2e (was 123, +9 list_wikis tool tests):
  - filter by `subject_type`
  - filter by `status` (placeholder vs published)
  - `label_prefix` case-insensitive, prefix-anchored
  - `label_prefix` literal-escapes LIKE wildcards (`%` doesn't match everything)
  - `has_contributions=true` returns wikis with pending contributions
  - `include_counts` attaches `contributions_pending`/`incoming_links`/`outgoing_links`
  - `limit` honoured
  - `offset` paginates
  - source files (type=file) are never returned

## Followup not in this PR

- The list_wikis tool currently bypasses the `safeResolve` boundary because it's read-only and doesn't take a path. No new attack surface.
- Vector search (planned) drops in as a seventh tool with the same shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)