### PR TITLE
feat: wiki chunker + entity_chunks schema (gated, no embedder yet)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ He worked at [Bell Labs](../organization/bell-labs.md).
 - **Quote numeric-looking strings** you want to keep as strings (e.g. `version: "1.10"` — unquoted `1.10` becomes the float `1.1`). The serializer is defensive on the way out — IDs and digit-only strings are auto-quoted on write — but on read, what you write is what you get.
 - `id` is auto-generated on first sync if missing, written back to the file.
 - `label` is required. Everything else is arbitrary.
+- `short_description` (optional, single-line) is recognized by the chunker and embedded into the per-wiki "card" chunk for semantic search.
 - Standard markdown links (`[text](path.md)`) become relationship edges.
 
 YAML is a superset of JSON, so wikis written with the old JSON-style frontmatter (`---\n{ ... }\n---`) still parse correctly. The first sync that writes back a generated `id` will rewrite the file in YAML form — heads-up if you have uncommitted changes to a wiki that was authored with JSON frontmatter.
@@ -71,15 +72,16 @@ The pre-2026-04 `contributions[]` frontmatter inbox and matching SQLite table ha
 
 ## Schema
 
-Four tables in SQLite:
+Tables in SQLite:
 
 - `spaces` — registered directories (id, name, watch_dir)
 - `entities` — wikis and source files (id, space_id, type, label, source_path, source_hash, properties JSON text)
 - `relationships` — edges between entities (source_id, target_id, predicate, link_text, link_path)
 - `agent_runs` — idempotency tracking for the agent runtime, keyed by `(role, idempotency_key)` with an `input_hash` so re-triggers on the same input skip cleanly.
 - `agent_queue` — persistent FIFO of pending agent work. The watcher inserts on file events; the per-space worker claims, runs, and DELETEs on success. Lease pattern (`started_at + 5min`) makes it crash-safe.
