### PR TITLE
feat: declarative agent config + universal key support + setup docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,9 +8,22 @@
 # (b) opting into the agent runtime with a real LLM, or (c) running
 # the manual demo / multiple instances.
 #
-# Copy this file to `.env` (gitignored) at the repo root. The manual
-# agent demo loads it automatically; CLI commands respect any vars
-# you export.
+# Where this file goes — pick whichever fits:
+#
+#   ~/.arkeon-wiki/.env       Universal: one place for all your spaces.
+#                              Auto-loaded by the daemon and the manual
+#                              demo. Use this if you want to set your
+#                              OpenAI/Anthropic key once and have it
+#                              work in every repo.
+#
+#   <your-repo>/.env          Per-repo override. Auto-loaded; takes
+#                              precedence over ~/.arkeon-wiki/.env.
+#                              Gitignored by `arkeon-wiki init`.
+#
+#   shell export              Highest precedence. Wins over both files.
+#                              Useful for CI and secret managers.
+#
+# Precedence: shell > <repo>/.env > ~/.arkeon-wiki/.env
 
 # =====================================================================
 # State directory

--- a/.env.example
+++ b/.env.example
@@ -1,113 +1,69 @@
 # =====================================================================
-# Arkeon environment configuration
+# arkeon-wiki environment configuration
 # =====================================================================
 #
-# In the default local-mode path (`arkeon start`), you don't need any
-# of these. Secrets are generated on first run and persisted in
-# ~/.arkeon-wiki/secrets.json, and the API talks to the embedded Postgres
-# and spawned Meilisearch that the CLI manages.
+# arkeon-wiki is filesystem-first — SQLite for indexing, no Postgres,
+# no Meilisearch, no auth. The defaults work out of the box. Set
+# variables here only if you're (a) overriding the state directory,
+# (b) opting into the agent runtime with a real LLM, or (c) running
+# the manual demo / multiple instances.
 #
-# Set values here only if you are:
-#   - bringing your own Postgres / Meilisearch (see "External services"
-#     below — this is how enterprise installs point Arkeon at managed
-#     infrastructure like RDS, Aurora, Cloud SQL, or Meilisearch Cloud)
-#   - running the API directly (`npx tsx packages/arkeon/src/index.ts start`)
-#     against an external Postgres / Meilisearch
-#   - opting into the knowledge extraction pipeline
-#   - switching storage from local to S3/R2/MinIO
-#
-# Env var naming: ARKEON_-prefixed names are canonical and win over the
-# bare equivalents (which are kept for back-compat with existing
-# ecosystem tooling like `DATABASE_URL`). For example, if you set both
-# ARKEON_DATABASE_URL and DATABASE_URL, the ARKEON_ one is used.
-#
-# Copy this file to `.env` and edit the values you care about.
+# Copy this file to `.env` (gitignored) at the repo root. The manual
+# agent demo loads it automatically; CLI commands respect any vars
+# you export.
 
 # =====================================================================
 # State directory
 # =====================================================================
-# Where the CLI keeps downloaded binaries, embedded Postgres data, and
-# generated secrets. Defaults to ~/.arkeon-wiki.
+# Where the daemon keeps SQLite, the pidfile, the registry of running
+# instances, and the log. Defaults to ~/.arkeon-wiki.
 # ARKEON_WIKI_HOME=/path/to/state
 
 # =====================================================================
-# Ports
-# =====================================================================
-# PORT=8000
-# PG_PORT=5433
-# MEILI_PORT=7700
-
-# =====================================================================
-# External services (bring your own Postgres / Meilisearch)
+# Agent runtime LLM configuration
 # =====================================================================
 #
-# If ARKEON_DATABASE_URL (or DATABASE_URL) is set, `arkeon start` skips
-# embedding Postgres and points the API at the URL. You must also set
-# ARKE_APP_PASSWORD — it's the password of the `arke_app` role that
-# the API logs in as for every request. Set ARKEON_MIGRATION_DATABASE_URL
-# to a superuser URL if you want migrations to run on startup (they
-# run against ARKEON_DATABASE_URL otherwise, which will fail on DDL
-# unless that role has enough privileges).
+# The agent runtime (src/server/agents/) is provider-agnostic via the
+# Vercel AI SDK. Three providers are supported out of the box; pick one
+# by setting the matching API key.
 #
-# Same deal for Meilisearch: if ARKEON_MEILI_URL is set, `arkeon start`
-# skips downloading/spawning the binary and talks to the URL instead.
+#   1. OpenAI (default for the manual demo)
+#      Sign up at https://platform.openai.com — works for GPT-5, GPT-4o,
+#      GPT-4o-mini, and any other model on api.openai.com.
+# OPENAI_API_KEY=sk-...
 #
-# ARKEON_DATABASE_URL=postgresql://arke_app:PASSWORD@db.example.com:5432/arke
-# ARKEON_MIGRATION_DATABASE_URL=postgresql://arke:PASSWORD@db.example.com:5432/arke
-# ARKE_APP_PASSWORD=PASSWORD
-# ARKEON_MEILI_URL=https://ms-xxxx.meilisearch.io
-# ARKEON_MEILI_MASTER_KEY=...
-
-# =====================================================================
-# Secrets — only required in external-services mode. `arkeon start`
-# generates and persists these automatically in the embedded mode.
-# =====================================================================
-# Admin bootstrap key. On first boot, an admin API key is seeded from
-# this value. Rotate after first use. Pin it here if you want a stable
-# key across deploys (e.g. injected from Kubernetes Secrets).
-# Generate: echo "ak_$(openssl rand -hex 32)"
-# ARKEON_ADMIN_BOOTSTRAP_KEY=
-
-# Symmetric encryption key for secrets at rest (AES-256-GCM).
-# MUST be exactly 64 hex chars (32 bytes). Losing this bricks encrypted data.
-# If unset, the API generates and persists one in system_config on first boot.
-# Generate: openssl rand -hex 32
-# ARKEON_ENCRYPTION_KEY=
-
-# =====================================================================
-# Storage
-# =====================================================================
-# STORAGE_BACKEND=local
-# STORAGE_DIR=./data/files
-
-# S3 / R2 / MinIO (only when STORAGE_BACKEND=s3)
-# S3_ENDPOINT=
-# S3_BUCKET=
-# S3_REGION=
-# S3_ACCESS_KEY_ID=
-# S3_SECRET_ACCESS_KEY=
-
-# =====================================================================
-# Wiki pipeline LLM configuration
+#   2. Anthropic (Claude)
+# ANTHROPIC_API_KEY=sk-ant-...
 #
-# The wiki pipeline uses an LLM for up to four steps. Default models
-# and API key can be set via env or ~/.arkeon-wiki/llm.json (see
-# docs/dev/WIKI_PIPELINE.md). Env vars take precedence over the file.
+#   3. OpenAI-compatible (everything else)
+#      Anything that speaks OpenAI's chat-completions shape works by
+#      pointing OPENAI_BASE_URL at it. Confirmed: Ollama, LM Studio,
+#      llama.cpp --server, vLLM, OpenRouter, Groq, Together, Fireworks,
+#      DeepInfra, Anyscale. Use OPENAI_API_KEY for the bearer (or
+#      "not-required" for local servers that don't auth).
 #
-# Per-step model overrides are env-only. For per-step provider
-# overrides (different API keys / base URLs per step), use the file.
-# =====================================================================
-# OPENAI_API_KEY=
-# OPENAI_BASE_URL=
-# WIKI_RESOLVE_MODEL=gpt-5.4-nano
-# WIKI_EXISTS_MODEL=gpt-5.4-nano
-# WIKI_DRAFT_MODEL=gpt-5.4-nano
-# WIKI_DEDUP_MODEL=gpt-5.4-nano
-# WIKI_LLM_CONFIG_PATH=~/.arkeon-wiki/llm.json
+#      Local Ollama:
+# OPENAI_API_KEY=not-required
+# OPENAI_BASE_URL=http://localhost:11434/v1
+#
+#      OpenRouter (one key, hundreds of models):
+# OPENAI_API_KEY=sk-or-v1-...
+# OPENAI_BASE_URL=https://openrouter.ai/api/v1
+#
+#      Groq:
+# OPENAI_API_KEY=gsk_...
+# OPENAI_BASE_URL=https://api.groq.com/openai/v1
 
 # =====================================================================
-# Misc
+# Manual agent demo (test/manual/agent-real-llm.test.ts)
 # =====================================================================
-# ARKE_API_URL=                  # internal SDK base URL (knowledge service)
-# API_BASE_URL=                  # self-URL for worker invocations
-# E2E_BASE_URL=http://localhost:8000
+#
+# Overrides for the demo run. Defaults: provider auto-detects from
+# whichever API key is set above; model is gpt-5-mini for OpenAI /
+# claude-sonnet-4-6 for Anthropic. Run with:
+#
+#   npm run test:manual -w packages/arkeon
+#
+# AGENT_DEMO_PROVIDER=openai          # openai | anthropic | openai-compatible
+# AGENT_DEMO_MODEL=gpt-5-mini
+# AGENT_DEMO_BASE_URL=                # required when provider=openai-compatible

--- a/README.md
+++ b/README.md
@@ -77,8 +77,26 @@ arkeon-wiki ls                 # list running instances
 arkeon-wiki logs [-f]          # print/tail the daemon log
 arkeon-wiki init [name]        # register current directory as a space
 arkeon-wiki search <query>     # keyword search (ripgrep, defaults to bound space)
+arkeon-wiki config init        # write .arkeon/agents.yaml from a template
+arkeon-wiki config show        # print merged effective agent config
+arkeon-wiki config validate    # schema-check the YAML
 arkeon-wiki start              # foreground (for use under pm2/launchd/etc.)
 ```
+
+## Agents (LLM-powered)
+
+arkeon-wiki ships a small AI agent runtime with built-in roles for extracting subjects from sources (`contributor`) and drafting wiki bodies (`editor`). Configure them in `.arkeon/agents.yaml` (committed) and put your API key in `~/.arkeon-wiki/.env` (per-user, machine-local).
+
+```bash
+arkeon-wiki config init                                       # template config
+echo "OPENAI_API_KEY=sk-..." > ~/.arkeon-wiki/.env             # one key for all spaces
+$EDITOR .arkeon/agents.yaml                                    # set provider/model/instructions
+arkeon-wiki config show                                        # confirm what'll run
+```
+
+Roles run on OpenAI, Anthropic, or any OpenAI-compatible backend (Ollama, LM Studio, OpenRouter, Groq, vLLM, …). Each role can use a different provider; secrets stay in `.env`, never YAML. Custom user-defined roles are first-class.
+
+Full setup guide: [docs/user/AGENT_RUNTIME.md](./docs/user/AGENT_RUNTIME.md).
 
 ## Configuration
 
@@ -90,6 +108,9 @@ All state lives in `~/.arkeon-wiki/` (override with `ARKEON_WIKI_HOME` or `--dat
 | `--data-dir <path>` flag | Per-invocation override |
 | `--port <port>` flag | API port (default: 8000) |
 | `--name <name>` flag | Run a named instance side-by-side with others |
+| `~/.arkeon-wiki/.env` | Universal API keys (OpenAI, Anthropic, etc.) — auto-loaded |
+| `<repo>/.env` | Per-repo API key override (gitignored by `init`) |
+| `.arkeon/agents.yaml` | Per-repo agent config: providers, models, operator instructions, custom roles. Committed. See [AGENT_RUNTIME.md](./docs/user/AGENT_RUNTIME.md). |
 
 ## Development
 