+- `entity_chunks` — per-wiki chunks for embedding-based search (issue #47). Populated by the chunker only when `ARKEON_WIKI_CHUNKING=1`. Cascades on entity delete. Embeddings, the `vec0` virtual table, and RRF fusion arrive in follow-up PRs.
 
-No actors, no auth, no queues, no versioning. Schema in `src/schema/001-foundation.sql`.
+No actors, no auth, no versioning. Schema split across `src/schema/001-foundation.sql` and `src/schema/002-chunks.sql`.
 
 ## Key modules
 
@@ -93,6 +95,7 @@ No actors, no auth, no queues, no versioning. Schema in `src/schema/001-foundati
 - `src/server/agents/` — the agent runtime: declarative `.arkeon/agents.yaml` config (Zod-validated), built-in `ingestor` role template, role-builder that merges YAML + builtins + env, tool registry (`read_file`, `list_wikis`, `search`, `edit_file`), the runAgent loop (Vercel AI SDK), and the per-space scheduler that drives auto-triggering. `edit_file` is the only mutation tool — three modes (CREATE, APPEND, REPLACE) dispatched on whether `search` is empty and whether the file exists. There's no overwrite path.
 - `src/server/lib/agent-queue.ts` — pure SQL helpers around the `agent_queue` table (`enqueue`, `claimNext`, `complete`, `fail`, `reclaimOrphans`).
 - `src/server/agents/path-filter.ts` — `shouldTrigger(path)` — the hardcoded `wiki/**` + `.arkeon/**` filter the scheduler consults before enqueueing. Single source of truth; when user-tunable include/exclude lands, this file is the place.
+- `src/server/lib/chunker.ts` — `chunkWiki(parsed, label)`: pure function that turns a wiki into the chunks the embedder will see. Issue #47. Card chunk (label + subject_type + aliases + short_description + lead paragraph) plus one chunk per non-empty H2 with the heading path prepended. Oversized sections fall back to H3-then-paragraph splits with ~80-token overlap. Persistence is gated by `ARKEON_WIKI_CHUNKING=1` in `syncWikiFile()`; the embedder, vec0 index, and RRF fusion arrive in follow-up PRs.
 
 ## API endpoints
 
@@ -166,7 +169,7 @@ Override the state dir with `ARKEON_WIKI_HOME` env var or `--data-dir`.
 
 ## Schema migrations
 
-Single file: `001-foundation.sql`. Must be idempotent (all `IF NOT EXISTS`). Runs on every startup.
+`src/schema/*.sql`, applied in alphabetical order. Currently `001-foundation.sql` (entities, spaces, relationships, agent runtime) and `002-chunks.sql` (`entity_chunks`, dormant until `ARKEON_WIKI_CHUNKING=1`). Must be idempotent (all `IF NOT EXISTS`). Runs on every startup.
 
 ## What's NOT here (yet)
 

--- a/packages/arkeon/src/schema/002-chunks.sql
+++ b/packages/arkeon/src/schema/002-chunks.sql
@@ -1,0 +1,22 @@
+-- 002-chunks.sql
+-- Per-wiki chunks for embedding-based search (issue #47).
+-- This migration only sets up storage. The chunker itself is gated
+-- behind ARKEON_WIKI_CHUNKING=1 (see syncWikiFile). The embedder
+-- and vec0 virtual table arrive in follow-up PRs.
+
+CREATE TABLE IF NOT EXISTS entity_chunks (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  entity_id     TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+  chunk_index   INTEGER NOT NULL,
+  chunk_kind    TEXT NOT NULL CHECK (chunk_kind IN ('card', 'section', 'section_part')),
+  heading_path  TEXT NOT NULL,
+  start_line    INTEGER,
+  end_line      INTEGER,
+  text          TEXT NOT NULL,
+  content_hash  TEXT NOT NULL,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE (entity_id, chunk_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_chunks_entity ON entity_chunks(entity_id);
+CREATE INDEX IF NOT EXISTS idx_entity_chunks_kind ON entity_chunks(entity_id, chunk_kind);

--- a/packages/arkeon/src/server/lib/chunker.ts
+++ b/packages/arkeon/src/server/lib/chunker.ts
@@ -1,0 +1,408 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Wiki chunker for embedding-based search (issue #47).
+ *
+ * Pure function — no I/O. Given a parsed wiki, returns the canonical
+ * list of chunks that the embedder will see. Each wiki produces:
+ *
+ *   1. One synthetic "card" chunk built from frontmatter + lead paragraph.
+ *      Wins queries where no single section has all the words.
+ *   2. One section chunk per non-empty H2, with the heading path
+ *      ("Label > H2 [> H3]") prepended to the body. Sections stay whole.
+ *   3. Fallback: oversized sections split by H3, then by paragraph,
+ *      with ~80-token overlap. Almost no real wiki section hits this.
+ *
+ * The embedder, vector index, and fusion layer arrive in follow-up PRs.
+ * This module's only job is to produce a deterministic, inspectable
+ * chunk list and the per-chunk content_hash that the embedder will use
+ * to skip unchanged chunks.
+ */
+
+import { createHash } from "node:crypto";
+
+import type { ParsedWiki } from "./frontmatter.js";
+
+export type ChunkKind = "card" | "section" | "section_part";
+
+export interface Chunk {
+  chunk_index: number;
+  chunk_kind: ChunkKind;
+  heading_path: string;
+  start_line: number | null;
+  end_line: number | null;
+  text: string;
+  content_hash: string;
+}
+
+/**
+ * Approximate token budget per section before we fall back to splitting.
+ * Whitespace-token count is a rough proxy for tokenizer output (typically
+ * within ~30% of the real count for English prose). Chosen well below the
+ * 2048-token context of EmbeddingGemma to leave headroom for the prepended
+ * heading path. Replace with a real tokenizer count when the embedder lands.
+ */
+const MAX_SECTION_TOKENS = 1500;
+
+/**
+ * Token overlap when an oversized section is paragraph-split. Matches the
+ * @m13v finding from the issue thread: ~80 tokens of carryover preserves
+ * cross-paragraph context without blowing up the chunk count.
+ */
+const OVERLAP_TOKENS = 80;
+
+interface Heading {
+  level: number;       // 2 for H2, 3 for H3, etc.
+  text: string;        // cleaned heading text (no leading #, no markdown)
+  lineIndex: number;   // 0-based line of the heading itself
+}
+
+interface Section {
+  heading: string;
+  startLine: number;        // line of the heading
+  bodyStartLine: number;    // first body line (1-based for storage)
+  bodyEndLine: number;      // last body line (1-based, inclusive)
+  body: string;             // trimmed body text (no heading)
+  subsections: Section[];   // H3s nested under an H2 (empty for H3)
+}
+
+export function chunkWiki(parsed: ParsedWiki, label: string): Chunk[] {
+  const chunks: Chunk[] = [];
+  const props = parsed.properties;
+  const { lead, sections } = parseSections(parsed.body);
+
+  let chunkIndex = 0;
+
+  const cardText = buildCardText({
+    label,
+    subject_type: stringOrNull(props.subject_type),
+    aliases: stringArrayOrEmpty(props.aliases),
+    short_description: stringOrNull(props.short_description),
+    lead,
+  });
+
+  if (cardText) {
+    chunks.push(makeChunk({
+      chunk_index: chunkIndex++,
+      chunk_kind: "card",
+      heading_path: label,
+      start_line: null,
+      end_line: null,
+      text: cardText,
+    }));
+  }
+
+  for (const section of sections) {
+    const trimmedBody = section.body.trim();
+    if (!trimmedBody && section.subsections.every((s) => !s.body.trim())) {
+      continue;
+    }
+
+    const headingPath = `${label} > ${section.heading}`;
+    const sectionTokens = estimateTokens(trimmedBody) +
+      section.subsections.reduce((n, s) => n + estimateTokens(s.body), 0);
+
+    if (sectionTokens <= MAX_SECTION_TOKENS) {
+      const text = `${headingPath}\n\n${reassembleSection(section).trim()}`;
+      chunks.push(makeChunk({
+        chunk_index: chunkIndex++,
+        chunk_kind: "section",
+        heading_path: headingPath,
+        start_line: section.bodyStartLine,
+        end_line: section.bodyEndLine,
+        text,
+      }));
+    } else {
+      for (const part of splitOversized(section, label)) {
+        chunks.push(makeChunk({ ...part, chunk_index: chunkIndex++ }));
+      }
+    }
+  }
+
+  return chunks;
+}
+
+// ── Frontmatter → card ───────────────────────────────────────────────
+
+interface CardInput {
+  label: string;
+  subject_type: string | null;
+  aliases: string[];
+  short_description: string | null;
+  lead: string;
+}
+
+function buildCardText(input: CardInput): string {
+  const lines: string[] = [];
+
+  if (input.subject_type) {
+    lines.push(`${input.label} (${input.subject_type})`);
+  } else {
+    lines.push(input.label);
+  }
+
+  if (input.aliases.length > 0) {
+    lines.push(`Aliases: ${input.aliases.join(", ")}`);
+  }
+
+  if (input.short_description) {
+    lines.push(input.short_description);
+  }
+
+  const lead = input.lead.trim();
+  if (lead) {
+    lines.push(lead);
+  }
+
+  // Card always carries at least the label; never returns empty.
+  return lines.join("\n\n");
+}
+
+// ── Body → sections ──────────────────────────────────────────────────
+
+/**
+ * Walk the body line-by-line, splitting on ATX headings (`## ...`,
+ * `### ...`). Lines before the first H2 form the "lead" used by the card.
+ * H3s nest inside the H2 above them. Anything deeper than H3 is treated
+ * as body content of the enclosing H3 (or H2 if no H3) — we don't try to
+ * model the full heading tree.
+ *
+ * Setext headings (`Title\n=====`) and code-fenced `#` lines are not
+ * treated as headings. Wikis in this repo use ATX style.
+ */
+function parseSections(body: string): { lead: string; sections: Section[] } {
+  const lines = body.split("\n");
+  const headings: Heading[] = [];
+  let inFence = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+
+    const m = /^(#{2,6})\s+(.+?)\s*#*\s*$/.exec(line);
+    if (m) {
+      headings.push({
+        level: m[1].length,
+        text: cleanHeadingText(m[2]),
+        lineIndex: i,
+      });
+    }
+  }
+
+  if (headings.length === 0) {
+    return { lead: body, sections: [] };
+  }
+
+  const firstH2 = headings.findIndex((h) => h.level === 2);
+  if (firstH2 === -1) {
+    // Only H3+ headings — keep the whole body as the lead, no sections.
+    return { lead: body, sections: [] };
+  }
+
+  const lead = lines.slice(0, headings[firstH2].lineIndex).join("\n");
+
+  const sections: Section[] = [];
+  for (let i = firstH2; i < headings.length; i++) {
+    const h = headings[i];
+    if (h.level !== 2) continue;
+
+    const next = headings.slice(i + 1).find((x) => x.level === 2);
+    const sectionEndLine = next ? next.lineIndex : lines.length;
+
+    const subHeadings = headings
+      .slice(i + 1)
+      .filter((x) => x.level === 3 && x.lineIndex < sectionEndLine);
+
+    const bodyEndLineForH2 = subHeadings.length > 0
+      ? subHeadings[0].lineIndex
+      : sectionEndLine;
+
+    const h2Body = lines.slice(h.lineIndex + 1, bodyEndLineForH2).join("\n");
+
+    const subsections: Section[] = subHeadings.map((sub, j) => {
+      const subEnd = j + 1 < subHeadings.length
+        ? subHeadings[j + 1].lineIndex
+        : sectionEndLine;
+      return {
+        heading: sub.text,
+        startLine: sub.lineIndex + 1,
+        bodyStartLine: sub.lineIndex + 2,
+        bodyEndLine: subEnd,
+        body: lines.slice(sub.lineIndex + 1, subEnd).join("\n"),
+        subsections: [],
+      };
+    });
+
+    sections.push({
+      heading: h.text,
+      startLine: h.lineIndex + 1,
+      bodyStartLine: h.lineIndex + 2,
+      bodyEndLine: sectionEndLine,
+      body: h2Body,
+      subsections,
+    });
+  }
+
+  return { lead, sections };
+}
+
+function reassembleSection(section: Section): string {
+  // Stitch H2 body + each H3 (with its heading line) back together so the
+  // chunked text matches what a reader would see.
+  const parts: string[] = [];
+  if (section.body.trim()) parts.push(section.body.trim());
+  for (const sub of section.subsections) {
+    if (!sub.body.trim()) continue;
+    parts.push(`### ${sub.heading}\n\n${sub.body.trim()}`);
+  }
+  return parts.join("\n\n");
+}
+
+// ── Oversized section fallback ───────────────────────────────────────
+
+interface PartialChunk {
+  chunk_kind: ChunkKind;
+  heading_path: string;
+  start_line: number | null;
+  end_line: number | null;
+  text: string;
+}
+
+function splitOversized(section: Section, label: string): PartialChunk[] {
+  const parts: PartialChunk[] = [];
+  const h2Path = `${label} > ${section.heading}`;
+
+  const h2Body = section.body.trim();
+  if (h2Body) {
+    if (estimateTokens(h2Body) <= MAX_SECTION_TOKENS) {
+      parts.push({
+        chunk_kind: "section_part",
+        heading_path: h2Path,
+        start_line: section.bodyStartLine,
+        end_line: section.subsections.length > 0
+          ? section.subsections[0].startLine - 1
+          : section.bodyEndLine,
+        text: `${h2Path}\n\n${h2Body}`,
+      });
+    } else {
+      for (const piece of paragraphSplit(h2Body, h2Path, section.bodyStartLine)) {
+        parts.push(piece);
+      }
+    }
+  }
+
+  for (const sub of section.subsections) {
+    const subBody = sub.body.trim();
+    if (!subBody) continue;
+    const subPath = `${label} > ${section.heading} > ${sub.heading}`;
+    if (estimateTokens(subBody) <= MAX_SECTION_TOKENS) {
+      parts.push({
+        chunk_kind: "section_part",
+        heading_path: subPath,
+        start_line: sub.bodyStartLine,
+        end_line: sub.bodyEndLine,
+        text: `${subPath}\n\n${subBody}`,
+      });
+    } else {
+      for (const piece of paragraphSplit(subBody, subPath, sub.bodyStartLine)) {
+        parts.push(piece);
+      }
+    }
+  }
+
+  return parts;
+}
+
+function paragraphSplit(
+  body: string,
+  headingPath: string,
+  startLine: number,
+): PartialChunk[] {
+  const paragraphs = body.split(/\n{2,}/).map((p) => p.trim()).filter(Boolean);
+  if (paragraphs.length === 0) return [];
+
+  const out: PartialChunk[] = [];
+  let buffer: string[] = [];
+  let bufferTokens = 0;
+  let pieceStart = startLine;
+
+  const flush = (endLine: number): void => {
+    if (buffer.length === 0) return;
+    const text = `${headingPath}\n\n${buffer.join("\n\n")}`;
+    out.push({
+      chunk_kind: "section_part",
+      heading_path: headingPath,
+      start_line: pieceStart,
+      end_line: endLine,
+      text,
+    });
+  };
+
+  let cursor = startLine;
+  for (const para of paragraphs) {
+    const paraTokens = estimateTokens(para);
+    const paraLines = para.split("\n").length;
+
+    if (bufferTokens + paraTokens > MAX_SECTION_TOKENS && buffer.length > 0) {
+      flush(cursor - 1);
+
+      const carry: string[] = [];
+      let carryTokens = 0;
+      for (let i = buffer.length - 1; i >= 0 && carryTokens < OVERLAP_TOKENS; i--) {
+        carry.unshift(buffer[i]);
+        carryTokens += estimateTokens(buffer[i]);
+      }
+      buffer = carry;
+      bufferTokens = carryTokens;
+      pieceStart = cursor;
+    }
+
+    buffer.push(para);
+    bufferTokens += paraTokens;
+    cursor += paraLines + 1;
+  }
+
+  flush(cursor - 1);
+  return out;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function makeChunk(input: Omit<Chunk, "content_hash">): Chunk {
+  return {
+    ...input,
+    content_hash: createHash("sha256").update(input.text).digest("hex"),
+  };
+}
+
+function estimateTokens(text: string): number {
+  const trimmed = text.trim();
+  if (!trimmed) return 0;
+  return trimmed.split(/\s+/).length;
+}
+
+function cleanHeadingText(raw: string): string {
+  // Strip common decorations: bold/italic markers, inline code backticks,
+  // attribute blocks `{.class}`, leading/trailing whitespace.
+  return raw
+    .replace(/\{[^}]*\}\s*$/, "")
+    .replace(/[*_`]+/g, "")
+    .trim();
+}
+
+function stringOrNull(v: unknown): string | null {
+  return typeof v === "string" && v.trim() ? v.trim() : null;
+}
+
+function stringArrayOrEmpty(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  return v
+    .filter((x): x is string => typeof x === "string")
+    .map((x) => x.trim())
+    .filter(Boolean);
+}

--- a/packages/arkeon/src/server/lib/sync.ts
+++ b/packages/arkeon/src/server/lib/sync.ts
@@ -18,6 +18,15 @@ import { createSql, withTransaction } from "./sql.js";
 import { generateUlid } from "./ids.js";
 import { parseFrontmatter, serializeFrontmatter } from "./frontmatter.js";
 import { extractMarkdownLinks, resolveRelativeLink } from "./markdown-links.js";
+import { chunkWiki } from "./chunker.js";
+
+// Issue #47 — opt-in until the embedder + vec0 index land. Setting
+// ARKEON_WIKI_CHUNKING=1 makes syncWikiFile populate entity_chunks.
+// Read at call time, not module load, so tests and CLI flags can flip
+// it after the module is imported.
+function chunkingEnabled(): boolean {
+  return process.env.ARKEON_WIKI_CHUNKING === "1";
+}
 
 export interface Space {
   id: string;
@@ -151,6 +160,28 @@ async function syncWikiFile(
         linksResolved++;
       } else {
         linksDangling++;
+      }
+    }
+
+    if (chunkingEnabled()) {
+      const chunks = chunkWiki(parsed, label);
+      await tx`DELETE FROM entity_chunks WHERE entity_id = ${entityId}`;
+      for (const c of chunks) {
+        await tx`
+          INSERT INTO entity_chunks
+            (entity_id, chunk_index, chunk_kind, heading_path,
+             start_line, end_line, text, content_hash)
+          VALUES (
+            ${entityId},
+            ${c.chunk_index},
+            ${c.chunk_kind},
+            ${c.heading_path},
+            ${c.start_line},
+            ${c.end_line},
+            ${c.text},
+            ${c.content_hash}
+          )
+        `;
       }
     }
 

--- a/packages/arkeon/test/e2e/chunks.test.ts
+++ b/packages/arkeon/test/e2e/chunks.test.ts
@@ -1,0 +1,229 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * End-to-end test for the chunking pipeline (issue #47).
+ *
+ * Flips ARKEON_WIKI_CHUNKING=1 before starting its own server, writes a
+ * wiki, waits for the watcher, and asserts that entity_chunks is
+ * populated correctly. With chunking off (default), the existing
+ * fs-sync.test.ts already covers the no-chunks behavior.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdirSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+import yaml from "js-yaml";
+
+import { createSql } from "../../src/server/lib/sql.js";
+import { waitForEntityBySourcePath } from "./helpers.js";
+
+const API_PORT = 18790;
+const BASE_URL = `http://localhost:${API_PORT}`;
+
+let testDir: string;
+let stateDir: string;
+let serverHandle: { stop: () => Promise<void> } | null = null;
+let spaceId: string;
+let prevChunkingEnv: string | undefined;
+
+function writeWiki(
+  relativePath: string,
+  properties: Record<string, unknown>,
+  body: string,
+): void {
+  const absPath = join(testDir, relativePath);
+  const dir = absPath.substring(0, absPath.lastIndexOf("/"));
+  mkdirSync(dir, { recursive: true });
+  const fm = yaml.dump(properties, { schema: yaml.JSON_SCHEMA, sortKeys: false }).trimEnd();
+  writeFileSync(absPath, `---\n${fm}\n---\n\n${body}\n`);
+}
+
+interface ChunkRow {
+  chunk_index: number;
+  chunk_kind: string;
+  heading_path: string;
+  text: string;
+  content_hash: string;
+}
+
+async function getChunks(entityId: string): Promise<ChunkRow[]> {
+  const sql = createSql();
+  const rows = await sql`
+    SELECT chunk_index, chunk_kind, heading_path, text, content_hash
+    FROM entity_chunks
+    WHERE entity_id = ${entityId}
+    ORDER BY chunk_index
+  `;
+  return rows as ChunkRow[];
+}
+
+async function waitForChunks(
+  entityId: string,
+  predicate: (rows: ChunkRow[]) => boolean,
+  timeoutMs = 5000,
+): Promise<ChunkRow[]> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const rows = await getChunks(entityId);
+    if (predicate(rows)) return rows;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  return getChunks(entityId);
+}
+
+beforeAll(async () => {
+  prevChunkingEnv = process.env.ARKEON_WIKI_CHUNKING;
+  process.env.ARKEON_WIKI_CHUNKING = "1";
+
+  const base = join(tmpdir(), `arkeon-chunks-${randomBytes(4).toString("hex")}`);
+  testDir = join(base, "repo");
+  stateDir = join(base, "state");
+  mkdirSync(testDir, { recursive: true });
+  mkdirSync(join(stateDir, "data"), { recursive: true });
+  mkdirSync(join(testDir, "wiki"), { recursive: true });
+
+  process.env.ARKEON_WIKI_HOME = stateDir;
+
+  const dbFile = join(stateDir, "data", "arke.db");
+
+  const { runMigrations } = await import("../../src/schema/index.js");
+  await runMigrations({ dbPath: dbFile });
+
+  const { startApi } = await import("../../src/server/server.js");
+  const apiHandle = await startApi({ port: API_PORT, dbPath: dbFile });
+  serverHandle = { stop: () => apiHandle.stop() };
+
+  const res = await fetch(`${BASE_URL}/spaces`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: "chunks-test", watch_dir: testDir }),
+  });
+  const data = await res.json() as { id: string };
+  spaceId = data.id;
+}, 60_000);
+
+afterAll(async () => {
+  if (serverHandle) await serverHandle.stop();
+  if (testDir && existsSync(testDir)) {
+    rmSync(testDir.substring(0, testDir.lastIndexOf("/")), { recursive: true, force: true });
+  }
+  if (prevChunkingEnv === undefined) {
+    delete process.env.ARKEON_WIKI_CHUNKING;
+  } else {
+    process.env.ARKEON_WIKI_CHUNKING = prevChunkingEnv;
+  }
+}, 30_000);
+
+describe("entity_chunks (ARKEON_WIKI_CHUNKING=1)", () => {
+  it("populates a card + section chunks for a synced wiki", async () => {
+    writeWiki("wiki/person/shannon.md", {
+      label: "Claude Shannon",
+      subject_type: "person",
+      aliases: ["C. E. Shannon"],
+      short_description: "American mathematician, father of information theory.",
+    }, [
+      "Claude Shannon was an American mathematician.",
+      "",
+      "## Early Life",
+      "",
+      "Born in 1916 in Michigan.",
+      "",
+      "## Career",
+      "",
+      "Worked at Bell Labs.",
+    ].join("\n"));
+
+    const entity = await waitForEntityBySourcePath(spaceId, "wiki/person/shannon.md");
+    const chunks = await waitForChunks(entity.id, (rows) => rows.length === 3);
+
+    expect(chunks.map((c) => c.chunk_kind)).toEqual(["card", "section", "section"]);
+    expect(chunks.map((c) => c.chunk_index)).toEqual([0, 1, 2]);
+
+    expect(chunks[0].heading_path).toBe("Claude Shannon");
+    expect(chunks[0].text).toContain("Claude Shannon (person)");
+    expect(chunks[0].text).toContain("Aliases: C. E. Shannon");
+    expect(chunks[0].text).toContain("father of information theory");
+
+    expect(chunks[1].heading_path).toBe("Claude Shannon > Early Life");
+    expect(chunks[1].text.startsWith("Claude Shannon > Early Life\n\n")).toBe(true);
+    expect(chunks[1].text).toContain("Born in 1916 in Michigan.");
+
+    expect(chunks[2].heading_path).toBe("Claude Shannon > Career");
+    expect(chunks[2].text).toContain("Worked at Bell Labs.");
+
+    for (const c of chunks) {
+      expect(c.content_hash).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  it("replaces chunks on edit (no orphans, new content_hash)", async () => {
+    const entity = await waitForEntityBySourcePath(spaceId, "wiki/person/shannon.md");
+    const before = await getChunks(entity.id);
+    const earlyLifeBefore = before.find((c) => c.heading_path === "Claude Shannon > Early Life")!;
+
+    writeWiki("wiki/person/shannon.md", {
+      id: entity.id,
+      label: "Claude Shannon",
+      subject_type: "person",
+      aliases: ["C. E. Shannon"],
+      short_description: "American mathematician, father of information theory.",
+    }, [
+      "Claude Shannon was an American mathematician.",
+      "",
+      "## Early Life",
+      "",
+      "Born in 1916 in Petoskey, Michigan.",
+      "",
+      "## Career",
+      "",
+      "Worked at Bell Labs.",
+    ].join("\n"));
+
+    const after = await waitForChunks(
+      entity.id,
+      (rows) => {
+        const el = rows.find((c) => c.heading_path === "Claude Shannon > Early Life");
+        return !!el && el.content_hash !== earlyLifeBefore.content_hash;
+      },
+    );
+
+    expect(after).toHaveLength(3);
+    const earlyLifeAfter = after.find((c) => c.heading_path === "Claude Shannon > Early Life")!;
+    expect(earlyLifeAfter.text).toContain("Petoskey, Michigan");
+    expect(earlyLifeAfter.content_hash).not.toBe(earlyLifeBefore.content_hash);
+  });
+
+  it("does not chunk source (non-wiki) files", async () => {
+    const sourcePath = "notes/meeting.txt";
+    const absPath = join(testDir, sourcePath);
+    mkdirSync(absPath.substring(0, absPath.lastIndexOf("/")), { recursive: true });
+    writeFileSync(absPath, "Meeting notes from today.");
+
+    const entity = await waitForEntityBySourcePath(spaceId, sourcePath);
+    expect(entity.type).toBe("file");
+
+    // Watcher is async; give it time to (not) chunk this.
+    await new Promise((r) => setTimeout(r, 800));
+    const chunks = await getChunks(entity.id);
+    expect(chunks).toHaveLength(0);
+  });
+
+  it("cascades chunk deletion when the entity is deleted", async () => {
+    writeWiki("wiki/person/temp.md", {
+      label: "Temp Wiki",
+      subject_type: "person",
+    }, "## Section\n\nBody.");
+
+    const entity = await waitForEntityBySourcePath(spaceId, "wiki/person/temp.md");
+    await waitForChunks(entity.id, (rows) => rows.length > 0);
+
+    const res = await fetch(`${BASE_URL}/wikis/${entity.id}`, { method: "DELETE" });
+    expect((await res.json() as { deleted: boolean }).deleted).toBe(true);
+
+    const after = await getChunks(entity.id);
+    expect(after).toHaveLength(0);
+  });
+});

--- a/packages/arkeon/test/unit/chunker.test.ts
+++ b/packages/arkeon/test/unit/chunker.test.ts
@@ -1,0 +1,323 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { createHash } from "node:crypto";
+import { chunkWiki } from "../../src/server/lib/chunker.js";
+import type { ParsedWiki } from "../../src/server/lib/frontmatter.js";
+
+function wiki(properties: Record<string, unknown>, body: string): ParsedWiki {
+  return { properties, body };
+}
+
+describe("chunker — card composition", () => {
+  it("emits a card chunk with just the label when nothing else is present", () => {
+    const chunks = chunkWiki(wiki({}, ""), "Claude Shannon");
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].chunk_kind).toBe("card");
+    expect(chunks[0].chunk_index).toBe(0);
+    expect(chunks[0].heading_path).toBe("Claude Shannon");
+    expect(chunks[0].text).toBe("Claude Shannon");
+    expect(chunks[0].start_line).toBeNull();
+    expect(chunks[0].end_line).toBeNull();
+  });
+
+  it("includes subject_type in parentheses on the first line", () => {
+    const chunks = chunkWiki(
+      wiki({ subject_type: "person" }, ""),
+      "Claude Shannon",
+    );
+    expect(chunks[0].text.split("\n")[0]).toBe("Claude Shannon (person)");
+  });
+
+  it("includes aliases line when present and non-empty", () => {
+    const chunks = chunkWiki(
+      wiki({ subject_type: "person", aliases: ["Shannon", "C. E. Shannon"] }, ""),
+      "Claude Shannon",
+    );
+    expect(chunks[0].text).toContain("Aliases: Shannon, C. E. Shannon");
+  });
+
+  it("ignores empty aliases and non-string entries", () => {
+    const chunks = chunkWiki(
+      wiki({ aliases: ["", "  ", 42, "Shannon"] }, ""),
+      "Claude Shannon",
+    );
+    expect(chunks[0].text).toContain("Aliases: Shannon");
+  });
+
+  it("omits the aliases line when the field is missing or empty", () => {
+    const chunks = chunkWiki(wiki({ aliases: [] }, ""), "Claude Shannon");
+    expect(chunks[0].text).not.toContain("Aliases:");
+  });
+
+  it("includes short_description when present", () => {
+    const chunks = chunkWiki(
+      wiki({ short_description: "Father of information theory." }, ""),
+      "Claude Shannon",
+    );
+    expect(chunks[0].text).toContain("Father of information theory.");
+  });
+
+  it("includes the lead paragraph (text before the first H2) on the card", () => {
+    const body = "Claude Shannon was an American mathematician.\n\n## Early Life\n\nBorn in Michigan.";
+    const chunks = chunkWiki(wiki({}, body), "Claude Shannon");
+
+    const card = chunks.find((c) => c.chunk_kind === "card")!;
+    expect(card.text).toContain("Claude Shannon was an American mathematician.");
+    expect(card.text).not.toContain("Born in Michigan");
+  });
+});
+
+describe("chunker — section chunks", () => {
+  const body = [
+    "Lead paragraph for the wiki.",
+    "",
+    "## Early Life",
+    "",
+    "Shannon was born in 1916 in Michigan.",
+    "",
+    "## Career",
+    "",
+    "Worked at Bell Labs.",
+  ].join("\n");
+
+  it("emits one chunk per non-empty H2 section", () => {
+    const chunks = chunkWiki(wiki({}, body), "Claude Shannon");
+    const sections = chunks.filter((c) => c.chunk_kind === "section");
+    expect(sections).toHaveLength(2);
+    expect(sections.map((s) => s.heading_path)).toEqual([
+      "Claude Shannon > Early Life",
+      "Claude Shannon > Career",
+    ]);
+  });
+
+  it("prepends the heading path to the section body in chunk text", () => {
+    const chunks = chunkWiki(wiki({}, body), "Claude Shannon");
+    const earlyLife = chunks.find((c) => c.heading_path === "Claude Shannon > Early Life")!;
+    expect(earlyLife.text.startsWith("Claude Shannon > Early Life\n\n")).toBe(true);
+    expect(earlyLife.text).toContain("Shannon was born in 1916 in Michigan.");
+  });
+
+  it("assigns sequential chunk_index starting from 0 (card first)", () => {
+    const chunks = chunkWiki(wiki({}, body), "Claude Shannon");
+    expect(chunks.map((c) => c.chunk_index)).toEqual([0, 1, 2]);
+    expect(chunks[0].chunk_kind).toBe("card");
+  });
+
+  it("skips heading-only sections (no body)", () => {
+    const empty = "## Section A\n\nA has content.\n\n## Section B\n\n## Section C\n\nC has content.";
+    const chunks = chunkWiki(wiki({}, empty), "Wiki");
+    const sectionLabels = chunks
+      .filter((c) => c.chunk_kind === "section")
+      .map((c) => c.heading_path);
+    expect(sectionLabels).toEqual(["Wiki > Section A", "Wiki > Section C"]);
+  });
+
+  it("absorbs H3 sub-sections into the parent H2 chunk when small enough", () => {
+    const nested = [
+      "## Career",
+      "",
+      "Overview of his career.",
+      "",
+      "### Bell Labs",
+      "",
+      "Joined in 1941.",
+      "",
+      "### MIT",
+      "",
+      "Returned in 1956.",
+    ].join("\n");
+
+    const chunks = chunkWiki(wiki({}, nested), "Claude Shannon");
+    const sections = chunks.filter((c) => c.chunk_kind === "section");
+    expect(sections).toHaveLength(1);
+    expect(sections[0].heading_path).toBe("Claude Shannon > Career");
+    expect(sections[0].text).toContain("Overview of his career.");
+    expect(sections[0].text).toContain("### Bell Labs");
+    expect(sections[0].text).toContain("Joined in 1941.");
+    expect(sections[0].text).toContain("### MIT");
+  });
+
+  it("returns no section chunks when the body has no H2", () => {
+    const chunks = chunkWiki(wiki({}, "Just some prose."), "Wiki");
+    expect(chunks.filter((c) => c.chunk_kind === "section")).toHaveLength(0);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].chunk_kind).toBe("card");
+  });
+
+  it("populates start_line and end_line for section chunks", () => {
+    const chunks = chunkWiki(wiki({}, body), "Claude Shannon");
+    const earlyLife = chunks.find((c) => c.heading_path === "Claude Shannon > Early Life")!;
+    expect(typeof earlyLife.start_line).toBe("number");
+    expect(typeof earlyLife.end_line).toBe("number");
+    expect(earlyLife.start_line!).toBeGreaterThan(0);
+  });
+});
+
+describe("chunker — heading sanitization", () => {
+  it("strips bold/italic markers from heading text", () => {
+    const body = "## **Bold** and *italic*\n\nBody.";
+    const chunks = chunkWiki(wiki({}, body), "Wiki");
+    const section = chunks.find((c) => c.chunk_kind === "section")!;
+    expect(section.heading_path).toBe("Wiki > Bold and italic");
+  });
+
+  it("strips trailing attribute blocks", () => {
+    const body = "## Heading {.special-class}\n\nBody.";
+    const chunks = chunkWiki(wiki({}, body), "Wiki");
+    expect(chunks.find((c) => c.chunk_kind === "section")!.heading_path)
+      .toBe("Wiki > Heading");
+  });
+
+  it("ignores `##` lines inside fenced code blocks", () => {
+    const body = [
+      "Lead.",
+      "",
+      "```",
+      "## not a real heading",
+      "```",
+      "",
+      "## Real Section",
+      "",
+      "Real body.",
+    ].join("\n");
+
+    const chunks = chunkWiki(wiki({}, body), "Wiki");
+    const sections = chunks.filter((c) => c.chunk_kind === "section");
+    expect(sections).toHaveLength(1);
+    expect(sections[0].heading_path).toBe("Wiki > Real Section");
+  });
+
+  it("preserves unicode in headings", () => {
+    const body = "## Café Society\n\nBody.";
+    const chunks = chunkWiki(wiki({}, body), "Wiki");
+    expect(chunks.find((c) => c.chunk_kind === "section")!.heading_path)
+      .toBe("Wiki > Café Society");
+  });
+});
+
+describe("chunker — content_hash", () => {
+  it("is the sha256 of the chunk text", () => {
+    const chunks = chunkWiki(wiki({}, "## Section\n\nBody."), "Wiki");
+    for (const c of chunks) {
+      const expected = createHash("sha256").update(c.text).digest("hex");
+      expect(c.content_hash).toBe(expected);
+    }
+  });
+
+  it("is stable across runs for identical input", () => {
+    const a = chunkWiki(wiki({ subject_type: "person" }, "## A\n\nB."), "X");
+    const b = chunkWiki(wiki({ subject_type: "person" }, "## A\n\nB."), "X");
+    expect(a.map((c) => c.content_hash)).toEqual(b.map((c) => c.content_hash));
+  });
+
+  it("changes when the wiki body changes", () => {
+    const a = chunkWiki(wiki({}, "## A\n\nFirst."), "X");
+    const b = chunkWiki(wiki({}, "## A\n\nSecond."), "X");
+    const aSection = a.find((c) => c.chunk_kind === "section")!;
+    const bSection = b.find((c) => c.chunk_kind === "section")!;
+    expect(aSection.content_hash).not.toBe(bSection.content_hash);
+  });
+});
+
+describe("chunker — oversized section fallback", () => {
+  // Build a section large enough to trip the 1500-token budget. Each
+  // paragraph is ~60 tokens; 30 paragraphs ≈ 1800 tokens.
+  function bigSection(numParas: number, paraTokens: number): string {
+    const word = "lorem ";
+    const para = word.repeat(paraTokens).trim();
+    const paras = Array.from({ length: numParas }, (_, i) => `${para} para${i}`);
+    return `## Big\n\n${paras.join("\n\n")}`;
+  }
+
+  it("splits an oversized section into section_part chunks", () => {
+    const chunks = chunkWiki(wiki({}, bigSection(30, 60)), "Wiki");
+    const parts = chunks.filter((c) => c.chunk_kind === "section_part");
+    expect(parts.length).toBeGreaterThan(1);
+
+    for (const p of parts) {
+      expect(p.heading_path).toBe("Wiki > Big");
+      expect(p.text.startsWith("Wiki > Big\n\n")).toBe(true);
+    }
+  });
+
+  it("emits no section chunk when the section was split (only section_part)", () => {
+    const chunks = chunkWiki(wiki({}, bigSection(30, 60)), "Wiki");
+    expect(chunks.find(
+      (c) => c.chunk_kind === "section" && c.heading_path === "Wiki > Big",
+    )).toBeUndefined();
+  });
+
+  it("preserves overlap between adjacent section_parts", () => {
+    const chunks = chunkWiki(wiki({}, bigSection(30, 60)), "Wiki");
+    const parts = chunks.filter((c) => c.chunk_kind === "section_part");
+    expect(parts.length).toBeGreaterThanOrEqual(2);
+
+    // The last paragraph of part N should also appear at the start of
+    // part N+1 (after the heading_path prefix). We only check that some
+    // overlap exists — the carryover is bounded by OVERLAP_TOKENS.
+    const tailOfFirst = parts[0].text.split("\n\n").slice(-1)[0];
+    expect(parts[1].text).toContain(tailOfFirst);
+  });
+
+  it("splits an oversized H3 with its own heading path", () => {
+    const word = "lorem ".repeat(60).trim();
+    const paras = Array.from({ length: 30 }, (_, i) => `${word} p${i}`).join("\n\n");
+    const body = `## Career\n\nShort intro.\n\n### Bell Labs\n\n${paras}`;
+
+    const chunks = chunkWiki(wiki({}, body), "Wiki");
+    const partPaths = chunks
+      .filter((c) => c.chunk_kind === "section_part")
+      .map((c) => c.heading_path);
+
+    expect(partPaths.some((p) => p === "Wiki > Career > Bell Labs")).toBe(true);
+  });
+});
+
+describe("chunker — full integration shape", () => {
+  it("produces a deterministic chunk list for a realistic wiki", () => {
+    const props = {
+      label: "Claude Shannon",
+      subject_type: "person",
+      aliases: ["C. E. Shannon"],
+      short_description: "American mathematician, father of information theory.",
+    };
+    const body = [
+      "Claude Shannon was an American mathematician and electrical engineer.",
+      "",
+      "## Early Life",
+      "",
+      "Born in 1916 in Petoskey, Michigan.",
+      "",
+      "## Career",
+      "",
+      "Joined Bell Labs in 1941.",
+      "",
+      "### Information Theory",
+      "",
+      "Published *A Mathematical Theory of Communication* in 1948.",
+    ].join("\n");
+
+    const chunks = chunkWiki(wiki(props, body), "Claude Shannon");
+
+    expect(chunks.map((c) => c.chunk_kind)).toEqual(["card", "section", "section"]);
+    expect(chunks.map((c) => c.heading_path)).toEqual([
+      "Claude Shannon",
+      "Claude Shannon > Early Life",
+      "Claude Shannon > Career",
+    ]);
+
+    const card = chunks[0];
+    expect(card.text).toContain("Claude Shannon (person)");
+    expect(card.text).toContain("Aliases: C. E. Shannon");
+    expect(card.text).toContain("father of information theory");
+    expect(card.text).toContain("American mathematician and electrical engineer");
+
+    const career = chunks[2];
+    expect(career.text).toContain("Joined Bell Labs in 1941.");
+    expect(career.text).toContain("### Information Theory");
+    expect(career.text).toContain("A Mathematical Theory of Communication");
+  });
+});