--- a/docs/user/AGENT_RUNTIME.md
+++ b/docs/user/AGENT_RUNTIME.md
@@ -1,0 +1,261 @@
+# Agent runtime
+
+arkeon-wiki ships a small AI agent runtime that lets you wire LLMs into the wiki without writing code. Built-in roles cover the common jobs (extracting subjects from sources, drafting wiki bodies); you tune their model, focus, and instructions in YAML and add your own custom roles when you need them.
+
+This page is the from-scratch setup guide. If you only want to know what the runtime does, see [README.md](../../README.md).
+
+## TL;DR
+
+```bash
+# 1. Install
+npm install -g arkeon-wiki
+
+# 2. Pick where your API key lives — anywhere on this list works.
+mkdir -p ~/.arkeon-wiki && echo "OPENAI_API_KEY=sk-..." >> ~/.arkeon-wiki/.env
+# (or)  echo "OPENAI_API_KEY=sk-..." >> .env       # in the current repo
+# (or)  export OPENAI_API_KEY=sk-...               # in your shell profile
+
+# 3. Bind a directory and configure agents
+arkeon-wiki up
+arkeon-wiki init                  # registers cwd as a space
+arkeon-wiki config init           # writes .arkeon/agents.yaml from a template
+$EDITOR .arkeon/agents.yaml       # set provider, model, instructions
+arkeon-wiki config show           # confirm the merged effective config
+```
+
+## Where do my API keys go?
+
+Three places, in increasing specificity. The most specific wins:
+
+| Location | Use when |
+|---|---|
+| `~/.arkeon-wiki/.env` | **You have one OpenAI/Anthropic account and want it to work across every space.** Set once, forget. |
+| `<your-repo>/.env` | Per-repo override. E.g., a work repo using a team-billed key vs. a personal repo on yours. |
+| Shell env (`export OPENAI_API_KEY=…`) | One-off sessions, CI, secret managers (`OPENAI_API_KEY=$(op read ...) arkeon-wiki ...`). Wins over both files. |
+
+`.env` files in your repo are gitignored automatically by `arkeon-wiki init`. The user-global `~/.arkeon-wiki/.env` is per-machine and never touched by git.
+
+**API keys never go in YAML.** `.arkeon/agents.yaml` is committed to your repo so the team shares model choices and instructions; it must not contain secrets.
+
+### Which environment variable to set
+
+By default, arkeon-wiki looks up the standard env var per provider. You don't need to touch `api_key_env` in YAML for the common case.
+
+| Provider in YAML | Env var read |
+|---|---|
+| `openai` | `OPENAI_API_KEY` |
+| `anthropic` | `ANTHROPIC_API_KEY` |
+| `openai-compatible` | `OPENAI_API_KEY` (most local/proxy servers reuse it) |
+
+Override per role only when you genuinely need a different env var name (e.g. a separate Groq key alongside an OpenAI key):
+
+```yaml
+roles:
+  fast-extractor:
+    provider: openai-compatible
+    base_url: https://api.groq.com/openai/v1
+    api_key_env: GROQ_API_KEY      # only here because it's a different account
+    model: llama-3.3-70b
+```
+
+## Configuration: `.arkeon/agents.yaml`
+
+Run `arkeon-wiki config init` once per repo. It writes a fully-commented template you can edit:
+
+```yaml
+defaults:
+  provider: openai             # openai | anthropic | openai-compatible
+  model: gpt-5-mini
+
+  # Operator notes appended to every role's system prompt. Use this to
+  # steer subjects, tone, and scope without rewriting the workflow.
+  instructions: |
+    This wiki tracks researchers in climate science. Skip subjects
+    not directly relevant to the field. Use British English.
+
+# Per-role overrides. Built-in roles (contributor, editor) are defined
+# in the package and inherited automatically — fields you omit fall
+# back to the built-in. Custom roles appear here too.
+roles:
+  contributor:
+    model: gpt-5-mini          # cheap extraction
+    max_steps: 12
+    instructions: |
+      Be aggressive about creating placeholders for any named subject
+      a reader might want a wiki page for. Skip generic terms.
+
+  editor:
+    provider: anthropic        # different provider per role is fine
+    model: claude-opus-4-7
+    api_key_env: ANTHROPIC_API_KEY
+    max_steps: 20
+    instructions: |
+      Each section is 2-4 paragraphs. Cite sources by linking to the
+      source file inline. End every wiki body with "Further reading"
+      if there are 3+ outgoing links.
+
+  link-checker:                # custom user-defined role
+    model: gpt-5-mini
+    tools: [list_wikis, read_file, edit_file]
+    max_steps: 30
+    system: |
+      You find wikis with broken or missing cross-references and add
+      markdown links to the wikis they should connect to. Use search
+      and list_wikis to discover candidates.
+    user: |
+      Wiki to check: {{trigger_entity_id}}
+```
+
+### Config commands
+
+```
+arkeon-wiki config init               # create .arkeon/agents.yaml from template
+arkeon-wiki config show               # print merged effective config
+arkeon-wiki config validate           # schema-check the YAML
+```
+
+`config show` is the source of truth for "what is actually going to run" — it reflects the merged result of `~/.arkeon-wiki/agents.yaml`, `.arkeon/agents.yaml`, and the built-in templates.
+
+## Built-in roles
+
+| Role | Tools | Job |
+|---|---|---|
+| `contributor` | `list_wikis`, `read_file`, `contribute` | Read source files, identify subjects, route them through `contribute()` to existing or new placeholder wikis. |
+| `editor` | `read_file`, `edit_file`, `write_file`, `list_wikis` | Take a wiki with pending contributions and either draft its body (placeholder → published) or weave new contributions into the existing body. |
+
+You can override any field of a built-in (`provider`, `model`, `tools`, `max_steps`, `instructions`, `system`, `user`) without redefining the whole role. To inherit a built-in's default workflow but bias the focus, set `instructions:` only.
+
+## Custom roles
+
+Define a custom role by adding any name under `roles:` that isn't a built-in. Custom roles **must** specify:
+
+- `system:` — the full system prompt (the workflow)
+- `tools:` — list of tool names from the registry
+
+Optional: `provider`, `model`, `api_key_env`, `base_url`, `max_steps`, `user` (template), `instructions`.
+
+The available tools are:
+
+| Tool | Use |
+|---|---|
+| `list_wikis` | Frontmatter-aware enumeration: filter by `subject_type`, `status`, `label_prefix`, `has_contributions`. |
+| `search` | Keyword search via ripgrep, returns ranked entity hits with snippets. |
+| `read_file` | Read a file's contents (markdown returns parsed frontmatter + body). |
+| `write_file` | Net-new file (or full overwrite). |
+| `edit_file` | SEARCH/REPLACE on an existing file (Aider-style; SEARCH must match exactly once). |
+| `contribute` | Macro: route a `(subject, excerpt, claim)` to an existing wiki by label/alias match, or create a placeholder. |
+
+### Prompt template variables
+
+Both `system:` and `user:` are templates. Available variables:
+
+| Variable | Resolves to |
+|---|---|
+| `{{trigger_path}}` | The path that triggered this run (source file path, wiki path, etc.). Empty if the agent was invoked without a trigger. |
+| `{{trigger_entity_id}}` | The entity id of the trigger. Empty if none. |
+| `{{space_id}}` / `{{space_name}}` / `{{space_watch_dir}}` | The space the agent is running in. |
+| `{{role_name}}` | The role being run. |
+
+Unknown placeholders resolve to the empty string (no errors).
+
+## Providers
+
+| Provider | What it covers | Required fields |
+|---|---|---|
+| `openai` | Anything on `api.openai.com` (GPT-5, GPT-4o, etc.) | `model` |
+| `anthropic` | Claude (Sonnet, Opus, Haiku) | `model` |
+| `openai-compatible` | Ollama, LM Studio, llama.cpp `--server`, vLLM, OpenRouter, Groq, Together, Fireworks, DeepInfra — anything speaking the OpenAI chat-completions shape | `model`, `base_url` |
+
+### Local Ollama
+
+```yaml
+defaults:
+  provider: openai-compatible
+  base_url: http://localhost:11434/v1
+  model: llama3.1:70b
+```
+
+No API key needed. (Set `OPENAI_API_KEY=not-required` if Ollama complains.)
+
+### OpenRouter (one key, hundreds of models)
+
+```yaml
+defaults:
+  provider: openai-compatible
+  base_url: https://openrouter.ai/api/v1
+  model: anthropic/claude-sonnet-4-6
+  api_key_env: OPENROUTER_API_KEY
+```
+
+Then put `OPENROUTER_API_KEY=sk-or-v1-…` in `~/.arkeon-wiki/.env`.
+
+### Mixing providers per role
+
+```yaml
+defaults:
+  provider: openai
+  model: gpt-5-mini
+
+roles:
+  contributor:                # cheap extraction on OpenAI
+    model: gpt-5-mini
+  editor:                     # stronger writing on Claude
+    provider: anthropic
+    model: claude-opus-4-7
+    api_key_env: ANTHROPIC_API_KEY
+  drafter:                    # local model for offline drafting
+    provider: openai-compatible
+    base_url: http://localhost:11434/v1
+    model: llama3.1:70b
+    tools: [list_wikis, read_file, write_file]
+    system: |
+      You draft wiki bodies offline...
+```
+
+Each role gets its own provider and key. Set `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` in `~/.arkeon-wiki/.env`; the local model needs no key.
+
+## Verifying setup
+
+A real-LLM smoke test ships with the package:
+
+```bash
+npm install -g arkeon-wiki    # if not already installed
+# (with key set in ~/.arkeon-wiki/.env or shell)
+arkeon-wiki up
+arkeon-wiki init
+arkeon-wiki config show       # confirm merged config
+```
+
+If you have the package source checked out:
+
+```bash
+npm run test:manual -w packages/arkeon
+```
+
+This runs the contributor role against a synthetic source paragraph and prints the wikis that landed, token usage, and total cost.
+
+## Troubleshooting
+
+**`Required env var OPENAI_API_KEY is not set`**
+Your YAML resolved to `provider: openai`, but no key was found. Drop one in `~/.arkeon-wiki/.env`, your repo's `.env`, or shell-export it.
+
+**`Provider 'openai-compatible' requires base_url`**
+You set `provider: openai-compatible` (often inherited from a default) but didn't set `base_url`. Either set it or change to `openai` / `anthropic`.
+
+**`Role 'X': no system prompt`**
+You defined a custom role but left out `system:`. Built-in roles fall back to a template; custom roles must supply their own.
+
+**`Role 'X': no tools configured`**
+Same idea — custom roles must specify `tools:`.
+
+**Schema errors from `config validate`**
+Check the unknown field name; the schema is strict. The likely candidates:
+- `provider` accepts only `openai | anthropic | openai-compatible`
+- `max_steps` must be a positive integer
+- `tools` is an array of strings (tool names)
+
+## What's not yet wired
+
+- **Auto-triggering** — roles in YAML don't yet specify *when* they fire. The contributor (#49) will register on file events for sources outside `wiki/`; the editor (#50) will poll wikis with pending contributions every N seconds. Until those workers land, run agents manually via the runtime API or the upcoming `arkeon-wiki agent run <role>` command.
+- **Per-role budgets / cost caps** — set `max_steps` for now; spending caps are a planned follow-up.
+- **Streaming output** — `runAgent` currently waits for the full response. Streaming will come with the daemon integration.

--- a/docs/user/AGENT_RUNTIME.md
+++ b/docs/user/AGENT_RUNTIME.md
@@ -116,6 +116,17 @@ arkeon-wiki config validate           # schema-check the YAML
 
 `config show` is the source of truth for "what is actually going to run" — it reflects the merged result of `~/.arkeon-wiki/agents.yaml`, `.arkeon/agents.yaml`, and the built-in templates.
 
+### How merging works
+
+| Section | Behavior when set in both global and repo |
+|---|---|
+| `defaults` | **Field-level merge.** `defaults.provider` from global + `defaults.model` from repo combine. Repo wins on shared fields. |
+| `roles.<name>` | **Per-role replacement.** If `roles.contributor` exists in both files, the repo entry replaces the global entry **wholesale** — fields you don't repeat are *not* inherited from the global. |
+
+This asymmetry keeps role overrides predictable: when you write `roles.contributor:` in your repo's YAML, you're declaring exactly what that role looks like for this repo, not partially patching whatever your `~/` happens to have.
+
+To carry over a field from a global role override, copy it. The most common case is global YAML setting universal `defaults` and the per-repo file overriding individual roles — that works without copying anything because `defaults` *do* merge.
+
 ## Built-in roles
 
 | Role | Tools | Job |

--- a/packages/arkeon/src/cli/commands/repo/config.ts
+++ b/packages/arkeon/src/cli/commands/repo/config.ts
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `arkeon-wiki config <subcommand>` — manage the agent configuration.
+ *
+ * Subcommands:
+ *   show        print the merged effective config (built-ins + YAML)
+ *   init        create .arkeon/agents.yaml from a template
+ *   validate    schema-check .arkeon/agents.yaml
+ *
+ * The config file is `.arkeon/agents.yaml` in the current repo (or
+ * `~/.arkeon-wiki/agents.yaml` for user-global defaults). Both are
+ * optional; the runtime falls back to the built-in templates plus
+ * env-var-based key resolution.
+ */
+
+import type { Command } from "commander";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+import yaml from "js-yaml";
+
+import {
+  AGENT_CONFIG_SCHEMA,
+  loadAgentConfig,
+} from "../../../server/agents/config.js";
+import { BUILTIN_ROLES } from "../../../server/agents/builtins.js";
+import { listAvailableRoles } from "../../../server/agents/role-builder.js";
+import { output } from "../../lib/output.js";
+
+const REPO_RELATIVE_PATH = join(".arkeon", "agents.yaml");
+
+const TEMPLATE = `# .arkeon/agents.yaml
+#
+# Per-repo agent configuration. Committed to the repo so the team
+# shares the same focus, model choices, and operator instructions.
+# Secrets never live here — set OPENAI_API_KEY / ANTHROPIC_API_KEY
+# in .env (gitignored) or your shell.
+#
+# Built-in roles (contributor, editor) are defined in the package and
+# inherited automatically. Override their fields here, or define your
+# own custom roles. Run \`arkeon-wiki config show\` to see the merged
+# effective config.
+
+defaults:
+  provider: openai             # openai | anthropic | openai-compatible
+  model: gpt-5-mini
+  # Operator-supplied focus / style notes. Appended to every role's
+  # system prompt. Use this to steer subjects, tone, scope.
+  # instructions: |
+  #   This wiki tracks researchers in climate science. Skip subjects
+  #   not directly relevant. Cross-link to existing wikis.
+
+# Per-role overrides (built-in roles inherit by name). Add custom
+# roles here too — they need at least 'system' and 'tools'.
+#
+# roles:
+#   contributor:
+#     model: gpt-5-mini
+#     max_steps: 12
+#     instructions: |
+#       Be aggressive about creating placeholders for named subjects.
+#
+#   editor:
+#     provider: anthropic
+#     model: claude-opus-4-7
+#     api_key_env: ANTHROPIC_API_KEY    # optional, default per provider
+#     max_steps: 20
+#
+#   link-checker:                       # custom user-defined role
+#     model: gpt-5-mini
+#     tools: [list_wikis, read_file, edit_file]
+#     max_steps: 30
+#     system: |
+#       You find broken cross-references and fix them.
+#     user: |
+#       Wiki: {{trigger_entity_id}}
+`;
+
+export function registerConfigCommand(program: Command): void {
+  const cmd = program
+    .command("config")
+    .description("Manage the agent configuration");
+
+  cmd
+    .command("show")
+    .description("Print the merged effective config (env + repo + global)")
+    .action(async () => {
+      try {
+        await runShow();
+      } catch (error) {
+        output.error(error, { operation: "config show" });
+        process.exitCode = 1;
+      }
+    });
+
+  cmd
+    .command("init")
+    .description("Create .arkeon/agents.yaml from a template")
+    .option("--force", "Overwrite an existing file", false)
+    .action(async (options: { force: boolean }) => {
+      try {
+        await runInit(options.force);
+      } catch (error) {
+        output.error(error, { operation: "config init" });
+        process.exitCode = 1;
+      }
+    });
+
+  cmd
+    .command("validate")
+    .description("Schema-check .arkeon/agents.yaml")
+    .action(async () => {
+      try {
+        await runValidate();
+      } catch (error) {
+        output.error(error, { operation: "config validate" });
+        process.exitCode = 1;
+      }
+    });
+}
+
+async function runShow(): Promise<void> {
+  const cwd = process.cwd();
+  const merged = loadAgentConfig({ spaceDir: cwd });
+  const roles = listAvailableRoles(merged);
+
+  console.log("# Effective agent configuration");
+  console.log(`# spaceDir: ${cwd}`);
+  console.log("");
+  console.log(yaml.dump({ defaults: merged.defaults ?? {}, roles: merged.roles ?? {} }, { sortKeys: false }));
+
+  console.log(`# Available roles (${roles.length}):`);
+  for (const name of roles) {
+    const isBuiltin = Object.prototype.hasOwnProperty.call(BUILTIN_ROLES, name);
+    const overridden = !!merged.roles?.[name];
+    const tag =
+      isBuiltin && overridden
+        ? "(builtin, overridden)"
+        : isBuiltin
+        ? "(builtin)"
+        : "(custom)";
+    console.log(`#   ${name}  ${tag}`);
+  }
+}
+
+async function runInit(force: boolean): Promise<void> {
+  const cwd = process.cwd();
+  const target = resolve(cwd, REPO_RELATIVE_PATH);
+
+  if (existsSync(target) && !force) {
+    output.result({
+      operation: "config init",
+      created: false,
+      path: target,
+      hint: "File already exists. Use --force to overwrite, or edit it directly.",
+    });
+    return;
+  }
+
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, TEMPLATE);
+
+  output.result({
+    operation: "config init",
+    created: true,
+    path: target,
+    hint:
+      "Edit this file to set your provider/model and operator instructions. " +
+      "Add API keys to .env (not this file).",
+  });
+}
+
+async function runValidate(): Promise<void> {
+  const cwd = process.cwd();
+  const target = resolve(cwd, REPO_RELATIVE_PATH);
+
+  if (!existsSync(target)) {
+    output.result({
+      operation: "config validate",
+      valid: true,
+      path: target,
+      hint: "No agents.yaml present — runtime will use built-in defaults.",
+    });
+    return;
+  }
+
+  const text = readFileSync(target, "utf-8");
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(text);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`agents.yaml is not valid YAML: ${msg}`);
+  }
+  // Throws ZodError on schema violations; output.error formats it.
+  AGENT_CONFIG_SCHEMA.parse(parsed ?? {});
+
+  output.result({
+    operation: "config validate",
+    valid: true,
+    path: target,
+  });
+}

--- a/packages/arkeon/src/cli/commands/repo/init.ts
+++ b/packages/arkeon/src/cli/commands/repo/init.ts
@@ -77,12 +77,31 @@ async function runInit(name: string | undefined, options: InitOptions): Promise<
   };
   writeFileSync(join(arkeonDir, "state.json"), JSON.stringify(state, null, 2));
 