### PR DESCRIPTION
## Summary

First PR towards #47. Builds the chunking pipeline that the embedder, `sqlite-vec` index, and RRF fusion will sit on top of. Embedder + vector index + query path remain explicitly out of scope and will land as separate PRs.

- **`src/server/lib/chunker.ts`** — pure function `chunkWiki(parsed, label)`. One synthesized **card** chunk per wiki (label + subject_type + aliases + short_description + lead paragraph) plus one **section** chunk per non-empty H2 with the heading path (`Label > H2 [> H3]`) prepended. Whole sections stay whole; oversized sections fall back to H3-then-paragraph splits with ~80-token overlap. No I/O, fully unit-testable.
- **`src/schema/002-chunks.sql`** — `entity_chunks` table with `chunk_kind`, `heading_path`, `content_hash`. `ON DELETE CASCADE` from `entities`. Idempotent.
- **`src/server/lib/sync.ts`** — chunker runs inside the existing `syncWikiFile` transaction when `ARKEON_WIKI_CHUNKING=1`. Default off, so tarball smoke tests and normal CLI use are unaffected.
- **`short_description`** recognized as an optional frontmatter field — it's load-bearing for the card chunk and doubles as a UI snippet.
- **CLAUDE.md** — documents the chunker, the new field, and the schema split.