-  // Add .arkeon/ to .gitignore
+  // Gitignore only the per-clone state file. `.arkeon/agents.yaml` and
+  // any other configuration that lives in the .arkeon dir are intended
+  // to be committed so the team shares them.
   const gitignorePath = join(cwd, ".gitignore");
   if (existsSync(gitignorePath)) {
     const gitignoreContent = readFileSync(gitignorePath, "utf-8");
-    if (!gitignoreContent.includes(".arkeon/")) {
-      writeFileSync(gitignorePath, `${gitignoreContent.trimEnd()}\n.arkeon/\n`);
+    const stale = ".arkeon/";
+    const target = ".arkeon/state.json";
+    let updated = gitignoreContent;
+    // Migrate any pre-existing `.arkeon/` (which would also hide
+    // committed config) to the narrower `.arkeon/state.json`.
+    if (
+      updated.split("\n").some((line) => line.trim() === stale) &&
+      !updated.includes(target)
+    ) {
+      updated = updated
+        .split("\n")
+        .map((line) => (line.trim() === stale ? target : line))
+        .join("\n");
+    }
+    if (!updated.includes(target)) {
+      updated = `${updated.trimEnd()}\n${target}\n`;
+    }
+    if (updated !== gitignoreContent) {
+      writeFileSync(gitignorePath, updated);
     }
   }
 

--- a/packages/arkeon/src/index.ts
+++ b/packages/arkeon/src/index.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 import { Command } from "commander";
 
 import { registerLocalCommands } from "./cli/commands/local/index.js";
+import { registerConfigCommand } from "./cli/commands/repo/config.js";
 import { registerInitCommand } from "./cli/commands/repo/init.js";
 import { registerSearchCommand } from "./cli/commands/repo/search.js";
 
@@ -42,5 +43,6 @@ program.hook("preAction", (command) => {
 registerLocalCommands(program);
 registerInitCommand(program);
 registerSearchCommand(program);
+registerConfigCommand(program);
 
 program.parse();

--- a/packages/arkeon/src/server/agents/builtins.ts
+++ b/packages/arkeon/src/server/agents/builtins.ts
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Built-in role templates.
+ *
+ * Each entry is a `RoleConfig` whose fields are the *defaults* the
+ * runtime will use unless the user's agents.yaml overrides them. The
+ * goal is that an empty `.arkeon/agents.yaml` (just `defaults:` with
+ * a model) gets you working agents — you only configure what you want
+ * to change.
+ *
+ * Workflows + tool descriptions live here, in code, where they get
+ * type-checked and reviewed. Operators tune *focus, style, scope* via
+ * the `instructions` field in YAML; they don't rewrite the workflow.
+ *
+ * Custom user-defined roles are NOT in this file — they live entirely
+ * in YAML and must supply their own `system`/`tools`/etc.
+ */
+
+import type { RoleConfig } from "./config.js";
+
+export const BUILTIN_ROLES: Record<string, RoleConfig> = {
+  // ── contributor ────────────────────────────────────────────────
+  contributor: {
+    tools: ["list_wikis", "read_file", "contribute"],
+    max_steps: 12,
+    system: [
+      "You are a contributor agent for a wiki knowledge graph.",
+      "",
+      "Workflow:",
+      "  1. Use list_wikis to see what subjects already have wikis in this space.",
+      "  2. Use read_file to read the source document at the given path.",
+      "  3. Identify each distinct subject the source discusses (people,",
+      "     organizations, concepts, publications, events, places, etc.).",
+      "  4. For each subject, call contribute() with:",
+      "       - subject.label: the canonical name",
+      "       - subject.subject_type: 'person' | 'organization' | 'concept' |",
+      "         'publication' | 'event' | 'place' | etc.",
+      "       - subject.aliases: alternate forms when matching existing wikis",
+      "       - excerpt: a verbatim or near-verbatim sentence from the source",
+      "       - claim: a one-line summary of what the source establishes",
+      "         about that subject",
+      "       - source_id: the source entity id you were given (always pass it)",
+      "  5. Stop when every distinct subject has been contributed.",
+      "",
+      "Do not write any wiki bodies — that is a separate agent's job.",
+      "Be concise. Skip generic terms; only contribute named subjects a",
+      "reader would plausibly want a wiki page for.",
+    ].join("\n"),
+    user: [
+      "Source path: {{trigger_path}}",
+      "Source entity id: {{trigger_entity_id}}",
+      "",
+      "Identify subjects in this source and contribute them.",
+    ].join("\n"),
+  },
+
+  // ── editor ─────────────────────────────────────────────────────
+  // Forward-looking template for #50; kept here so YAML overrides land
+  // before the consumer.
+  editor: {
+    tools: ["read_file", "edit_file", "write_file", "list_wikis"],
+    max_steps: 20,
+    system: [
+      "You are an editor agent for a wiki knowledge graph.",
+      "",
+      "Your job is to take a wiki and the contributions accumulated on it",
+      "(stored in its frontmatter `contributions[]`) and either:",
+      "  - draft the body, if the wiki has status: placeholder, OR",
+      "  - update the existing body to incorporate new pending contributions.",
+      "",
+      "Workflow:",
+      "  1. Use read_file to load the target wiki.",
+      "  2. Inspect frontmatter `status` and `contributions[]`. If status",
+      "     is 'placeholder', mode=draft. Otherwise mode=edit.",
+      "  3. Optionally use list_wikis or read_file to look up neighboring",
+      "     wikis for tone/style reference.",
+      "  4. For mode=draft: use write_file with full content (frontmatter",
+      "     + body). Flip status to 'published'. Mark all contributions",
+      "     consumed by setting consumed_at.",
+      "  5. For mode=edit: use edit_file (SEARCH/REPLACE) to weave new",
+      "     contributions into the existing body. Mark consumed contributions.",
+      "",
+      "Cross-link to existing wikis whenever a name comes up that already",
+      "has a page in this space. Use markdown links: [Label](path.md).",
+    ].join("\n"),
+    user: [
+      "Target wiki id: {{trigger_entity_id}}",
+      "",
+      "Draft or update its body using the pending contributions.",
+    ].join("\n"),
+  },
+};
+
+export function isBuiltinRole(name: string): boolean {
+  return Object.prototype.hasOwnProperty.call(BUILTIN_ROLES, name);
+}

--- a/packages/arkeon/src/server/agents/config.ts
+++ b/packages/arkeon/src/server/agents/config.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Declarative agent configuration loaded from YAML.
+ *
+ * Two locations, both optional:
+ *   - $SPACE_DIR/.arkeon/agents.yaml   per-repo, COMMITTED
+ *   - ~/.arkeon-wiki/agents.yaml        per-user, machine-local
+ *
+ * Per-repo wins over user-global. Field-level merge for `defaults`,
+ * per-role override for entries under `roles`. Secrets never appear
+ * in YAML — `api_key_env` names which env var to read.
+ *
+ * The YAML is the *source of truth* for what providers/models a role
+ * uses, what tools it can call, what its prompts say, and the
+ * operator-supplied focus/style instructions. Built-in templates in
+ * builtins.ts cover the workflow + tool-use patterns; YAML tunes the
+ * knobs operators care about.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import yaml from "js-yaml";
+import { z } from "zod";
+
+// ── Schema ────────────────────────────────────────────────────────
+
+export const ROLE_CONFIG_SCHEMA = z.object({
+  // Model selection
+  provider: z.enum(["openai", "anthropic", "openai-compatible"]).optional(),
+  model: z.string().optional(),
+  api_key_env: z.string().optional(),
+  base_url: z.string().optional(),
+
+  // Tools the LLM may call (names from ALL_TOOLS in tools.ts)
+  tools: z.array(z.string()).optional(),
+
+  // Loop bound
+  max_steps: z.number().int().positive().max(100).optional(),
+
+  // Prompts
+  /** Full system prompt. Replaces the built-in template entirely. */
+  system: z.string().optional(),
+  /** User-message template. Variables: {{trigger_path}}, {{trigger_entity_id}},
+   *  {{space_id}}, {{space_name}}. */
+  user: z.string().optional(),
+  /** Operator notes appended to the system prompt (built-in or custom).
+   *  Use this for focus/style/scope guidance without rewriting the workflow. */
+  instructions: z.string().optional(),
+});
+
+export const AGENT_CONFIG_SCHEMA = z.object({
+  /** Inherited by every role. */
+  defaults: ROLE_CONFIG_SCHEMA.optional(),
+  /** Per-role overrides (built-in roles) and user-defined roles.
+   *  Map keys are role names. */
+  roles: z.record(z.string(), ROLE_CONFIG_SCHEMA).optional(),
+});
+
+export type RoleConfig = z.infer<typeof ROLE_CONFIG_SCHEMA>;
+export type AgentConfig = z.infer<typeof AGENT_CONFIG_SCHEMA>;
+
+// ── Loader ────────────────────────────────────────────────────────
+
+const REPO_RELATIVE_PATH = join(".arkeon", "agents.yaml");
+const USER_GLOBAL_PATH = join(homedir(), ".arkeon-wiki", "agents.yaml");
+
+export interface LoadAgentConfigOptions {
+  /** The space's watch_dir. The repo-local config is at
+   *  {spaceDir}/.arkeon/agents.yaml. */
+  spaceDir?: string;
+  /** Override the user-global path (mainly for tests). */
+  userGlobalPath?: string;
+}
+
+/**
+ * Load and merge agent config from user-global and repo-local YAML.
+ * Either or both may be missing — always returns a valid (possibly
+ * empty) AgentConfig.
+ */
+export function loadAgentConfig(opts: LoadAgentConfigOptions = {}): AgentConfig {
+  const userGlobalPath = opts.userGlobalPath ?? USER_GLOBAL_PATH;
+  const repoLocalPath = opts.spaceDir
+    ? join(opts.spaceDir, REPO_RELATIVE_PATH)
+    : null;
+
+  const userGlobal = readConfigFile(userGlobalPath);
+  const repoLocal = repoLocalPath ? readConfigFile(repoLocalPath) : {};
+
+  return mergeConfigs(userGlobal, repoLocal);
+}
+
+function readConfigFile(path: string): AgentConfig {
+  if (!existsSync(path)) return {};
+  const text = readFileSync(path, "utf-8");
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(text);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`agents.yaml at ${path} is not valid YAML: ${msg}`);
+  }
+  if (parsed === null || parsed === undefined) return {};
+  return AGENT_CONFIG_SCHEMA.parse(parsed);
+}
+
+/**
+ * Merge two configs: `b` (repo-local) overrides `a` (user-global).
+ * - `defaults`: field-level shallow merge.
+ * - `roles`: per-role replacement (a role from `b` replaces `a`'s entry
+ *   wholesale, rather than merging field by field). Keeps the model
+ *   simple — to inherit, copy.
+ */
+export function mergeConfigs(a: AgentConfig, b: AgentConfig): AgentConfig {
+  return {
+    defaults: { ...a.defaults, ...b.defaults },
+    roles: { ...a.roles, ...b.roles },
+  };
+}

--- a/packages/arkeon/src/server/agents/env-loader.ts
+++ b/packages/arkeon/src/server/agents/env-loader.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * .env loader for the agent runtime.
+ *
+ * Two officially-supported locations, in increasing specificity:
+ *
+ *   1. ~/.arkeon-wiki/.env     "set once for all my spaces" (user-global)
+ *   2. <space.watch_dir>/.env  per-repo override (gitignored by `init`)
+ *
+ * The shell environment always wins over both — explicit `export
+ * OPENAI_API_KEY=...` (or a secret manager) takes precedence. This
+ * matches the conventions of git config, dotenv-flow, and most
+ * 12-factor tooling.
+ *
+ * Precedence (most specific wins):
+ *
+ *   shell env  >  <space>/.env  >  ~/.arkeon-wiki/.env
+ *
+ * Used by the manual demo and (when #49 lands) the daemon entrypoint.
+ */
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { config as dotenvConfig } from "dotenv";
+
+export interface LoadAgentEnvOptions {
+  /** Per-space directory; if set, look at {spaceDir}/.env there too. */
+  spaceDir?: string;
+  /** Override the user-global .env path (mainly for tests). */
+  userGlobalPath?: string;
+}
+
+export interface LoadAgentEnvResult {
+  /** Paths that existed and were loaded, in load order. */
+  loaded: string[];
+}
+
+const USER_GLOBAL_PATH = join(homedir(), ".arkeon-wiki", ".env");
+
+/**
+ * Load .env files in the right precedence order. Existing process env
+ * vars (set by the shell) are never overridden — they always win.
+ */
+export function loadAgentEnv(opts: LoadAgentEnvOptions = {}): LoadAgentEnvResult {
+  // Snapshot keys that came from the shell (or any earlier load) before
+  // we touch process.env. These are protected: nothing we read from
+  // .env will overwrite them.
+  const shellKeys = new Set(Object.keys(process.env));
+
+  const userGlobal = opts.userGlobalPath ?? USER_GLOBAL_PATH;
+  const repoLocal = opts.spaceDir ? join(opts.spaceDir, ".env") : null;
+  const loaded: string[] = [];
+
+  // Load user-global first; per-repo can override.
+  loadAndMerge(userGlobal, shellKeys, loaded);
+  if (repoLocal) loadAndMerge(repoLocal, shellKeys, loaded);
+
+  return { loaded };
+}
+
+function loadAndMerge(
+  path: string,
+  shellKeys: Set<string>,
+  loaded: string[],
+): void {
+  if (!existsSync(path)) return;
+  // Parse into a side-buffer so we can decide per-key whether to apply.
+  const buffer: Record<string, string> = {};
+  dotenvConfig({ path, processEnv: buffer, quiet: true });
+  for (const [k, v] of Object.entries(buffer)) {
+    if (shellKeys.has(k)) continue;        // shell wins — never overwrite
+    process.env[k] = v;                    // file wins over earlier file
+  }
+  loaded.push(path);
+}

--- a/packages/arkeon/src/server/agents/role-builder.ts
+++ b/packages/arkeon/src/server/agents/role-builder.ts
@@ -1,0 +1,221 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Turns declarative role config (YAML + built-in templates) into the
+ * runtime AgentRole object that runAgent consumes.
+ *
+ * Resolution chain for each field, most specific wins:
+ *   1. config.roles[name]
+ *   2. BUILTIN_ROLES[name]   (only when it's a built-in)
+ *   3. config.defaults
+ *
+ * Required-everywhere fields (provider, model, system, tools) must
+ * resolve to *something* by the end; otherwise we throw clearly.
+ *
+ * `instructions` is the only field that *layers* (defaults +
+ * role-specific are concatenated to the system prompt). All other
+ * fields use last-write-wins.
+ */
+
+import type { ModelConfig } from "./model.js";
+import type { AgentConfig, RoleConfig } from "./config.js";
+import { BUILTIN_ROLES, isBuiltinRole } from "./builtins.js";
+import {
+  hashInput,
+  type AgentInput,
+  type AgentRole,
+  type IdempotencyKey,
+} from "./runtime.js";
+
+/**
+ * Build an AgentRole for the named role from the declarative config.
+ *
+ * Throws if a required field can't be resolved (e.g. a custom role
+ * with no built-in template and no `system` in YAML).
+ */
+export function buildAgentRole(name: string, config: AgentConfig): AgentRole {
+  const builtin: RoleConfig = isBuiltinRole(name) ? BUILTIN_ROLES[name] : {};
+  const fromConfig: RoleConfig = config.roles?.[name] ?? {};
+  const defaults: RoleConfig = config.defaults ?? {};
+
+  // Field-level resolution (most specific wins).
+  const provider =
+    fromConfig.provider ?? builtin.provider ?? defaults.provider;
+  const modelId = fromConfig.model ?? builtin.model ?? defaults.model;
+  const baseUrl =
+    fromConfig.base_url ?? builtin.base_url ?? defaults.base_url;
+  const apiKeyEnv =
+    fromConfig.api_key_env ?? builtin.api_key_env ?? defaults.api_key_env;
+
+  if (!provider) {
+    throw new Error(
+      `Role '${name}': no provider resolved (set provider in defaults or roles.${name}).`,
+    );
+  }
+  if (!modelId) {
+    throw new Error(
+      `Role '${name}': no model id resolved (set model in defaults or roles.${name}).`,
+    );
+  }
+
+  const tools = fromConfig.tools ?? builtin.tools ?? defaults.tools ?? [];
+  if (tools.length === 0) {
+    throw new Error(
+      `Role '${name}': no tools configured (set tools in roles.${name} or builtin).`,
+    );
+  }
+
+  const maxSteps =
+    fromConfig.max_steps ?? builtin.max_steps ?? defaults.max_steps ?? 10;
+
+  // Prompt resolution: system replaces, instructions layer.
+  const baseSystem = fromConfig.system ?? builtin.system;
+  if (!baseSystem) {
+    throw new Error(
+      `Role '${name}': no system prompt. Custom (non-builtin) roles must ` +
+        `set 'system' in YAML.`,
+    );
+  }
+  const instructionsLayer = [defaults.instructions, fromConfig.instructions]
+    .filter((s): s is string => typeof s === "string" && s.trim().length > 0)
+    .join("\n\n");
+  const system = instructionsLayer
+    ? `${baseSystem}\n\n--- Operator instructions ---\n${instructionsLayer}`
+    : baseSystem;
+
+  const userTemplate =
+    fromConfig.user ?? builtin.user ?? defaults.user ?? "{{user_input}}";
+
+  const apiKey = resolveApiKey(provider, apiKeyEnv);
+  const model = toModelConfig(provider, modelId, baseUrl, apiKey);
+
+  return {
+    name,
+    model,
+    tools,
+    maxSteps,
+    buildPrompt: async (input: AgentInput) => ({
+      system: fillTemplate(system, promptVars(name, input)),
+      prompt: fillTemplate(userTemplate, promptVars(name, input)),
+    }),
+    idempotencyKey: defaultIdempotencyKey(name),
+    concurrencyKey: defaultConcurrencyKey(name),
+  };
+}
+
+// ── Prompt template ──────────────────────────────────────────────
+
+export function promptVars(
+  roleName: string,
+  input: AgentInput,
+): Record<string, string> {
+  return {
+    role_name: roleName,
+    trigger_path: input.triggerPath ?? "",
+    trigger_entity_id: input.triggerEntityId ?? "",
+    space_id: input.space.id,
+    space_name: input.space.name,
+    space_watch_dir: input.space.watch_dir,
+  };
+}
+
+export function fillTemplate(
+  template: string,
+  vars: Record<string, string>,
+): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, name: string) =>
+    Object.prototype.hasOwnProperty.call(vars, name) ? vars[name] : "",
+  );
+}
+
+// ── Defaults for keying functions ────────────────────────────────
+
+export function defaultIdempotencyKey(
+  roleName: string,
+): (input: AgentInput) => IdempotencyKey {
+  return (input: AgentInput): IdempotencyKey => {
+    const key =
+      input.triggerPath ??
+      input.triggerEntityId ??
+      `${roleName}::${input.space.id}`;
+    const hash = hashInput({
+      triggerPath: input.triggerPath ?? null,
+      triggerEntityId: input.triggerEntityId ?? null,
+      meta: input.meta ?? null,
+    });
+    return { key, hash };
+  };
+}
+
+export function defaultConcurrencyKey(
+  roleName: string,
+): (input: AgentInput) => string {
+  return (input: AgentInput) =>
+    input.triggerEntityId
+      ? `${roleName}::${input.space.id}::${input.triggerEntityId}`
+      : `${roleName}::${input.space.id}`;
+}
+
+// ── Provider/key plumbing ────────────────────────────────────────
+
+const DEFAULT_API_KEY_ENV: Record<string, string> = {
+  openai: "OPENAI_API_KEY",
+  anthropic: "ANTHROPIC_API_KEY",
+  "openai-compatible": "OPENAI_API_KEY",
+};
+
+function resolveApiKey(
+  provider: string,
+  apiKeyEnv: string | undefined,
+): string | undefined {
+  const envName = apiKeyEnv ?? DEFAULT_API_KEY_ENV[provider];
+  if (!envName) return undefined;
+  const value = process.env[envName];
+  if (!value && provider !== "openai-compatible") {
+    throw new Error(
+      `Provider '${provider}' requires env var ${envName} (not set).`,
+    );
+  }
+  return value;
+}
+
+function toModelConfig(
+  provider: string,
+  id: string,
+  baseUrl: string | undefined,
+  apiKey: string | undefined,
+): ModelConfig {
+  switch (provider) {
+    case "anthropic":
+      return { provider: "anthropic", id, apiKey };
+    case "openai":
+      return { provider: "openai", id, apiKey };
+    case "openai-compatible":
+      if (!baseUrl) {
+        throw new Error(
+          "Provider 'openai-compatible' requires base_url to be set.",
+        );
+      }
+      return {
+        provider: "openai-compatible",
+        id,
+        baseURL: baseUrl,
+        apiKey,
+      };
+    default:
+      throw new Error(`Unknown provider: ${provider}`);
+  }
+}
+
+// ── Discovery ────────────────────────────────────────────────────
+
+/**
+ * List all role names available given a config: built-ins plus any
+ * roles defined in YAML. Useful for `arkeon-wiki agent list`.
+ */
+export function listAvailableRoles(config: AgentConfig): string[] {
+  const set = new Set<string>(Object.keys(BUILTIN_ROLES));
+  for (const name of Object.keys(config.roles ?? {})) set.add(name);
+  return [...set].sort();
+}

--- a/packages/arkeon/test/manual/agent-real-llm.test.ts
+++ b/packages/arkeon/test/manual/agent-real-llm.test.ts
@@ -4,21 +4,19 @@
 /**
  * Layer 3: real-LLM end-to-end demo.
  *
- * Drives runAgent against an actual OpenAI/Anthropic model, with the
- * full ALL_TOOLS registry, against a tempdir space seeded with a
- * source file. Verifies the LLM can use the tool descriptions to:
- *   1. discover what already exists (list_wikis)
- *   2. read the source file (read_file)
- *   3. identify subjects and contribute them (contribute)
+ * Drives runAgent against an actual provider (OpenAI by default) using
+ * the declarative built-in `contributor` role from agents/builtins.ts.
+ * This exercises the whole config → role-builder → runtime → tools
+ * stack, exactly the way #49's contributor worker will.
  *
- * Skipped automatically when no API key is set, so it doesn't break
- * the default suite. Invoke explicitly:
+ * Skipped automatically when no API key is set. Invoke explicitly:
  *
- *   OPENAI_API_KEY=sk-... npm run test:manual -w packages/arkeon
+ *   npm run test:manual -w packages/arkeon
  *
- * Override the model with AGENT_DEMO_MODEL (default: gpt-5-mini).
- * Override the provider with AGENT_DEMO_PROVIDER (openai|anthropic|
- * openai-compatible) and AGENT_DEMO_BASE_URL for openai-compatible.
+ * Drop your key into a .env file at the repo root (auto-loaded), or
+ * set OPENAI_API_KEY / ANTHROPIC_API_KEY in the shell. Override the
+ * provider/model/baseURL with AGENT_DEMO_PROVIDER, AGENT_DEMO_MODEL,
+ * AGENT_DEMO_BASE_URL.
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -36,15 +34,14 @@ import { randomBytes } from "node:crypto";
 
 import { config as loadDotenv } from "dotenv";
 
-import { runAgent, type AgentRole } from "../../src/server/agents/runtime.js";
+import type { AgentConfig } from "../../src/server/agents/config.js";
+import { buildAgentRole } from "../../src/server/agents/role-builder.js";
+import { runAgent } from "../../src/server/agents/runtime.js";
 import { ALL_TOOLS } from "../../src/server/agents/tools.js";
-import type { ModelConfig } from "../../src/server/agents/model.js";
 import { createSql } from "../../src/server/lib/sql.js";
 import type { Space } from "../../src/server/lib/sync.js";
 
-// Auto-load .env from the repo root (../../../../.env from this file)
-// so users only need to put their key in one place. Existing process
-// env vars take precedence over the file.
+// Auto-load .env from the repo root (../../../../.env from this file).
 loadDotenv({ path: resolve(__dirname, "../../../../.env"), quiet: true });
 
 const API_PORT = 18799;
@@ -64,19 +61,23 @@ const MODEL =
   process.env.AGENT_DEMO_MODEL ??
   (PROVIDER === "anthropic" ? "claude-sonnet-4-6" : "gpt-5-mini");
 
-function modelConfig(): ModelConfig {
-  if (PROVIDER === "anthropic") {
-    return { provider: "anthropic", id: MODEL, apiKey: process.env.ANTHROPIC_API_KEY };
-  }
-  if (PROVIDER === "openai-compatible") {
-    return {
-      provider: "openai-compatible",
-      id: MODEL,
-      baseURL: process.env.AGENT_DEMO_BASE_URL ?? "http://localhost:11434/v1",
-      apiKey: process.env.OPENAI_API_KEY,
-    };
-  }
-  return { provider: "openai", id: MODEL, apiKey: process.env.OPENAI_API_KEY };
+/**
+ * Synthesize the same shape that loadAgentConfig() would produce —
+ * but here we drive it from env vars instead of a YAML file, since
+ * the demo's job is to prove the runtime works, not to test the
+ * loader. (The loader has its own unit tests.)
+ */
+function demoConfig(): AgentConfig {
+  return {
+    defaults: {
+      provider: PROVIDER,
+      model: MODEL,
+      base_url: process.env.AGENT_DEMO_BASE_URL,
+    },
+    // No `roles` override → uses the built-in `contributor` template
+    // verbatim. Add an entry like { roles: { contributor: { instructions: ... } } }
+    // here to demo operator-supplied focus tweaks.
+  };
 }
 
 let testDir: string;