## Why this shape

Per the discussion on #47: our wikis are structured cleanly enough that we can use a section as the chunk unit and skip the recursive splitter for the common case. @m13v's recursive heading split with overlap remains the fallback for sections that exceed the embedder's context. This keeps the index ~50% smaller than fixed-window splitting and gives wiki-level intent ("what is X") its own dedicated chunk.

## What's NOT in this PR

- No embedder (Ollama vs ONNX runtime selection, model download UX) — separate PR.
- No `vec0` virtual table or vector inserts — that's the embedder PR.
- No query path or RRF fusion — comes after the index lands.
- No `reindex` CLI — backfill story for the embedder PR.
- No threadpool tuning — relevant once we're actually running ONNX.

The `content_hash` column is dead weight in this PR but pays off in the embedder PR: it lets the embedding step diff old vs new chunks and only re-embed the changes (so a one-paragraph edit doesn't re-embed the whole wiki).

## Test plan

- [x] `npm run typecheck -w packages/arkeon` — clean
- [x] `npm test -w packages/arkeon` — 150/150 (includes 26 new chunker unit tests)
- [x] `npm run test:e2e -w packages/arkeon` — 134/134 (includes 4 new chunks e2e tests; existing tests unaffected with the flag off)
- [x] Verified the migration is idempotent by running it twice (existing `schema idempotency` e2e test covers all `*.sql` in the schema dir)

🤖 Generated with [Claude Code](https://claude.com/claude-code)