@@ -126,10 +127,8 @@ afterAll(async () => {
 
 describe.skipIf(!HAS_KEY)("real-LLM contributor agent", () => {
   it(
-    "extracts subjects from a source file and contributes to the right wikis",
+    "uses the built-in contributor role to extract subjects from a source",
     async () => {
-      // Seed a short source paragraph that mentions multiple distinct
-      // subjects. Keep it small so token cost stays trivial.
       const sourcePath = "sources/shannon-bio.md";
       writeFileSync(
         join(testDir, sourcePath),
@@ -145,7 +144,7 @@ describe.skipIf(!HAS_KEY)("real-LLM contributor agent", () => {
       );
 
       // Wait for the watcher to index the source so contribute() can
-      // resolve source_id if the LLM passes one.
+      // pass source_id through.
       const sql = createSql();
       const deadline = Date.now() + 5000;
       let sourceId: string | null = null;
@@ -161,58 +160,32 @@ describe.skipIf(!HAS_KEY)("real-LLM contributor agent", () => {
       }
       expect(sourceId).toBeTruthy();
 
-      const role: AgentRole = {
-        name: "demo-contributor",
-        model: modelConfig(),
-        tools: ["list_wikis", "read_file", "contribute"],
-        maxSteps: 12,
-        buildPrompt: async () => ({
-          system: [
-            "You are a contributor agent for a wiki knowledge graph.",
-            "",
-            "Workflow:",
-            "  1. Use list_wikis to see what already exists in this space.",
-            "  2. Use read_file to read the source document at the given path.",
-            "  3. Identify each distinct subject it discusses (people,",
-            "     organizations, concepts, etc.).",
-            "  4. For each subject, call contribute() with:",
-            "       - subject.label: the canonical name",
-            "       - subject.subject_type: 'person' | 'organization' |",
-            "         'concept' | 'event' | etc.",
-            "       - excerpt: a short verbatim or paraphrased sentence from",
-            "         the source",
-            "       - claim: a one-line summary of what the source establishes",
-            "         about that subject",
-            "       - source_id: the source entity id you were given",
-            "  5. Stop when every distinct subject has been contributed.",
-            "",
-            "Do not write any wiki bodies — that is a separate agent's job.",
-            "Be concise. Aim for at most 4 contribute calls.",
-          ].join("\n"),
-          prompt: [
-            `Source path: ${sourcePath}`,
-            `Source entity id: ${sourceId}`,
-            "",
-            "Identify subjects and contribute them.",
-          ].join("\n"),
-        }),
-        idempotencyKey: () => ({ key: sourcePath, hash: "v1" }),
-        concurrencyKey: ({ space: s }) => `demo::${s.id}`,
-      };
+      // The whole point: build the role declaratively from config +
+      // built-in template. No inline role construction.
+      const role = buildAgentRole("contributor", demoConfig());
 
-      const result = await runAgent(role, { space }, ALL_TOOLS);
+      const result = await runAgent(
+        role,
+        { space, triggerPath: sourcePath, triggerEntityId: sourceId! },
+        ALL_TOOLS,
+      );
 
       // ── Report ──────────────────────────────────────────────────
       console.log("\n──────── REAL-LLM AGENT RESULT ────────");
       console.log(`provider:  ${PROVIDER}`);
       console.log(`model:     ${MODEL}`);
+      console.log(`role:      contributor (built-in)`);
       console.log(`steps:     ${result.steps}`);
       console.log(`edits:     ${result.edits.length}`);
       for (const e of result.edits) {
         console.log(`           ${e.path}`);
       }
-      console.log(`tokens:    in=${result.usage?.inputTokens ?? "?"}  out=${result.usage?.outputTokens ?? "?"}`);
-      console.log(`final text: ${result.text.slice(0, 200)}${result.text.length > 200 ? "..." : ""}`);
+      console.log(
+        `tokens:    in=${result.usage?.inputTokens ?? "?"}  out=${result.usage?.outputTokens ?? "?"}`,
+      );
+      console.log(
+        `final text: ${result.text.slice(0, 200)}${result.text.length > 200 ? "..." : ""}`,
+      );
       console.log("\nWikis on disk:");
       const wikiDir = join(testDir, "wiki");
       function walk(dir: string, prefix = "  ") {
@@ -223,12 +196,9 @@ describe.skipIf(!HAS_KEY)("real-LLM contributor agent", () => {
           } else if (entry.name.endsWith(".md")) {
             const fm = readFileSync(path, "utf-8");
             const labelMatch = fm.match(/label:\s*(.+)/);
-            const contribsMatch = fm.match(/contributions:\s*\n([\s\S]*?)(\n[a-z]|---|$)/);
-            console.log(`${prefix}${path.replace(testDir + "/", "")}  →  ${labelMatch?.[1] ?? "(no label)"}`);
-            if (contribsMatch) {
-              const lines = contribsMatch[1].split("\n").filter((l) => l.trim().startsWith("- "));
-              console.log(`${prefix}  contributions: ${lines.length}`);
-            }
+            console.log(
+              `${prefix}${path.replace(testDir + "/", "")}  →  ${labelMatch?.[1] ?? "(no label)"}`,
+            );
           }
         }
       }
@@ -236,15 +206,10 @@ describe.skipIf(!HAS_KEY)("real-LLM contributor agent", () => {
       console.log("───────────────────────────────────────\n");
 
       // ── Lenient assertions ──────────────────────────────────────
-      // We don't pin which subjects the LLM identifies — different
-      // models will make different judgements. Just verify the loop
-      // ran end-to-end and produced *some* mutations.
       expect(result.skipped).toBe(false);
       expect(result.steps).toBeGreaterThan(1);
       expect(result.edits.length).toBeGreaterThan(0);
 
-      // At least one wiki file should exist with a populated
-      // contributions array.
       const wikiFiles: string[] = [];
       function findMd(dir: string) {
         for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -255,11 +220,10 @@ describe.skipIf(!HAS_KEY)("real-LLM contributor agent", () => {
       }
       findMd(wikiDir);
       expect(wikiFiles.length).toBeGreaterThan(0);
-
-      const withContribs = wikiFiles.filter((p) =>
-        readFileSync(p, "utf-8").includes("contributions:"),
-      );
-      expect(withContribs.length).toBeGreaterThan(0);
+      expect(
+        wikiFiles.filter((p) => readFileSync(p, "utf-8").includes("contributions:"))
+          .length,
+      ).toBeGreaterThan(0);
     },
     180_000,
   );

--- a/packages/arkeon/test/manual/agent-real-llm.test.ts
+++ b/packages/arkeon/test/manual/agent-real-llm.test.ts
@@ -30,15 +30,22 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { randomBytes } from "node:crypto";
+
+import { config as loadDotenv } from "dotenv";
 
 import { runAgent, type AgentRole } from "../../src/server/agents/runtime.js";
 import { ALL_TOOLS } from "../../src/server/agents/tools.js";
 import type { ModelConfig } from "../../src/server/agents/model.js";
 import { createSql } from "../../src/server/lib/sql.js";
 import type { Space } from "../../src/server/lib/sync.js";
+
+// Auto-load .env from the repo root (../../../../.env from this file)
+// so users only need to put their key in one place. Existing process
+// env vars take precedence over the file.
+loadDotenv({ path: resolve(__dirname, "../../../../.env"), quiet: true });
 
 const API_PORT = 18799;
 

--- a/packages/arkeon/test/manual/agent-real-llm.test.ts
+++ b/packages/arkeon/test/manual/agent-real-llm.test.ts
@@ -1,0 +1,259 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Layer 3: real-LLM end-to-end demo.
+ *
+ * Drives runAgent against an actual OpenAI/Anthropic model, with the
+ * full ALL_TOOLS registry, against a tempdir space seeded with a
+ * source file. Verifies the LLM can use the tool descriptions to:
+ *   1. discover what already exists (list_wikis)
+ *   2. read the source file (read_file)
+ *   3. identify subjects and contribute them (contribute)
+ *
+ * Skipped automatically when no API key is set, so it doesn't break
+ * the default suite. Invoke explicitly:
+ *
+ *   OPENAI_API_KEY=sk-... npm run test:manual -w packages/arkeon
+ *
+ * Override the model with AGENT_DEMO_MODEL (default: gpt-5-mini).
+ * Override the provider with AGENT_DEMO_PROVIDER (openai|anthropic|
+ * openai-compatible) and AGENT_DEMO_BASE_URL for openai-compatible.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+
+import { runAgent, type AgentRole } from "../../src/server/agents/runtime.js";
+import { ALL_TOOLS } from "../../src/server/agents/tools.js";
+import type { ModelConfig } from "../../src/server/agents/model.js";
+import { createSql } from "../../src/server/lib/sql.js";
+import type { Space } from "../../src/server/lib/sync.js";
+
+const API_PORT = 18799;
+
+const HAS_OPENAI = !!process.env.OPENAI_API_KEY;
+const HAS_ANTHROPIC = !!process.env.ANTHROPIC_API_KEY;
+const HAS_KEY =
+  HAS_OPENAI || HAS_ANTHROPIC || !!process.env.AGENT_DEMO_BASE_URL;
+
+const PROVIDER = (process.env.AGENT_DEMO_PROVIDER ??
+  (HAS_OPENAI ? "openai" : HAS_ANTHROPIC ? "anthropic" : "openai-compatible")) as
+  | "openai"
+  | "anthropic"
+  | "openai-compatible";
+
+const MODEL =
+  process.env.AGENT_DEMO_MODEL ??
+  (PROVIDER === "anthropic" ? "claude-sonnet-4-6" : "gpt-5-mini");
+
+function modelConfig(): ModelConfig {
+  if (PROVIDER === "anthropic") {
+    return { provider: "anthropic", id: MODEL, apiKey: process.env.ANTHROPIC_API_KEY };
+  }
+  if (PROVIDER === "openai-compatible") {
+    return {
+      provider: "openai-compatible",
+      id: MODEL,
+      baseURL: process.env.AGENT_DEMO_BASE_URL ?? "http://localhost:11434/v1",
+      apiKey: process.env.OPENAI_API_KEY,
+    };
+  }
+  return { provider: "openai", id: MODEL, apiKey: process.env.OPENAI_API_KEY };
+}
+
+let testDir: string;
+let stateDir: string;
+let serverHandle: { stop: () => Promise<void> } | null = null;
+let space: Space;
+
+beforeAll(async () => {
+  if (!HAS_KEY) return;
+
+  const base = join(tmpdir(), `arkeon-real-llm-${randomBytes(4).toString("hex")}`);
+  testDir = join(base, "repo");
+  stateDir = join(base, "state");
+  mkdirSync(testDir, { recursive: true });
+  mkdirSync(join(stateDir, "data"), { recursive: true });
+  mkdirSync(join(testDir, "wiki"), { recursive: true });
+  mkdirSync(join(testDir, "sources"), { recursive: true });
+
+  process.env.ARKEON_WIKI_HOME = stateDir;
+
+  const dbFile = join(stateDir, "data", "arke.db");
+  const { runMigrations } = await import("../../src/schema/index.js");
+  await runMigrations({ dbPath: dbFile });
+
+  const { startApi } = await import("../../src/server/server.js");
+  const apiHandle = await startApi({ port: API_PORT, dbPath: dbFile });
+  serverHandle = { stop: async () => apiHandle.stop() };
+
+  const spaceRes = await fetch(`http://localhost:${API_PORT}/spaces`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: "real-llm-space", watch_dir: testDir }),
+  });
+  const json = (await spaceRes.json()) as { id: string };
+  space = { id: json.id, name: "real-llm-space", watch_dir: testDir };
+}, 60_000);
+
+afterAll(async () => {
+  if (serverHandle) await serverHandle.stop();
+  if (testDir && existsSync(testDir)) {
+    rmSync(testDir.substring(0, testDir.lastIndexOf("/")), {
+      recursive: true,
+      force: true,
+    });
+  }
+}, 30_000);
+
+describe.skipIf(!HAS_KEY)("real-LLM contributor agent", () => {
+  it(
+    "extracts subjects from a source file and contributes to the right wikis",
+    async () => {
+      // Seed a short source paragraph that mentions multiple distinct
+      // subjects. Keep it small so token cost stays trivial.
+      const sourcePath = "sources/shannon-bio.md";
+      writeFileSync(
+        join(testDir, sourcePath),
+        [
+          "# Founding Information Theory",
+          "",
+          "Claude Shannon was an American mathematician and electrical engineer.",
+          "His 1948 paper, *A Mathematical Theory of Communication*, founded the",
+          "field of information theory. He spent most of his career at Bell Labs,",
+          "where he also did pioneering work on cryptography during World War II.",
+          "",
+        ].join("\n"),
+      );
+
+      // Wait for the watcher to index the source so contribute() can
+      // resolve source_id if the LLM passes one.
+      const sql = createSql();
+      const deadline = Date.now() + 5000;
+      let sourceId: string | null = null;
+      while (Date.now() < deadline) {
+        const rows = await sql`
+          SELECT id FROM entities WHERE space_id = ${space.id} AND source_path = ${sourcePath}
+        `;
+        if (rows.length > 0) {
+          sourceId = rows[0].id as string;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 200));
+      }
+      expect(sourceId).toBeTruthy();
+
+      const role: AgentRole = {
+        name: "demo-contributor",
+        model: modelConfig(),
+        tools: ["list_wikis", "read_file", "contribute"],
+        maxSteps: 12,
+        buildPrompt: async () => ({
+          system: [
+            "You are a contributor agent for a wiki knowledge graph.",
+            "",
+            "Workflow:",
+            "  1. Use list_wikis to see what already exists in this space.",
+            "  2. Use read_file to read the source document at the given path.",
+            "  3. Identify each distinct subject it discusses (people,",
+            "     organizations, concepts, etc.).",
+            "  4. For each subject, call contribute() with:",
+            "       - subject.label: the canonical name",
+            "       - subject.subject_type: 'person' | 'organization' |",
+            "         'concept' | 'event' | etc.",
+            "       - excerpt: a short verbatim or paraphrased sentence from",
+            "         the source",
+            "       - claim: a one-line summary of what the source establishes",
+            "         about that subject",
+            "       - source_id: the source entity id you were given",
+            "  5. Stop when every distinct subject has been contributed.",
+            "",
+            "Do not write any wiki bodies — that is a separate agent's job.",
+            "Be concise. Aim for at most 4 contribute calls.",
+          ].join("\n"),
+          prompt: [
+            `Source path: ${sourcePath}`,
+            `Source entity id: ${sourceId}`,
+            "",
+            "Identify subjects and contribute them.",
+          ].join("\n"),
+        }),
+        idempotencyKey: () => ({ key: sourcePath, hash: "v1" }),
+        concurrencyKey: ({ space: s }) => `demo::${s.id}`,
+      };
+
+      const result = await runAgent(role, { space }, ALL_TOOLS);
+
+      // ── Report ──────────────────────────────────────────────────
+      console.log("\n──────── REAL-LLM AGENT RESULT ────────");
+      console.log(`provider:  ${PROVIDER}`);
+      console.log(`model:     ${MODEL}`);
+      console.log(`steps:     ${result.steps}`);
+      console.log(`edits:     ${result.edits.length}`);
+      for (const e of result.edits) {
+        console.log(`           ${e.path}`);
+      }
+      console.log(`tokens:    in=${result.usage?.inputTokens ?? "?"}  out=${result.usage?.outputTokens ?? "?"}`);
+      console.log(`final text: ${result.text.slice(0, 200)}${result.text.length > 200 ? "..." : ""}`);
+      console.log("\nWikis on disk:");
+      const wikiDir = join(testDir, "wiki");
+      function walk(dir: string, prefix = "  ") {
+        for (const entry of readdirSync(dir, { withFileTypes: true })) {
+          const path = join(dir, entry.name);
+          if (entry.isDirectory()) {
+            walk(path, prefix + "  ");
+          } else if (entry.name.endsWith(".md")) {
+            const fm = readFileSync(path, "utf-8");
+            const labelMatch = fm.match(/label:\s*(.+)/);
+            const contribsMatch = fm.match(/contributions:\s*\n([\s\S]*?)(\n[a-z]|---|$)/);
+            console.log(`${prefix}${path.replace(testDir + "/", "")}  →  ${labelMatch?.[1] ?? "(no label)"}`);
+            if (contribsMatch) {
+              const lines = contribsMatch[1].split("\n").filter((l) => l.trim().startsWith("- "));
+              console.log(`${prefix}  contributions: ${lines.length}`);
+            }
+          }
+        }
+      }
+      walk(wikiDir);
+      console.log("───────────────────────────────────────\n");
+
+      // ── Lenient assertions ──────────────────────────────────────
+      // We don't pin which subjects the LLM identifies — different
+      // models will make different judgements. Just verify the loop
+      // ran end-to-end and produced *some* mutations.
+      expect(result.skipped).toBe(false);
+      expect(result.steps).toBeGreaterThan(1);
+      expect(result.edits.length).toBeGreaterThan(0);
+
+      // At least one wiki file should exist with a populated
+      // contributions array.
+      const wikiFiles: string[] = [];
+      function findMd(dir: string) {
+        for (const entry of readdirSync(dir, { withFileTypes: true })) {
+          const p = join(dir, entry.name);
+          if (entry.isDirectory()) findMd(p);
+          else if (entry.name.endsWith(".md")) wikiFiles.push(p);
+        }
+      }
+      findMd(wikiDir);
+      expect(wikiFiles.length).toBeGreaterThan(0);
+
+      const withContribs = wikiFiles.filter((p) =>
+        readFileSync(p, "utf-8").includes("contributions:"),
+      );
+      expect(withContribs.length).toBeGreaterThan(0);
+    },
+    180_000,
+  );
+});

--- a/packages/arkeon/test/manual/agent-real-llm.test.ts
+++ b/packages/arkeon/test/manual/agent-real-llm.test.ts
@@ -32,17 +32,17 @@ import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { randomBytes } from "node:crypto";
 
-import { config as loadDotenv } from "dotenv";
-
 import type { AgentConfig } from "../../src/server/agents/config.js";
+import { loadAgentEnv } from "../../src/server/agents/env-loader.js";
 import { buildAgentRole } from "../../src/server/agents/role-builder.js";
 import { runAgent } from "../../src/server/agents/runtime.js";
 import { ALL_TOOLS } from "../../src/server/agents/tools.js";
 import { createSql } from "../../src/server/lib/sql.js";
 import type { Space } from "../../src/server/lib/sync.js";
 
-// Auto-load .env from the repo root (../../../../.env from this file).
-loadDotenv({ path: resolve(__dirname, "../../../../.env"), quiet: true });
+// Load .env files in precedence order: shell > repo .env > ~/.arkeon-wiki/.env.
+// The repo's .env is at ../../../../ from this file (worktree root).
+loadAgentEnv({ spaceDir: resolve(__dirname, "../../../..") });
 
 const API_PORT = 18799;
 

--- a/packages/arkeon/test/unit/agents-config.test.ts
+++ b/packages/arkeon/test/unit/agents-config.test.ts
@@ -1,0 +1,430 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  AGENT_CONFIG_SCHEMA,
+  loadAgentConfig,
+  mergeConfigs,
+  type AgentConfig,
+} from "../../src/server/agents/config.js";
+import { BUILTIN_ROLES } from "../../src/server/agents/builtins.js";
+import {
+  buildAgentRole,
+  fillTemplate,
+  listAvailableRoles,
+} from "../../src/server/agents/role-builder.js";
+import type { AgentInput } from "../../src/server/agents/runtime.js";
+
+// ── Schema ───────────────────────────────────────────────────────
+
+describe("AGENT_CONFIG_SCHEMA", () => {
+  it("accepts an empty config", () => {
+    expect(AGENT_CONFIG_SCHEMA.parse({})).toEqual({});
+  });
+
+  it("accepts defaults only", () => {
+    const parsed = AGENT_CONFIG_SCHEMA.parse({
+      defaults: { provider: "openai", model: "gpt-5-mini" },
+    });
+    expect(parsed.defaults?.provider).toBe("openai");
+  });
+
+  it("accepts a full configured role", () => {
+    const parsed = AGENT_CONFIG_SCHEMA.parse({
+      defaults: { provider: "openai", model: "gpt-5-mini" },
+      roles: {
+        contributor: {
+          tools: ["list_wikis", "contribute"],
+          max_steps: 5,
+          instructions: "be terse",
+        },
+      },
+    });
+    expect(parsed.roles?.contributor?.max_steps).toBe(5);
+  });
+
+  it("rejects an unknown provider", () => {
+    expect(() =>
+      AGENT_CONFIG_SCHEMA.parse({ defaults: { provider: "weirdo" } }),
+    ).toThrow();
+  });
+
+  it("rejects max_steps <= 0", () => {
+    expect(() =>
+      AGENT_CONFIG_SCHEMA.parse({ defaults: { max_steps: 0 } }),
+    ).toThrow();
+  });
+});
+
+// ── mergeConfigs ─────────────────────────────────────────────────
+
+describe("mergeConfigs", () => {
+  it("merges defaults field-by-field, b wins", () => {
+    const a: AgentConfig = { defaults: { provider: "openai", model: "a" } };
+    const b: AgentConfig = { defaults: { model: "b" } };
+    const merged = mergeConfigs(a, b);
+    expect(merged.defaults).toEqual({ provider: "openai", model: "b" });
+  });
+
+  it("replaces roles wholesale (not field-merged)", () => {
+    const a: AgentConfig = {
+      roles: { contributor: { instructions: "from-a", max_steps: 5 } },
+    };
+    const b: AgentConfig = { roles: { contributor: { max_steps: 10 } } };
+    const merged = mergeConfigs(a, b);
+    // b's contributor entry wins entirely; instructions from a is dropped
+    expect(merged.roles?.contributor).toEqual({ max_steps: 10 });
+  });
+
+  it("preserves roles only present in one side", () => {
+    const a: AgentConfig = { roles: { contributor: { max_steps: 5 } } };
+    const b: AgentConfig = { roles: { editor: { max_steps: 20 } } };
+    const merged = mergeConfigs(a, b);
+    expect(merged.roles?.contributor?.max_steps).toBe(5);
+    expect(merged.roles?.editor?.max_steps).toBe(20);
+  });
+});
+
+// ── loadAgentConfig ──────────────────────────────────────────────
+
+describe("loadAgentConfig", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "agents-cfg-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns empty config when no files exist", () => {
+    expect(
+      loadAgentConfig({ spaceDir: dir, userGlobalPath: join(dir, "nope.yaml") }),
+    ).toEqual({ defaults: {}, roles: {} });
+  });
+
+  it("loads a repo-local agents.yaml", () => {
+    mkdirSync(join(dir, ".arkeon"), { recursive: true });
+    writeFileSync(
+      join(dir, ".arkeon", "agents.yaml"),
+      "defaults:\n  provider: openai\n  model: gpt-5-mini\n",
+    );
+    const config = loadAgentConfig({
+      spaceDir: dir,
+      userGlobalPath: join(dir, "nonexistent-global.yaml"),
+    });
+    expect(config.defaults?.provider).toBe("openai");
+    expect(config.defaults?.model).toBe("gpt-5-mini");
+  });
+
+  it("repo-local overrides user-global on shared fields", () => {
+    const globalPath = join(dir, "global.yaml");
+    writeFileSync(
+      globalPath,
+      "defaults:\n  provider: anthropic\n  model: claude-sonnet-4-6\n",
+    );
+    mkdirSync(join(dir, ".arkeon"), { recursive: true });
+    writeFileSync(
+      join(dir, ".arkeon", "agents.yaml"),
+      "defaults:\n  model: gpt-5-mini\n",
+    );
+
+    const config = loadAgentConfig({ spaceDir: dir, userGlobalPath: globalPath });
+    expect(config.defaults?.provider).toBe("anthropic");  // from global
+    expect(config.defaults?.model).toBe("gpt-5-mini");    // overridden by repo
+  });
+
+  it("throws a clear error on invalid YAML", () => {
+    mkdirSync(join(dir, ".arkeon"), { recursive: true });
+    writeFileSync(
+      join(dir, ".arkeon", "agents.yaml"),
+      "defaults: {[\n  not yaml at all\n",
+    );
+    expect(() =>
+      loadAgentConfig({
+        spaceDir: dir,
+        userGlobalPath: join(dir, "nope.yaml"),
+      }),
+    ).toThrow(/not valid YAML/);
+  });
+});
+
+// ── buildAgentRole ───────────────────────────────────────────────
+
+describe("buildAgentRole — built-in contributor", () => {
+  beforeEach(() => {
+    process.env.OPENAI_API_KEY = "sk-test";
+  });
+  afterEach(() => {
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it("builds a working AgentRole from just defaults", () => {
+    const role = buildAgentRole("contributor", {
+      defaults: { provider: "openai", model: "gpt-5-mini" },
+    });
+
+    expect(role.name).toBe("contributor");
+    expect(role.maxSteps).toBe(BUILTIN_ROLES.contributor.max_steps);
+    expect(role.tools).toEqual(BUILTIN_ROLES.contributor.tools);
+    expect(role.model).toEqual({
+      provider: "openai",
+      id: "gpt-5-mini",
+      apiKey: "sk-test",
+    });
+  });
+
+  it("lets a role override the model and provider", () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+    try {
+      const role = buildAgentRole("contributor", {
+        defaults: { provider: "openai", model: "gpt-5-mini" },
+        roles: {
+          contributor: { provider: "anthropic", model: "claude-sonnet-4-6" },
+        },
+      });
+      expect(role.model.provider).toBe("anthropic");
+      expect(role.model.id).toBe("claude-sonnet-4-6");
+    } finally {
+      delete process.env.ANTHROPIC_API_KEY;
+    }
+  });
+
+  it("layers space-level + role-level instructions onto built-in system", async () => {
+    const role = buildAgentRole("contributor", {
+      defaults: {
+        provider: "openai",
+        model: "gpt-5-mini",
+        instructions: "Space-wide focus: climate science.",
+      },
+      roles: {
+        contributor: { instructions: "Skip generic terms." },
+      },
+    });
+
+    const { system } = await role.buildPrompt({
+      space: { id: "s1", name: "n", watch_dir: "/tmp" },
+      triggerPath: "x.md",
+      triggerEntityId: "ent1",
+    });
+
+    expect(system).toContain("contributor agent");           // built-in stays
+    expect(system).toContain("Space-wide focus: climate");   // defaults layer
+    expect(system).toContain("Skip generic terms.");         // role layer
+    expect(system).toContain("--- Operator instructions ---");
+  });
+
+  it("fills {{trigger_path}} / {{trigger_entity_id}} into the user template", async () => {
+    const role = buildAgentRole("contributor", {
+      defaults: { provider: "openai", model: "gpt-5-mini" },
+    });
+    const { prompt } = await role.buildPrompt({
+      space: { id: "s1", name: "n", watch_dir: "/tmp" },
+      triggerPath: "sources/foo.md",
+      triggerEntityId: "01ENT",
+    });
+    expect(prompt).toContain("sources/foo.md");
+    expect(prompt).toContain("01ENT");
+  });
+
+  it("throws when the required env var for an api key is missing", () => {
+    delete process.env.OPENAI_API_KEY;
+    expect(() =>
+      buildAgentRole("contributor", {
+        defaults: { provider: "openai", model: "gpt-5-mini" },
+      }),
+    ).toThrow(/OPENAI_API_KEY/);
+  });
+
+  it("respects a custom api_key_env name", () => {
+    process.env.MY_CUSTOM_KEY = "sk-custom";
+    try {
+      const role = buildAgentRole("contributor", {
+        defaults: {
+          provider: "openai",
+          model: "gpt-5-mini",
+          api_key_env: "MY_CUSTOM_KEY",
+        },
+      });
+      expect(role.model.apiKey).toBe("sk-custom");
+    } finally {
+      delete process.env.MY_CUSTOM_KEY;
+    }
+  });
+
+  it("openai-compatible can run without an api key (local servers)", () => {
+    delete process.env.OPENAI_API_KEY;
+    const role = buildAgentRole("contributor", {
+      defaults: {
+        provider: "openai-compatible",
+        model: "llama3.1:70b",
+        base_url: "http://localhost:11434/v1",
+      },
+    });
+    expect(role.model.provider).toBe("openai-compatible");
+  });
+
+  it("openai-compatible requires base_url", () => {
+    expect(() =>
+      buildAgentRole("contributor", {
+        defaults: { provider: "openai-compatible", model: "x" },
+      }),
+    ).toThrow(/base_url/);
+  });
+});
+
+describe("buildAgentRole — user-defined role", () => {
+  beforeEach(() => {
+    process.env.OPENAI_API_KEY = "sk-test";
+  });
+  afterEach(() => {
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it("builds a custom role with explicit system + tools", () => {
+    const role = buildAgentRole("link-checker", {
+      defaults: { provider: "openai", model: "gpt-5-mini" },
+      roles: {
+        "link-checker": {
+          system: "You find broken links.",
+          tools: ["list_wikis", "read_file"],
+          max_steps: 30,
+        },
+      },
+    });
+
+    expect(role.name).toBe("link-checker");
+    expect(role.tools).toEqual(["list_wikis", "read_file"]);
+    expect(role.maxSteps).toBe(30);
+  });
+
+  it("rejects a custom role without a system prompt", () => {
+    expect(() =>
+      buildAgentRole("custom-no-prompt", {
+        defaults: { provider: "openai", model: "gpt-5-mini" },
+        roles: { "custom-no-prompt": { tools: ["read_file"] } },
+      }),
+    ).toThrow(/system prompt/);
+  });
+
+  it("rejects a custom role without tools", () => {
+    expect(() =>
+      buildAgentRole("custom-no-tools", {
+        defaults: { provider: "openai", model: "gpt-5-mini" },
+        roles: { "custom-no-tools": { system: "you are X" } },
+      }),
+    ).toThrow(/no tools/);
+  });
+});
+
+// ── fillTemplate ─────────────────────────────────────────────────
+
+describe("fillTemplate", () => {
+  it("substitutes {{var}} placeholders", () => {
+    expect(fillTemplate("hi {{name}}, path is {{p}}", { name: "Ada", p: "x.md" })).toBe(
+      "hi Ada, path is x.md",
+    );
+  });
+
+  it("treats unknown vars as empty string (no throw)", () => {
+    expect(fillTemplate("hi {{missing}} done", {})).toBe("hi  done");
+  });
+
+  it("leaves non-matching braces alone", () => {
+    expect(fillTemplate("a {b} c", { b: "1" })).toBe("a {b} c");
+  });
+});
+
+// ── listAvailableRoles ───────────────────────────────────────────
+
+describe("listAvailableRoles", () => {
+  it("includes all built-ins", () => {
+    expect(listAvailableRoles({})).toEqual(
+      Object.keys(BUILTIN_ROLES).sort(),
+    );
+  });
+
+  it("includes user-defined roles alongside built-ins", () => {
+    const roles = listAvailableRoles({
+      roles: { "my-thing": { system: "x", tools: ["read_file"] } },
+    });
+    expect(roles).toContain("contributor");
+    expect(roles).toContain("editor");
+    expect(roles).toContain("my-thing");
+  });
+
+  it("does not duplicate when a YAML override targets a built-in", () => {
+    const roles = listAvailableRoles({
+      roles: { contributor: { max_steps: 99 } },
+    });
+    const contribCount = roles.filter((r) => r === "contributor").length;
+    expect(contribCount).toBe(1);
+  });
+});
+
+// ── default keying ───────────────────────────────────────────────
+
+describe("default idempotency / concurrency keys", () => {
+  beforeEach(() => {
+    process.env.OPENAI_API_KEY = "sk-test";
+  });
+  afterEach(() => {
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it("uses triggerPath as the idempotency key when present", () => {
+    const role = buildAgentRole("contributor", {
+      defaults: { provider: "openai", model: "gpt-5-mini" },
+    });
+    const input: AgentInput = {
+      space: { id: "s1", name: "n", watch_dir: "/tmp" },
+      triggerPath: "src/a.md",
+    };
+    expect(role.idempotencyKey(input).key).toBe("src/a.md");
+  });
+
+  it("falls back to triggerEntityId", () => {
+    const role = buildAgentRole("contributor", {
+      defaults: { provider: "openai", model: "gpt-5-mini" },
+    });
+    const input: AgentInput = {
+      space: { id: "s1", name: "n", watch_dir: "/tmp" },
+      triggerEntityId: "01ENT",
+    };
+    expect(role.idempotencyKey(input).key).toBe("01ENT");
+  });
+
+  it("hashes meta + trigger info into the idempotency hash", () => {
+    const role = buildAgentRole("contributor", {
+      defaults: { provider: "openai", model: "gpt-5-mini" },
+    });
+    const a = role.idempotencyKey({
+      space: { id: "s1", name: "n", watch_dir: "/tmp" },
+      triggerPath: "x.md",
+      meta: { hash: "v1" },
+    });
+    const b = role.idempotencyKey({
+      space: { id: "s1", name: "n", watch_dir: "/tmp" },
+      triggerPath: "x.md",
+      meta: { hash: "v2" },
+    });
+    expect(a.hash).not.toBe(b.hash);
+  });
+
+  it("scopes concurrency to (role, space, triggerEntityId)", () => {
+    const role = buildAgentRole("contributor", {
+      defaults: { provider: "openai", model: "gpt-5-mini" },
+    });
+    expect(
+      role.concurrencyKey({
+        space: { id: "s1", name: "n", watch_dir: "/tmp" },
+        triggerEntityId: "01ENT",
+      }),
+    ).toBe("contributor::s1::01ENT");
+  });
+});

--- a/packages/arkeon/test/unit/agents-env-loader.test.ts
+++ b/packages/arkeon/test/unit/agents-env-loader.test.ts
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { loadAgentEnv } from "../../src/server/agents/env-loader.js";
+
+let dir: string;
+const KEYS = [
+  "TEST_AL_KEY_1",
+  "TEST_AL_KEY_2",
+  "TEST_AL_KEY_3",
+  "TEST_AL_USER_ONLY",
+  "TEST_AL_REPO_ONLY",
+];
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "agent-env-"));
+  for (const k of KEYS) delete process.env[k];
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  for (const k of KEYS) delete process.env[k];
+});
+
+function writeEnv(path: string, contents: Record<string, string>): void {
+  const lines = Object.entries(contents).map(([k, v]) => `${k}=${v}`);
+  writeFileSync(path, lines.join("\n") + "\n");
+}
+
+describe("loadAgentEnv", () => {
+  it("returns no loaded paths when nothing exists", () => {
+    const result = loadAgentEnv({
+      spaceDir: dir,
+      userGlobalPath: join(dir, "missing.env"),
+    });
+    expect(result.loaded).toEqual([]);
+  });
+
+  it("loads user-global .env when no repo .env exists", () => {
+    const userPath = join(dir, "user.env");
+    writeEnv(userPath, { TEST_AL_USER_ONLY: "from-global" });
+
+    const result = loadAgentEnv({ spaceDir: dir, userGlobalPath: userPath });
+
+    expect(result.loaded).toEqual([userPath]);
+    expect(process.env.TEST_AL_USER_ONLY).toBe("from-global");
+  });
+
+  it("loads repo .env when no user-global exists", () => {
+    const repoEnv = join(dir, ".env");
+    writeEnv(repoEnv, { TEST_AL_REPO_ONLY: "from-repo" });
+
+    const result = loadAgentEnv({
+      spaceDir: dir,
+      userGlobalPath: join(dir, "missing.env"),
+    });
+
+    expect(result.loaded).toEqual([repoEnv]);
+    expect(process.env.TEST_AL_REPO_ONLY).toBe("from-repo");
+  });
+
+  it("repo .env overrides user-global on the same key", () => {
+    const userPath = join(dir, "user.env");
+    const repoEnv = join(dir, ".env");
+    writeEnv(userPath, { TEST_AL_KEY_1: "from-global" });
+    writeEnv(repoEnv, { TEST_AL_KEY_1: "from-repo" });
+
+    loadAgentEnv({ spaceDir: dir, userGlobalPath: userPath });
+
+    expect(process.env.TEST_AL_KEY_1).toBe("from-repo");
+  });
+
+  it("shell env wins over both .env files", () => {
+    const userPath = join(dir, "user.env");
+    const repoEnv = join(dir, ".env");
+    writeEnv(userPath, { TEST_AL_KEY_2: "from-global" });
+    writeEnv(repoEnv, { TEST_AL_KEY_2: "from-repo" });
+
+    process.env.TEST_AL_KEY_2 = "from-shell";
+    loadAgentEnv({ spaceDir: dir, userGlobalPath: userPath });
+
+    expect(process.env.TEST_AL_KEY_2).toBe("from-shell");
+  });
+
+  it("loads user-global keys not present in repo .env", () => {
+    const userPath = join(dir, "user.env");
+    const repoEnv = join(dir, ".env");
+    writeEnv(userPath, {
+      TEST_AL_USER_ONLY: "u",
+      TEST_AL_KEY_3: "from-global",
+    });
+    writeEnv(repoEnv, { TEST_AL_KEY_3: "from-repo" });
+
+    loadAgentEnv({ spaceDir: dir, userGlobalPath: userPath });
+
+    expect(process.env.TEST_AL_USER_ONLY).toBe("u");        // only in global
+    expect(process.env.TEST_AL_KEY_3).toBe("from-repo");    // overridden
+  });
+
+  it("returns load order in result.loaded (global, repo)", () => {
+    const userPath = join(dir, "user.env");
+    const repoEnv = join(dir, ".env");
+    writeEnv(userPath, { X: "1" });
+    writeEnv(repoEnv, { Y: "2" });
+
+    const result = loadAgentEnv({ spaceDir: dir, userGlobalPath: userPath });
+
+    expect(result.loaded).toEqual([userPath, repoEnv]);
+  });
+
+  it("works with no spaceDir (only user-global)", () => {
+    const userPath = join(dir, "user.env");
+    writeEnv(userPath, { TEST_AL_USER_ONLY: "u" });
+
+    const result = loadAgentEnv({ userGlobalPath: userPath });
+
+    expect(result.loaded).toEqual([userPath]);
+    expect(process.env.TEST_AL_USER_ONLY).toBe("u");
+  });
+});


### PR DESCRIPTION
Builds on top of the agent runtime that landed in #56 and the list_wikis tool that landed in #61. Four commits, all green:

- \`31e5018 test:\` Layer 3 manual test — drives \`runAgent\` against a real OpenAI/Anthropic/openai-compatible model with the full \`ALL_TOOLS\` registry, gated on an API key being present, never run in CI
- \`b263de0 docs:\` rewrite \`.env.example\` for fs-first + agent runtime (the previous version still referenced the retired Postgres/Meili/auth surface)
- \`57c1f63 feat:\` declarative agent config — \`.arkeon/agents.yaml\` (committed), built-in \`contributor\` and \`editor\` role templates, role-builder, and \`arkeon-wiki config show/init/validate\` CLI commands
- \`945e622 docs:\` end-user setup guide + \`~/.arkeon-wiki/.env\` universal key support

## Why these belong together

The runtime in #56 wasn't usable end-to-end yet — operators had to construct \`AgentRole\` objects in TypeScript. This PR makes it config-driven, so users can:

1. \`arkeon-wiki config init\` → templated YAML
2. Drop their key in \`~/.arkeon-wiki/.env\` (universal across all spaces) or per-repo \`.env\` or shell
3. Edit \`.arkeon/agents.yaml\` to set provider/model and operator instructions per role
4. Run agents via \`runAgent(buildAgentRole(name, config), input, ALL_TOOLS)\` — used by the manual test today, will be used by #49 and #50 when they land

Custom user-defined roles fall out for free: anything in the \`roles:\` map with a \`system\` and \`tools\` is a real role. Each role can pick its own provider, model, and key.

## Configuration model

\`\`\`yaml
# .arkeon/agents.yaml — committed, no secrets
defaults:
  provider: openai
  model: gpt-5-mini
  instructions: |
    Operator notes appended to every role's system prompt.

roles:
  contributor:                # overrides built-in
    model: gpt-5-mini
    instructions: |
      Be aggressive about creating placeholders for named subjects.

  editor:
    provider: anthropic       # different provider per role is fine
    model: claude-opus-4-7
    api_key_env: ANTHROPIC_API_KEY
    max_steps: 20

  link-checker:               # custom user-defined role
    model: gpt-5-mini
    tools: [list_wikis, read_file, edit_file]
    max_steps: 30
    system: |
      You find broken cross-references and fix them.
\`\`\`

## Secrets stay out of YAML

\`api_key_env\` names which env var to read; the actual key lives in \`.env\`. Three locations, in increasing specificity:

| Location | Use when |
|---|---|
| \`~/.arkeon-wiki/.env\` | One key for all your spaces. Auto-loaded by the runtime. |
| \`<repo>/.env\` | Per-repo override. Gitignored by \`init\`. |
| Shell env (\`export …\`) | Highest precedence. CI, secret managers, one-off sessions. |

\`loadAgentEnv()\` snapshots existing process env keys before reading any file, so shell-set values are immune to anything in \`.env\`.

## Init now preserves committed config

\`arkeon-wiki init\` previously gitignored all of \`.arkeon/\`, which would have hidden \`agents.yaml\`. It now narrows the gitignore to just \`.arkeon/state.json\` (the per-clone state) and migrates existing \`.gitignore\` entries transparently.

## Documentation

- New: [\`docs/user/AGENT_RUNTIME.md\`](https://github.com/Arkeon-Technologies/arkeon-wiki/blob/worktree-agent-config-docs/docs/user/AGENT_RUNTIME.md) — from-scratch setup guide for users who got the package via \`npm install\`. Covers install, key placement, provider conventions, custom roles, prompt template variables, mixed-provider setups, troubleshooting.
- README: new \"Agents (LLM-powered)\" section pointing at the guide; configuration table mentions all three .env locations and \`agents.yaml\`.
- \`.env.example\`: header documents the three locations and precedence.

## Test plan

- [x] \`npm run typecheck -w packages/arkeon\` clean
- [x] \`npm test -w packages/arkeon\` — 110 unit (was 69 at #56 merge):
  - 33 new for config schema, mergeConfigs, loadAgentConfig, buildAgentRole (built-in and user-defined), fillTemplate, listAvailableRoles, default keying
  - 8 new for the env-loader (precedence, shell-wins, load order)
- [x] \`npm run test:e2e -w packages/arkeon\` — 132 e2e, all green
- [x] Layer 3 manual test (real OpenAI gpt-5-mini) — produces 4-6 placeholder wikis from a synthetic source paragraph in ~50s, ~\$0.005. Skipped automatically when no key is set; not run in CI.

## Out of scope (next PRs)

- \`arkeon-wiki agent run <role>\` CLI for manual triggering
- Auto-trigger configuration in YAML (file watchers for #49, polling for #50)
- Daemon entrypoint wiring \`loadAgentEnv\` (so the daemon picks up keys when #49/#50 land)
- Per-role token / cost budgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)