### PR TITLE
feat: embedding pipeline + chunking on by default (PR 2 of 3 for #47)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ No actors, no auth, no versioning. Schema across `src/schema/001-foundation.sql`
 
 ## Key modules
 
-- `src/server/lib/sync.ts` — `syncFile()`: the core primitive. Reads a file, parses frontmatter, upserts entity, resolves links to relationship edges.
+- `src/server/lib/sync.ts` — `syncFile()`: the core primitive. Reads a file, parses frontmatter, upserts entity, resolves links to relationship edges. For wiki files, also runs the chunker and reconciles `entity_chunks` via a content_hash-keyed diff (UPDATE in place for unchanged chunks, INSERT for new, DELETE for removed) so embeddings survive across edits.
 - `src/server/lib/fs-watcher.ts` — watches registered directories, debounces changes, calls `syncFile()` / `removeByPath()`.
 - `src/server/lib/frontmatter.ts` — parse/serialize YAML frontmatter.
 - `src/server/lib/markdown-links.ts` — extract and resolve markdown links.
@@ -179,7 +179,6 @@ Override the state dir with `ARKEON_WIKI_HOME` env var or `--data-dir`.
 
 - No public vector-search query path. The pipeline writes embeddings; nothing queries them yet. RRF fusion with ripgrep and the `/search?mode=hybrid` integration are the next PR for issue #47.
 - No bundled ONNX runtime. Real embeddings require a local Ollama install + `ollama pull embeddinggemma:300m`. Without it, the worker falls back to a deterministic mock embedder that exercises the pipeline but is not semantically useful.
-- No per-chunk content-hash short-circuit. `syncWikiFile()` deletes and re-inserts every chunk on every wiki sync, so chunk_ids are ephemeral and the worker re-embeds the whole wiki on each save. Cheap during development, wasteful at scale — separate issue tracks the in-place upsert.
 - No FTS5 / BM25 ranking (ripgrep gives substring matching only)
 - No auth / API keys
 - No explorer (needs updating for new API)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Tables in SQLite:
 - `relationships` — edges between entities (source_id, target_id, predicate, link_text, link_path)
 - `agent_runs` — idempotency tracking for the agent runtime, keyed by `(role, idempotency_key)` with an `input_hash` so re-triggers on the same input skip cleanly.
 - `agent_queue` — persistent FIFO of pending agent work. The watcher inserts on file events; the per-space worker claims, runs, and DELETEs on success. Lease pattern (`started_at + 5min`) makes it crash-safe.
-- `entity_chunks` — per-wiki chunks for embedding-based search (issue #47). Populated by the chunker only when `ARKEON_WIKI_CHUNKING=1`. Cascades on entity delete. Embeddings, the `vec0` virtual table, and RRF fusion arrive in follow-up PRs.
+- `entity_chunks` — per-wiki chunks for embedding-based search (issue #47). Populated on every wiki sync; opt out with `ARKEON_WIKI_CHUNKING=0`. Cascades on entity delete. Embeddings, the `vec0` virtual table, and RRF fusion arrive in follow-up PRs.
 
 No actors, no auth, no versioning. Schema split across `src/schema/001-foundation.sql` and `src/schema/002-chunks.sql`.
 
@@ -95,7 +95,7 @@ No actors, no auth, no versioning. Schema split across `src/schema/001-foundatio
 - `src/server/agents/` — the agent runtime: declarative `.arkeon/agents.yaml` config (Zod-validated), built-in `ingestor` role template, role-builder that merges YAML + builtins + env, tool registry (`read_file`, `list_wikis`, `search`, `edit_file`), the runAgent loop (Vercel AI SDK), and the per-space scheduler that drives auto-triggering. `edit_file` is the only mutation tool — three modes (CREATE, APPEND, REPLACE) dispatched on whether `search` is empty and whether the file exists. There's no overwrite path.
 - `src/server/lib/agent-queue.ts` — pure SQL helpers around the `agent_queue` table (`enqueue`, `claimNext`, `complete`, `fail`, `reclaimOrphans`).
 - `src/server/agents/path-filter.ts` — `shouldTrigger(path)` — the hardcoded `wiki/**` + `.arkeon/**` filter the scheduler consults before enqueueing. Single source of truth; when user-tunable include/exclude lands, this file is the place.
-- `src/server/lib/chunker.ts` — `chunkWiki(parsed, label)`: pure function that turns a wiki into the chunks the embedder will see. Issue #47. Card chunk (label + subject_type + aliases + short_description + lead paragraph) plus one chunk per non-empty H2 with the heading path prepended. Oversized sections fall back to H3-then-paragraph splits with ~80-token overlap. Persistence is gated by `ARKEON_WIKI_CHUNKING=1` in `syncWikiFile()`; the embedder, vec0 index, and RRF fusion arrive in follow-up PRs.
+- `src/server/lib/chunker.ts` — `chunkWiki(parsed, label)`: pure function that turns a wiki into the chunks the embedder will see. Issue #47. Card chunk (label + subject_type + aliases + short_description + lead paragraph) plus one chunk per non-empty H2 with the heading path prepended. Oversized sections fall back to H3-then-paragraph splits with ~80-token overlap. Runs on every wiki sync (`syncWikiFile()`); set `ARKEON_WIKI_CHUNKING=0` to disable. The embedder, vec0 index, and RRF fusion arrive in follow-up PRs.
 
 ## API endpoints
 
@@ -169,7 +169,7 @@ Override the state dir with `ARKEON_WIKI_HOME` env var or `--data-dir`.
 
 ## Schema migrations
 
-`src/schema/*.sql`, applied in alphabetical order. Currently `001-foundation.sql` (entities, spaces, relationships, agent runtime) and `002-chunks.sql` (`entity_chunks`, dormant until `ARKEON_WIKI_CHUNKING=1`). Must be idempotent (all `IF NOT EXISTS`). Runs on every startup.
+`src/schema/*.sql`, applied in alphabetical order. Currently `001-foundation.sql` (entities, spaces, relationships, agent runtime) and `002-chunks.sql` (`entity_chunks`, populated on every wiki sync unless `ARKEON_WIKI_CHUNKING=0`). Must be idempotent (all `IF NOT EXISTS`). Runs on every startup.
 
 ## What's NOT here (yet)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,9 +79,12 @@ Tables in SQLite:
 - `relationships` — edges between entities (source_id, target_id, predicate, link_text, link_path)
 - `agent_runs` — idempotency tracking for the agent runtime, keyed by `(role, idempotency_key)` with an `input_hash` so re-triggers on the same input skip cleanly.
 - `agent_queue` — persistent FIFO of pending agent work. The watcher inserts on file events; the per-space worker claims, runs, and DELETEs on success. Lease pattern (`started_at + 5min`) makes it crash-safe.
-- `entity_chunks` — per-wiki chunks for embedding-based search (issue #47). Populated on every wiki sync; opt out with `ARKEON_WIKI_CHUNKING=0`. Cascades on entity delete. Embeddings, the `vec0` virtual table, and RRF fusion arrive in follow-up PRs.
+- `entity_chunks` — per-wiki chunks for embedding-based search (issue #47). Populated on every wiki sync; opt out with `ARKEON_WIKI_CHUNKING=0`. Cascades on entity delete.
+- `entity_embeddings` — pivot tracking which model + chunk content_hash produced each embedding. Cascades from `entity_chunks`.
+- `chunk_vectors` — `vec0` virtual table holding the actual float[256] vectors (sqlite-vec). Joined to chunks via `chunk_id`.
+- `embedding_queue` — per-entity work queue drained by the in-process embedding worker. Same lease pattern as `agent_queue`.
 
-No actors, no auth, no versioning. Schema split across `src/schema/001-foundation.sql` and `src/schema/002-chunks.sql`.
+No actors, no auth, no versioning. Schema across `src/schema/001-foundation.sql`, `002-chunks.sql`, and `003-embeddings.sql`.
 
 ## Key modules
 
@@ -95,7 +98,9 @@ No actors, no auth, no versioning. Schema split across `src/schema/001-foundatio
 - `src/server/agents/` — the agent runtime: declarative `.arkeon/agents.yaml` config (Zod-validated), built-in `ingestor` role template, role-builder that merges YAML + builtins + env, tool registry (`read_file`, `list_wikis`, `search`, `edit_file`), the runAgent loop (Vercel AI SDK), and the per-space scheduler that drives auto-triggering. `edit_file` is the only mutation tool — three modes (CREATE, APPEND, REPLACE) dispatched on whether `search` is empty and whether the file exists. There's no overwrite path.
 - `src/server/lib/agent-queue.ts` — pure SQL helpers around the `agent_queue` table (`enqueue`, `claimNext`, `complete`, `fail`, `reclaimOrphans`).
 - `src/server/agents/path-filter.ts` — `shouldTrigger(path)` — the hardcoded `wiki/**` + `.arkeon/**` filter the scheduler consults before enqueueing. Single source of truth; when user-tunable include/exclude lands, this file is the place.
-- `src/server/lib/chunker.ts` — `chunkWiki(parsed, label)`: pure function that turns a wiki into the chunks the embedder will see. Issue #47. Card chunk (label + subject_type + aliases + short_description + lead paragraph) plus one chunk per non-empty H2 with the heading path prepended. Oversized sections fall back to H3-then-paragraph splits with ~80-token overlap. Runs on every wiki sync (`syncWikiFile()`); set `ARKEON_WIKI_CHUNKING=0` to disable. The embedder, vec0 index, and RRF fusion arrive in follow-up PRs.
+- `src/server/lib/chunker.ts` — `chunkWiki(parsed, label)`: pure function that turns a wiki into the chunks the embedder will see. Issue #47. Card chunk (label + subject_type + aliases + short_description + lead paragraph) plus one chunk per non-empty H2 with the heading path prepended. Oversized sections fall back to H3-then-paragraph splits with ~80-token overlap. Runs on every wiki sync (`syncWikiFile()`); set `ARKEON_WIKI_CHUNKING=0` to disable.
+- `src/server/lib/embedding-queue.ts` — pure SQL helpers around `embedding_queue` (enqueue, claimNext, complete, fail, reclaimOrphans, queueStats, waitForDrain). Same lease pattern as `agent-queue.ts`.
+- `src/server/lib/embedder/` — the embedder runtime. `index.ts` resolves a singleton via `getEmbedder()` (Ollama auto-detect → mock fallback; `ARKEON_WIKI_EMBEDDER=mock|ollama` overrides). `mock.ts` is a deterministic SHA-derived embedder used in tests and as the no-runtime fallback. `ollama.ts` is the production HTTP backend (`embeddinggemma:300m` by default; `ARKEON_WIKI_OLLAMA_URL` / `ARKEON_WIKI_OLLAMA_MODEL` to customise). `worker.ts` claims entities off `embedding_queue`, embeds their chunks, and writes to `chunk_vectors` + `entity_embeddings`. The bundled-ONNX runtime + RRF query path land in follow-up PRs.
 
 ## API endpoints
 
@@ -117,8 +122,7 @@ Keyword search is filesystem-first: there is no keyword index in SQLite. The
 `--json` output, and join the matched paths back to entities. Results are
 ranked by `matched_lines` count.
 
-Vector / semantic search is planned next (sqlite-vec + EmbeddingGemma-300M)
-and will be fused with ripgrep results via reciprocal rank fusion.
+Vector / semantic search is in progress (issue #47). The chunker, queue, and embedder pipeline have landed: every wiki sync produces `entity_chunks` rows, enqueues the entity, and an in-process worker writes 256-dim embeddings into the `chunk_vectors` (sqlite-vec) virtual table via Ollama (auto-detected) or a deterministic mock fallback. The query path — query encoder, vector KNN, RRF fusion with ripgrep, public `/search` integration — and the bundled-ONNX runtime are still pending.
 
 ## Commands
 
@@ -169,11 +173,13 @@ Override the state dir with `ARKEON_WIKI_HOME` env var or `--data-dir`.
 
 ## Schema migrations
 
-`src/schema/*.sql`, applied in alphabetical order. Currently `001-foundation.sql` (entities, spaces, relationships, agent runtime) and `002-chunks.sql` (`entity_chunks`, populated on every wiki sync unless `ARKEON_WIKI_CHUNKING=0`). Must be idempotent (all `IF NOT EXISTS`). Runs on every startup.
+`src/schema/*.sql`, applied in alphabetical order. Currently `001-foundation.sql` (entities, spaces, relationships, agent runtime), `002-chunks.sql` (`entity_chunks`), and `003-embeddings.sql` (`chunk_vectors` vec0 table, `entity_embeddings` pivot, `embedding_queue`). Must be idempotent (all `IF NOT EXISTS`). Runs on every startup. Note: `003-embeddings.sql` requires the sqlite-vec extension to be loaded; `initDb()` does this automatically before migrations run.
 
 ## What's NOT here (yet)
 
-- No vector search (sqlite-vec + EmbeddingGemma planned, hybrid RRF with ripgrep)
+- No public vector-search query path. The pipeline writes embeddings; nothing queries them yet. RRF fusion with ripgrep and the `/search?mode=hybrid` integration are the next PR for issue #47.
+- No bundled ONNX runtime. Real embeddings require a local Ollama install + `ollama pull embeddinggemma:300m`. Without it, the worker falls back to a deterministic mock embedder that exercises the pipeline but is not semantically useful.
+- No per-chunk content-hash short-circuit. `syncWikiFile()` deletes and re-inserts every chunk on every wiki sync, so chunk_ids are ephemeral and the worker re-embeds the whole wiki on each save. Cheap during development, wasteful at scale — separate issue tracks the in-place upsert.
 - No FTS5 / BM25 ranking (ripgrep gives substring matching only)
 - No auth / API keys
 - No explorer (needs updating for new API)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3721,6 +3721,84 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sqlite-vec": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec/-/sqlite-vec-0.1.9.tgz",
+      "integrity": "sha512-L7XJWRIBNvR9O5+vh1FQ+IGkh/3D2AzVksW5gdtk28m78Hy8skFD0pqReKH1Yp0/BUKRGcffgKvyO/EON5JXpA==",
+      "license": "MIT OR Apache",
+      "optionalDependencies": {
+        "sqlite-vec-darwin-arm64": "0.1.9",
+        "sqlite-vec-darwin-x64": "0.1.9",
+        "sqlite-vec-linux-arm64": "0.1.9",
+        "sqlite-vec-linux-x64": "0.1.9",
+        "sqlite-vec-windows-x64": "0.1.9"
+      }
+    },
+    "node_modules/sqlite-vec-darwin-arm64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-arm64/-/sqlite-vec-darwin-arm64-0.1.9.tgz",
+      "integrity": "sha512-jSsZpE42OfBkGL/ItyJTVCUwl6o6Ka3U5rc4j+UBDIQzC1ulSSKMEhQLthsOnF/MdAf1MuAkYhkdKmmcjaIZQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-darwin-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-x64/-/sqlite-vec-darwin-x64-0.1.9.tgz",
+      "integrity": "sha512-KDlVyqQT7pnOhU1ymB9gs7dMbSoVmKHitT+k1/xkjarcX8bBqPxWrGlK/R+C5WmWkfvWwyq5FfXfiBYCBs6PlA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-linux-arm64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-arm64/-/sqlite-vec-linux-arm64-0.1.9.tgz",
+      "integrity": "sha512-5wXVJ9c9kR4CHm/wVqXb/R+XUHTdpZ4nWbPHlS+gc9qQFVHs92Km4bPnCKX4rtcPMzvNis+SIzMJR1SCEwpuUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sqlite-vec-linux-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-x64/-/sqlite-vec-linux-x64-0.1.9.tgz",
+      "integrity": "sha512-w3tCH8xK2finW8fQJ/m8uqKodXUZ9KAuAar2UIhz4BHILfpE0WM/MTGCRfa7RjYbrYim5Luk3guvMOGI7T7JQA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sqlite-vec-windows-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-windows-x64/-/sqlite-vec-windows-x64-0.1.9.tgz",
+      "integrity": "sha512-y3gEIyy/17bq2QFPQOWLE68TYWcRZkBQVA2XLrTPHNTOp55xJi/BBBmOm40tVMDMjtP+Elpk6UBUXdaq+46b0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -4909,6 +4987,7 @@
         "dotenv": "^17.3.1",
         "hono": "^4.12.9",
         "js-yaml": "^4.1.1",
+        "sqlite-vec": "^0.1.9",
         "zod": "^4.3.6"
       },
       "bin": {

--- a/packages/arkeon/package.json
+++ b/packages/arkeon/package.json
@@ -41,6 +41,7 @@
     "dotenv": "^17.3.1",
     "hono": "^4.12.9",
     "js-yaml": "^4.1.1",
+    "sqlite-vec": "^0.1.9",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/arkeon/src/schema/002-chunks.sql
+++ b/packages/arkeon/src/schema/002-chunks.sql
@@ -1,8 +1,8 @@
 -- 002-chunks.sql
 -- Per-wiki chunks for embedding-based search (issue #47).
--- This migration only sets up storage. The chunker itself is gated
--- behind ARKEON_WIKI_CHUNKING=1 (see syncWikiFile). The embedder
--- and vec0 virtual table arrive in follow-up PRs.
+-- The chunker runs on every wiki sync; opt out with
+-- ARKEON_WIKI_CHUNKING=0 (see syncWikiFile). The embedder and vec0
+-- virtual table arrive in follow-up PRs.
 
 CREATE TABLE IF NOT EXISTS entity_chunks (
   id            INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/packages/arkeon/src/schema/003-embeddings.sql
+++ b/packages/arkeon/src/schema/003-embeddings.sql
@@ -1,0 +1,50 @@
+-- 003-embeddings.sql
+-- Vector storage for chunk embeddings (issue #47).
+-- Requires the sqlite-vec extension to be loaded on the connection
+-- before this migration runs. initDb() in src/server/lib/sql.ts calls
+-- sqliteVec.load(db) immediately after opening the connection.
+--
+-- Two tables. Keeping the vector store and the metadata separate:
+--   - chunk_vectors holds just the float vectors. vec0 is a virtual
+--     table — no triggers, no FK *to* it, no ALTER. Joins via chunk_id.
+--   - entity_embeddings is a regular pivot tracking which model + which
+--     chunk content_hash produced each row, so we can detect stale
+--     embeddings and re-embed without dropping the vec0 row.
+
+CREATE VIRTUAL TABLE IF NOT EXISTS chunk_vectors USING vec0(
+  chunk_id INTEGER PRIMARY KEY,
+  embedding float[256] distance_metric=cosine
+);
+
+CREATE TABLE IF NOT EXISTS entity_embeddings (
+  chunk_id      INTEGER PRIMARY KEY REFERENCES entity_chunks(id) ON DELETE CASCADE,
+  model         TEXT NOT NULL,
+  content_hash  TEXT NOT NULL,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_embeddings_model
+  ON entity_embeddings(model);
+
+-- Per-entity work queue for the embedder. Watcher writes here after
+-- syncWikiFile finishes; a per-process worker drains it asynchronously.
+-- Lease pattern (started_at + 5min orphan reclaim) mirrors agent_queue
+-- so the same crash-safety reasoning applies.
+--
+-- UNIQUE(entity_id) coalesces rapid edits: if a wiki is saved 5 times
+-- before the first embedding run drains, the row is upserted (started_at
+-- reset) so we embed once against the latest chunks rather than queueing
+-- 5 redundant runs.
+CREATE TABLE IF NOT EXISTS embedding_queue (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  entity_id    TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+  enqueued_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  started_at   TEXT,
+  attempts     INTEGER NOT NULL DEFAULT 0,
+  last_error   TEXT,
+  UNIQUE(entity_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_embedding_queue_pending
+  ON embedding_queue(enqueued_at)
+  WHERE started_at IS NULL;

--- a/packages/arkeon/src/server/lib/embedder/index.ts
+++ b/packages/arkeon/src/server/lib/embedder/index.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Embedder runtime interface and selection (issue #47).
+ *
+ * `getEmbedder()` returns a singleton resolved at first use. The
+ * resolution order is:
+ *
+ *   1. ARKEON_WIKI_EMBEDDER override (mock | ollama). Forces a specific
+ *      backend; throws if unavailable.
+ *   2. Auto-detect: Ollama at localhost:11434 with the configured model
+ *      already pulled (fastest path when present).
+ *   3. Mock fallback. Logs a warning — vector search will be exercising
+ *      the pipeline, not real semantics.
+ *
+ * The ONNX runtime (transformers.js + EmbeddingGemma-300M, model cache,
+ * threadpool pinning) will land in a follow-up PR alongside the query
+ * path. Until then, real embeddings require a local Ollama install.
+ *
+ * Each backend exposes the same shape: `embed(texts) → Float32Array[]`,
+ * a `modelId` (used in entity_embeddings to detect stale rows when we
+ * swap models), and a `dim` (used to validate writes against the
+ * 256-dim vec0 schema).
+ *
+ * For tests we force the mock via env so CI doesn't depend on Ollama.
+ */
+
+export { type Embedder, type EmbedderKind, EMBEDDING_DIM } from "./types.js";
+
+import { type Embedder, type EmbedderKind } from "./types.js";
+
+let _embedder: Embedder | null = null;
+let _resolution: Promise<Embedder> | null = null;
+
+/**
+ * Resolve the embedder once and cache the singleton. Concurrent calls
+ * during the first resolution share the same promise.
+ */
+export function getEmbedder(): Promise<Embedder> {
+  if (_embedder) return Promise.resolve(_embedder);
+  if (_resolution) return _resolution;
+
+  _resolution = resolveEmbedder().then((e) => {
+    _embedder = e;
+    return e;
+  });
+  return _resolution;
+}
+
+/**
+ * Reset the cached singleton. Tests use this to switch backends between
+ * runs; also called from CLI commands that change the backend env var.
+ */
+export function resetEmbedder(): void {
+  _embedder = null;
+  _resolution = null;
+}
+
+async function resolveEmbedder(): Promise<Embedder> {
+  const override = process.env.ARKEON_WIKI_EMBEDDER as EmbedderKind | undefined;
+  if (override === "mock") {
+    const { MockEmbedder } = await import("./mock.js");
+    return new MockEmbedder();
+  }
+  if (override === "ollama") {
+    const { createOllamaEmbedder } = await import("./ollama.js");
+    return createOllamaEmbedder();
+  }
+
+  // Auto-detect: Ollama if reachable with the model pulled, else mock.
+  try {
+    const { tryOllama } = await import("./ollama.js");
+    const ollama = await tryOllama();
+    if (ollama) return ollama;
+  } catch {
+    // fall through
+  }
+
+  console.warn(
+    `[embedder] No real embedder available. Falling back to mock — ` +
+      `vector search will exercise the pipeline only, not real semantics. ` +
+      `Install Ollama (https://ollama.com) and pull the embeddinggemma ` +
+      `model for real embeddings, or wait for the bundled ONNX runtime in #47.`,
+  );
+  const { MockEmbedder } = await import("./mock.js");
+  return new MockEmbedder();
+}
+
+export { MockEmbedder } from "./mock.js";

--- a/packages/arkeon/src/server/lib/embedder/mock.ts
+++ b/packages/arkeon/src/server/lib/embedder/mock.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Deterministic mock embedder for tests and graceful fallback.
+ *
+ * Builds a 256-dim unit vector by hashing the input text into a
+ * sha256 digest, expanding it to fill the dimension, and L2-normalising
+ * so cosine distance is well-defined. Same text → same vector across
+ * runs and platforms. Not semantically meaningful — only useful to
+ * exercise the pipeline (write, store, look up) without pulling 200 MB
+ * of real weights into CI.
+ */
+
+import { createHash } from "node:crypto";
+import { type Embedder, EMBEDDING_DIM } from "./types.js";
+
+export class MockEmbedder implements Embedder {
+  readonly modelId = "mock@256";
+  readonly dim = EMBEDDING_DIM;
+
+  async embed(texts: string[]): Promise<Float32Array[]> {
+    return texts.map((text) => mockVector(text, this.dim));
+  }
+}
+
+function mockVector(text: string, dim: number): Float32Array {
+  // Stretch the 32-byte sha256 across `dim` floats by re-hashing with
+  // a counter until we have enough material. Each byte → one float.
+  const out = new Float32Array(dim);
+  let written = 0;
+  let counter = 0;
+  while (written < dim) {
+    const buf = createHash("sha256").update(`${counter}\n${text}`).digest();
+    for (let i = 0; i < buf.length && written < dim; i++) {
+      // Map [0, 255] → [-1, 1]
+      out[written++] = (buf[i] - 127.5) / 127.5;
+    }
+    counter++;
+  }
+
+  // L2-normalise so cosine distance behaves.
+  let mag = 0;
+  for (const v of out) mag += v * v;
+  mag = Math.sqrt(mag);
+  if (mag > 0) {
+    for (let i = 0; i < out.length; i++) out[i] /= mag;
+  }
+  return out;
+}

--- a/packages/arkeon/src/server/lib/embedder/ollama.ts
+++ b/packages/arkeon/src/server/lib/embedder/ollama.ts
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Ollama embedder (issue #47).
+ *
+ * Talks to a locally-running Ollama daemon via its HTTP API. Used when:
+ *   - The user has Ollama installed and the embeddinggemma model pulled.
+ *   - Forced via ARKEON_WIKI_EMBEDDER=ollama.
+ *
+ * `tryOllama()` is the auto-detect path: it returns a configured
+ * embedder if both the daemon is reachable and the model is present,
+ * else null. We never auto-pull — pulling 200 MB without warning isn't
+ * okay. The user must `ollama pull embeddinggemma:300m` first.
+ *
+ * Customise host/port/model via:
+ *   ARKEON_WIKI_OLLAMA_URL=http://localhost:11434
+ *   ARKEON_WIKI_OLLAMA_MODEL=embeddinggemma:300m
+ */
+
+import { type Embedder, EMBEDDING_DIM } from "./types.js";
+
+const DEFAULT_URL = "http://localhost:11434";
+const DEFAULT_MODEL = "embeddinggemma:300m";
+
+interface OllamaEmbedResponse {
+  embeddings: number[][];
+}
+
+interface OllamaTagsResponse {
+  models?: Array<{ name?: string; model?: string }>;
+}
+
+class OllamaEmbedder implements Embedder {
+  readonly modelId: string;
+  readonly dim = EMBEDDING_DIM;
+
+  constructor(
+    private readonly url: string,
+    private readonly model: string,
+  ) {
+    this.modelId = `ollama:${model}@${EMBEDDING_DIM}`;
+  }
+
+  async embed(texts: string[]): Promise<Float32Array[]> {
+    if (texts.length === 0) return [];
+
+    const res = await fetch(`${this.url}/api/embed`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: this.model,
+        input: texts,
+        // EmbeddingGemma supports Matryoshka — request 256d explicitly so
+        // we don't waste bytes round-tripping the full 768d.
+        options: { dimensions: EMBEDDING_DIM },
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(
+        `Ollama embed failed (${res.status} ${res.statusText}): ${body.slice(0, 200)}`,
+      );
+    }
+
+    const json = (await res.json()) as OllamaEmbedResponse;
+    if (!Array.isArray(json.embeddings) || json.embeddings.length !== texts.length) {
+      throw new Error(
+        `Ollama returned ${json.embeddings?.length ?? 0} vectors for ${texts.length} inputs`,
+      );
+    }
+
+    return json.embeddings.map((v) => {
+      if (v.length !== EMBEDDING_DIM) {
+        throw new Error(
+          `Ollama returned ${v.length}-dim vector, expected ${EMBEDDING_DIM}. ` +
+            `If your model doesn't support Matryoshka truncation, swap to embeddinggemma:300m.`,
+        );
+      }
+      return new Float32Array(v);
+    });
+  }
+}
+
+export function createOllamaEmbedder(): Embedder {
+  const url = process.env.ARKEON_WIKI_OLLAMA_URL ?? DEFAULT_URL;
+  const model = process.env.ARKEON_WIKI_OLLAMA_MODEL ?? DEFAULT_MODEL;
+  return new OllamaEmbedder(url, model);
+}
+
+/**
+ * Auto-detect helper. Returns an embedder if Ollama is reachable AND
+ * the configured model is present locally. Returns null otherwise —
+ * never throws — so the resolver can cleanly fall through to the next
+ * backend.
+ */
+export async function tryOllama(): Promise<Embedder | null> {
+  const url = process.env.ARKEON_WIKI_OLLAMA_URL ?? DEFAULT_URL;
+  const model = process.env.ARKEON_WIKI_OLLAMA_MODEL ?? DEFAULT_MODEL;
+
+  let tags: OllamaTagsResponse;
+  try {
+    const res = await fetch(`${url}/api/tags`, {
+      signal: AbortSignal.timeout(500),
+    });
+    if (!res.ok) return null;
+    tags = (await res.json()) as OllamaTagsResponse;
+  } catch {
+    return null;
+  }
+
+  const models = tags.models ?? [];
+  const present = models.some(
+    (m) => m.name === model || m.model === model,
+  );
+  if (!present) return null;
+
+  return new OllamaEmbedder(url, model);
+}

--- a/packages/arkeon/src/server/lib/embedder/types.ts
+++ b/packages/arkeon/src/server/lib/embedder/types.ts
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Embedder types and shared constants. Lives in its own module so
+ * concrete backends (mock, ollama, future onnx) can import without
+ * pulling in the resolver and creating a cycle.
+ */
+
+export interface Embedder {
+  /** Stable identifier of the model+dim pair, e.g. "embeddinggemma-300m@256". */
+  readonly modelId: string;
+  /** Vector dimensionality. Asserted to match the vec0 schema (256). */
+  readonly dim: number;
+  /** Embed a batch. Returned vectors are length === dim. */
+  embed(texts: string[]): Promise<Float32Array[]>;
+}
+
+/** Vec0 column dimension. Don't change without a schema migration. */
+export const EMBEDDING_DIM = 256;
+
+export type EmbedderKind = "mock" | "ollama";

--- a/packages/arkeon/src/server/lib/embedder/worker.ts
+++ b/packages/arkeon/src/server/lib/embedder/worker.ts
@@ -1,0 +1,242 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Embedding worker (issue #47).
+ *
+ * Drains the embedding_queue: for each claimed entity, fetches the
+ * chunks whose content_hash differs from the pivot's stored hash,
+ * embeds them, and upserts entity_embeddings + chunk_vectors. Chunks
+ * removed from the wiki are also purged here (vec0 + pivot rows whose
+ * chunk_id no longer exists in entity_chunks — guaranteed by the
+ * pivot's ON DELETE CASCADE, so we just need to clean up vec0).
+ *
+ * The worker is a single, in-process loop. There's no concurrency
+ * within a process — Ollama calls and ONNX model invocations both want
+ * a serialized batch path, and the queue's UNIQUE(entity_id) constraint
+ * already coalesces concurrent edits.
+ */
+
+import { createSql, getDb } from "./../sql.js";
+import { getEmbedder } from "./index.js";
+import { EMBEDDING_DIM } from "./types.js";
+import {
+  claimNext,
+  complete,
+  fail,
+  reclaimOrphans,
+} from "./../embedding-queue.js";
+
+interface ChunkRow {
+  id: number;
+  text: string;
+  content_hash: string;
+}
+
+interface PivotRow {
+  chunk_id: number;
+  model: string;
+  content_hash: string;
+}
+
+/**
+ * Try to drain one item off the queue. Returns true if an item was
+ * processed (success or failure recorded), false if the queue was
+ * empty. Callers loop until `false` to fully drain.
+ */
+export async function drainOne(): Promise<boolean> {
+  const item = await claimNext();
+  if (!item) return false;
+
+  try {
+    await embedEntity(item.entity_id);
+    await complete(item.id);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    await fail(item.id, msg);
+    console.error(
+      `[embedder] failed to embed entity ${item.entity_id}: ${msg}`,
+    );
+  }
+  return true;
+}
+
+/**
+ * Drain the queue until empty. Used by reindex CLI and tests.
+ */
+export async function drain(): Promise<void> {
+  while (await drainOne()) {
+    // tight loop; each call awaits its own embedder + DB write
+  }
+}
+
+/**
+ * Find chunks whose stored embedding is missing or stale (different
+ * content_hash or different model), embed only those, and upsert. Also
+ * purges vec0 rows for chunks that no longer exist in entity_chunks.
+ *
+ * Splits the work into:
+ *   1. Identify stale + new chunks → embed → upsert pivot + vec0.
+ *   2. Identify orphaned vec0 rows (chunks gone from entity_chunks via
+ *      cascade) → DELETE from chunk_vectors.
+ *
+ * Wraps step 1 in a transaction so a partial failure doesn't leave
+ * pivot/vec0 out of sync. vec0 doesn't support nested transactions
+ * the way regular tables do, but DELETE/INSERT inside an outer
+ * BEGIN/COMMIT works in practice (sqlite-vec docs).
+ */
+async function embedEntity(entityId: string): Promise<void> {
+  const embedder = await getEmbedder();
+  if (embedder.dim !== EMBEDDING_DIM) {
+    throw new Error(
+      `embedder dim=${embedder.dim} doesn't match vec0 schema dim=${EMBEDDING_DIM}`,
+    );
+  }
+
+  const sql = createSql();
+
+  const chunkRows = (await sql`
+    SELECT id, text, content_hash
+    FROM entity_chunks
+    WHERE entity_id = ${entityId}
+    ORDER BY chunk_index
+  `) as unknown as ChunkRow[];
+
+  const pivotRows = (await sql`
+    SELECT chunk_id, model, content_hash
+    FROM entity_embeddings
+    WHERE chunk_id IN (
+      SELECT id FROM entity_chunks WHERE entity_id = ${entityId}
+    )
+  `) as unknown as PivotRow[];
+
+  const pivotByChunk = new Map(pivotRows.map((p) => [p.chunk_id, p]));
+
+  const toEmbed: ChunkRow[] = [];
+  for (const chunk of chunkRows) {
+    const pivot = pivotByChunk.get(chunk.id);
+    if (
+      !pivot ||
+      pivot.model !== embedder.modelId ||
+      pivot.content_hash !== chunk.content_hash
+    ) {
+      toEmbed.push(chunk);
+    }
+  }
+
+  if (toEmbed.length > 0) {
+    const vectors = await embedder.embed(toEmbed.map((c) => c.text));
+    const db = getDb();
+
+    // sqlite-vec's PRIMARY KEY validator rejects integers bound through
+    // better-sqlite3's parameter path (verified empirically against
+    // sqlite-vec 0.1.9 — variant test reproduced the failure for both
+    // `chunk_id INTEGER PRIMARY KEY` and `rowid` columns). Inlining the
+    // integer as a SQL literal is the documented workaround. chunk_id
+    // comes from entity_chunks.id (INTEGER PRIMARY KEY AUTOINCREMENT)
+    // so there's no injection surface — the worst a malformed value
+    // could do is fail Number()-coercion below.
+    const upsertPivot = db.prepare(`
+      INSERT INTO entity_embeddings (chunk_id, model, content_hash)
+      VALUES (?, ?, ?)
+      ON CONFLICT(chunk_id) DO UPDATE SET
+        model = excluded.model,
+        content_hash = excluded.content_hash,
+        created_at = datetime('now')
+    `);
+
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      for (let i = 0; i < toEmbed.length; i++) {
+        const chunk = toEmbed[i];
+        const vec = vectors[i];
+        if (vec.length !== EMBEDDING_DIM) {
+          throw new Error(
+            `embedder returned ${vec.length}-dim vector for chunk ${chunk.id}, expected ${EMBEDDING_DIM}`,
+          );
+        }
+        const id = Number(chunk.id);
+        if (!Number.isInteger(id)) {
+          throw new Error(`chunk.id is not an integer: ${chunk.id}`);
+        }
+        db.prepare(`DELETE FROM chunk_vectors WHERE chunk_id = ${id}`).run();
+        db.prepare(`INSERT INTO chunk_vectors(chunk_id, embedding) VALUES (${id}, ?)`).run(
+          Buffer.from(vec.buffer, vec.byteOffset, vec.byteLength),
+        );
+        upsertPivot.run(id, embedder.modelId, chunk.content_hash);
+      }
+      db.exec("COMMIT");
+    } catch (err) {
+      db.exec("ROLLBACK");
+      throw err;
+    }
+  }
+
+  // Purge vec0 rows whose chunk_id no longer exists. The pivot's
+  // ON DELETE CASCADE handles entity_embeddings; vec0 needs an
+  // explicit cleanup. Same parameterized-PK limitation as above —
+  // inline the chunk_id as a literal (it's an integer we just
+  // selected from chunk_vectors).
+  const db = getDb();
+  const orphanRows = await sql`
+    SELECT cv.chunk_id
+    FROM chunk_vectors cv
+    LEFT JOIN entity_chunks ec ON ec.id = cv.chunk_id
+    WHERE ec.id IS NULL
+  `;
+  for (const o of orphanRows) {
+    const id = Number(o.chunk_id);
+    if (!Number.isInteger(id)) continue;
+    db.prepare(`DELETE FROM chunk_vectors WHERE chunk_id = ${id}`).run();
+  }
+}
+
+/**
+ * Background loop. Reclaims orphans on startup, then polls the queue
+ * forever. Calling stop() resolves the loop on its next iteration.
+ *
+ * Started by the daemon's lifecycle alongside the file watcher.
+ */
+export interface WorkerHandle {
+  stop: () => Promise<void>;
+}
+
+export function startEmbeddingWorker(opts: {
+  pollIntervalMs?: number;
+} = {}): WorkerHandle {
+  const pollMs = opts.pollIntervalMs ?? 500;
+  let running = true;
+  let active: Promise<void> = Promise.resolve();
+
+  active = (async () => {
+    try {
+      const reclaimed = await reclaimOrphans();
+      if (reclaimed > 0) {
+        console.log(`[embedder] reclaimed ${reclaimed} orphaned queue rows`);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[embedder] reclaim on startup failed: ${msg}`);
+    }
+
+    while (running) {
+      try {
+        const drained = await drainOne();
+        if (!drained) {
+          await new Promise((r) => setTimeout(r, pollMs));
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[embedder] worker loop error: ${msg}`);
+        await new Promise((r) => setTimeout(r, pollMs));
+      }
+    }
+  })();
+
+  return {
+    stop: async () => {
+      running = false;
+      await active;
+    },
+  };
+}

--- a/packages/arkeon/src/server/lib/embedder/worker.ts
+++ b/packages/arkeon/src/server/lib/embedder/worker.ts
@@ -5,16 +5,23 @@
  * Embedding worker (issue #47).
  *
  * Drains the embedding_queue: for each claimed entity, fetches the
- * chunks whose content_hash differs from the pivot's stored hash,
- * embeds them, and upserts entity_embeddings + chunk_vectors. Chunks
- * removed from the wiki are also purged here (vec0 + pivot rows whose
- * chunk_id no longer exists in entity_chunks — guaranteed by the
- * pivot's ON DELETE CASCADE, so we just need to clean up vec0).
+ * chunks whose content_hash differs from the pivot's stored hash, and
+ * upserts entity_embeddings + chunk_vectors for the diff. Removed
+ * chunks are cleaned up at the source — syncWikiFile deletes their
+ * chunk_vectors and entity_chunks rows in the same transaction (the
+ * pivot cascades), so this loop only ever inserts.
  *
  * The worker is a single, in-process loop. There's no concurrency
  * within a process — Ollama calls and ONNX model invocations both want
  * a serialized batch path, and the queue's UNIQUE(entity_id) constraint
  * already coalesces concurrent edits.
+ *
+ * Two SQL APIs are used in tandem: createSql() for tagged-template
+ * reads (chunks, pivots) and getDb()/db.prepare() for chunk_vectors
+ * INSERTs. The latter is the documented workaround for sqlite-vec
+ * 0.1.9's PRIMARY KEY validator, which rejects integers bound through
+ * better-sqlite3's parameter path on virtual-table xUpdate. Inlining
+ * the validated chunk_id as a SQL literal sidesteps the binding path.
  */
 
 import { createSql, getDb } from "./../sql.js";
@@ -75,15 +82,11 @@ export async function drain(): Promise<void> {
  * content_hash or different model), embed only those, and upsert. Also
  * purges vec0 rows for chunks that no longer exist in entity_chunks.
  *
- * Splits the work into:
- *   1. Identify stale + new chunks → embed → upsert pivot + vec0.
- *   2. Identify orphaned vec0 rows (chunks gone from entity_chunks via
- *      cascade) → DELETE from chunk_vectors.
- *
- * Wraps step 1 in a transaction so a partial failure doesn't leave
- * pivot/vec0 out of sync. vec0 doesn't support nested transactions
- * the way regular tables do, but DELETE/INSERT inside an outer
- * BEGIN/COMMIT works in practice (sqlite-vec docs).
+ * Identifies stale + new chunks (by content_hash and embedder modelId)
+ * and embeds + upserts pivot + vec0 in a single transaction so a
+ * partial failure doesn't leave pivot/vec0 out of sync. Removed chunks
+ * are cleaned up at the source by syncWikiFile, so this loop never
+ * has to scan for orphans.
  */
 async function embedEntity(entityId: string): Promise<void> {
   const embedder = await getEmbedder();
@@ -170,24 +173,6 @@ async function embedEntity(entityId: string): Promise<void> {
       db.exec("ROLLBACK");
       throw err;
     }
-  }
-
-  // Purge vec0 rows whose chunk_id no longer exists. The pivot's
-  // ON DELETE CASCADE handles entity_embeddings; vec0 needs an
-  // explicit cleanup. Same parameterized-PK limitation as above —
-  // inline the chunk_id as a literal (it's an integer we just
-  // selected from chunk_vectors).
-  const db = getDb();
-  const orphanRows = await sql`
-    SELECT cv.chunk_id
-    FROM chunk_vectors cv
-    LEFT JOIN entity_chunks ec ON ec.id = cv.chunk_id
-    WHERE ec.id IS NULL
-  `;
-  for (const o of orphanRows) {
-    const id = Number(o.chunk_id);
-    if (!Number.isInteger(id)) continue;
-    db.prepare(`DELETE FROM chunk_vectors WHERE chunk_id = ${id}`).run();
   }
 }
 

--- a/packages/arkeon/src/server/lib/embedding-queue.ts
+++ b/packages/arkeon/src/server/lib/embedding-queue.ts
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pure SQL helpers for the embedding queue (issue #47).
+ *
+ * Same lease-pattern queue as agent-queue.ts, scoped to a single
+ * concern: "this entity's chunks need re-embedding." The shape is
+ * (entity_id) — there's no per-role concept here, just one worker.
+ *
+ *   pending  (started_at IS NULL)
+ *     ↓ claim
+ *   in_flight (started_at = NOW)
+ *     ├─ on success → row DELETEd
+ *     └─ on failure → started_at = NULL, last_error set, attempts++
+ *
+ * Coalescing: rapid edits to the same wiki upsert the row, so 5 saves
+ * before the queue drains turns into one embed against the latest
+ * chunks. Stale-vs-fresh detection happens inside the worker by
+ * comparing entity_chunks.content_hash to entity_embeddings.content_hash
+ * — see embedder/worker.ts.
+ */
+
+import { createSql } from "./sql.js";
+
+export interface EmbeddingQueueItem {
+  id: number;
+  entity_id: string;
+  enqueued_at: string;
+  started_at: string | null;
+  attempts: number;
+  last_error: string | null;
+}
+
+export const ORPHAN_LEASE_MINUTES = 5;
+export const MAX_ATTEMPTS = 5;
+
+/**
+ * Insert or coalesce a pending row for an entity. Resets started_at
+ * and attempts on conflict so a previously-failed entity gets retried
+ * the next time it's saved.
+ */
+export async function enqueueEntity(entityId: string): Promise<number> {
+  const sql = createSql();
+  const rows = await sql`
+    INSERT INTO embedding_queue (entity_id)
+    VALUES (${entityId})
+    ON CONFLICT(entity_id) DO UPDATE SET
+      enqueued_at = datetime('now'),
+      started_at = NULL,
+      attempts = 0,
+      last_error = NULL
+    RETURNING id
+  `;
+  return rows[0].id as number;
+}
+
+/**
+ * Atomically claim the next pending entity. Returns null if the queue
+ * is empty or every pending row has hit MAX_ATTEMPTS.
+ */
+export async function claimNext(): Promise<EmbeddingQueueItem | null> {
+  const sql = createSql();
+  const rows = await sql`
+    UPDATE embedding_queue
+    SET started_at = datetime('now'), attempts = attempts + 1
+    WHERE id = (
+      SELECT id FROM embedding_queue
+      WHERE started_at IS NULL
+        AND attempts < ${MAX_ATTEMPTS}
+      ORDER BY enqueued_at
+      LIMIT 1
+    )
+    RETURNING *
+  `;
+  if (rows.length === 0) return null;
+  return rowToItem(rows[0]);
+}
+
+export async function complete(id: number): Promise<void> {
+  const sql = createSql();
+  await sql`DELETE FROM embedding_queue WHERE id = ${id}`;
+}
+
+export async function fail(id: number, errorMessage: string): Promise<void> {
+  const sql = createSql();
+  await sql`
+    UPDATE embedding_queue
+    SET started_at = NULL, last_error = ${errorMessage}
+    WHERE id = ${id}
+  `;
+}
+
+/**
+ * Reset rows whose started_at is older than the lease TTL — they
+ * belong to a worker that crashed mid-run. Returns the number of
+ * rows reclaimed. Run on daemon startup.
+ */
+export async function reclaimOrphans(
+  leaseMinutes: number = ORPHAN_LEASE_MINUTES,
+): Promise<number> {
+  const sql = createSql();
+  const cutoff = `-${leaseMinutes} minutes`;
+  const rows = await sql`
+    UPDATE embedding_queue
+    SET started_at = NULL,
+        last_error = 'reclaimed: lease expired (worker crash?)'
+    WHERE started_at IS NOT NULL
+      AND started_at < datetime('now', ${cutoff})
+    RETURNING id
+  `;
+  return rows.length;
+}
+
+/** Diagnostic counts. */
+export async function queueStats(): Promise<{ pending: number; in_flight: number }> {
+  const sql = createSql();
+  const rows = await sql`
+    SELECT
+      SUM(CASE WHEN started_at IS NULL THEN 1 ELSE 0 END) AS pending,
+      SUM(CASE WHEN started_at IS NOT NULL THEN 1 ELSE 0 END) AS in_flight
+    FROM embedding_queue
+  `;
+  return {
+    pending: Number(rows[0]?.pending ?? 0),
+    in_flight: Number(rows[0]?.in_flight ?? 0),
+  };
+}
+
+/**
+ * Block until the queue is empty (no pending and no in-flight rows).
+ * Used by the reindex CLI and tests. Polls every 100ms.
+ */
+export async function waitForDrain(timeoutMs = 60_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const stats = await queueStats();
+    if (stats.pending === 0 && stats.in_flight === 0) return;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  const stats = await queueStats();
+  throw new Error(
+    `embedding queue did not drain within ${timeoutMs}ms ` +
+      `(pending=${stats.pending}, in_flight=${stats.in_flight})`,
+  );
+}
+
+function rowToItem(row: Record<string, unknown>): EmbeddingQueueItem {
+  return {
+    id: row.id as number,
+    entity_id: row.entity_id as string,
+    enqueued_at: row.enqueued_at as string,
+    started_at: (row.started_at as string | null) ?? null,
+    attempts: row.attempts as number,
+    last_error: (row.last_error as string | null) ?? null,
+  };
+}

--- a/packages/arkeon/src/server/lib/sql.ts
+++ b/packages/arkeon/src/server/lib/sql.ts
@@ -3,6 +3,7 @@
 
 import Database from "better-sqlite3";
 import type { Database as DatabaseType } from "better-sqlite3";
+import * as sqliteVec from "sqlite-vec";
 
 type Row = Record<string, unknown>;
 
@@ -18,6 +19,23 @@ export function initDb(path: string): DatabaseType {
   _db = new Database(path);
   _db.pragma("journal_mode = WAL");
   _db.pragma("foreign_keys = ON");
+
+  // sqlite-vec must be loaded before any prepared statement that touches
+  // vec0 functions or the migration that creates `chunk_vectors`. The
+  // helper wraps db.loadExtension() with the right binary path resolved
+  // from the platform-specific optional dependencies.
+  try {
+    sqliteVec.load(_db);
+    _db.prepare("SELECT vec_version()").get();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Failed to load sqlite-vec extension: ${msg}. ` +
+        `If you are running on an unsupported platform (e.g. Alpine/musl), ` +
+        `embeddings will not work; rebuild against a supported runtime.`,
+    );
+  }
+
   return _db;
 }
 

--- a/packages/arkeon/src/server/lib/sync.ts
+++ b/packages/arkeon/src/server/lib/sync.ts
@@ -174,24 +174,76 @@ async function syncWikiFile(
 
     if (chunkingEnabled()) {
       const chunks = chunkWiki(parsed, label);
-      await tx`DELETE FROM entity_chunks WHERE entity_id = ${entityId}`;
-      for (const c of chunks) {
-        await tx`
-          INSERT INTO entity_chunks
-            (entity_id, chunk_index, chunk_kind, heading_path,
-             start_line, end_line, text, content_hash)
-          VALUES (
-            ${entityId},
-            ${c.chunk_index},
-            ${c.chunk_kind},
-            ${c.heading_path},
-            ${c.start_line},
-            ${c.end_line},
-            ${c.text},
-            ${c.content_hash}
-          )
-        `;
+
+      // Diff-based upsert keyed on (entity_id, content_hash) — keeps
+      // chunk_ids stable for unchanged content so entity_embeddings (and
+      // therefore chunk_vectors) survive across edits. The plain
+      // DELETE+INSERT we used before threw away cascaded pivot rows on
+      // every save and forced a full re-embed of the wiki even when only
+      // one paragraph changed.
+      //
+      // The UNIQUE(entity_id, chunk_index) constraint complicates the
+      // shuffle when chunks reorder (e.g. a new section inserted between
+      // two existing ones bumps every chunk_index after it). Negate every
+      // chunk_index first so the positive-integer space is free; then do
+      // UPDATEs and INSERTs to the new positive indices; then DELETE any
+      // row left at a negative index — that's a chunk no longer present.
+      const existingRows = (await tx`
+        SELECT id, content_hash
+        FROM entity_chunks
+        WHERE entity_id = ${entityId}
+      `) as Array<{ id: number; content_hash: string }>;
+
+      const existingByHash = new Map<string, number[]>();
+      for (const r of existingRows) {
+        const ids = existingByHash.get(r.content_hash);
+        if (ids) ids.push(r.id);
+        else existingByHash.set(r.content_hash, [r.id]);
       }
+
+      await tx`
+        UPDATE entity_chunks
+        SET chunk_index = -chunk_index - 1
+        WHERE entity_id = ${entityId}
+      `;
+
+      for (const c of chunks) {
+        const candidates = existingByHash.get(c.content_hash);
+        if (candidates && candidates.length > 0) {
+          const id = candidates.shift()!;
+          await tx`
+            UPDATE entity_chunks SET
+              chunk_index = ${c.chunk_index},
+              chunk_kind = ${c.chunk_kind},
+              heading_path = ${c.heading_path},
+              start_line = ${c.start_line},
+              end_line = ${c.end_line},
+              text = ${c.text}
+            WHERE id = ${id}
+          `;
+        } else {
+          await tx`
+            INSERT INTO entity_chunks
+              (entity_id, chunk_index, chunk_kind, heading_path,
+               start_line, end_line, text, content_hash)
+            VALUES (
+              ${entityId},
+              ${c.chunk_index},
+              ${c.chunk_kind},
+              ${c.heading_path},
+              ${c.start_line},
+              ${c.end_line},
+              ${c.text},
+              ${c.content_hash}
+            )
+          `;
+        }
+      }
+
+      await tx`
+        DELETE FROM entity_chunks
+        WHERE entity_id = ${entityId} AND chunk_index < 0
+      `;
     }
 
     return { linksResolved, linksDangling };

--- a/packages/arkeon/src/server/lib/sync.ts
+++ b/packages/arkeon/src/server/lib/sync.ts
@@ -19,6 +19,7 @@ import { generateUlid } from "./ids.js";
 import { parseFrontmatter, serializeFrontmatter } from "./frontmatter.js";
 import { extractMarkdownLinks, resolveRelativeLink } from "./markdown-links.js";
 import { chunkWiki } from "./chunker.js";
+import { enqueueEntity } from "./embedding-queue.js";
 
 // Issue #47 — chunking is on by default. Set ARKEON_WIKI_CHUNKING=0 to
 // skip writes to entity_chunks (e.g. for tarball smoke tests that don't
@@ -26,6 +27,14 @@ import { chunkWiki } from "./chunker.js";
 // CLI flags can flip it after the module is imported.
 function chunkingEnabled(): boolean {
   return process.env.ARKEON_WIKI_CHUNKING !== "0";
+}
+
+// Issue #47 — embeddings are also on by default but require an embedder
+// runtime. The mock fallback exercises the pipeline; for real semantic
+// search the user needs Ollama (or wait for the bundled ONNX runtime in
+// a follow-up). Set ARKEON_WIKI_EMBEDDINGS=0 to skip the queue entirely.
+function embeddingsEnabled(): boolean {
+  return process.env.ARKEON_WIKI_EMBEDDINGS !== "0" && chunkingEnabled();
 }
 
 export interface Space {
@@ -187,6 +196,21 @@ async function syncWikiFile(
 
     return { linksResolved, linksDangling };
   });
+
+  // Hand off to the embedding worker (issue #47). Outside the
+  // transaction so a slow embedder can't hold the write lock. The
+  // worker re-checks each chunk's content_hash against the pivot
+  // before re-embedding, so this is cheap in the no-changes case.
+  if (embeddingsEnabled()) {
+    try {
+      await enqueueEntity(entityId);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(
+        `[sync] failed to enqueue ${entityId} for embedding: ${msg}`,
+      );
+    }
+  }
 
   // If we generated a new ID, write it back to the file's frontmatter
   if (isNew) {

--- a/packages/arkeon/src/server/lib/sync.ts
+++ b/packages/arkeon/src/server/lib/sync.ts
@@ -20,12 +20,12 @@ import { parseFrontmatter, serializeFrontmatter } from "./frontmatter.js";
 import { extractMarkdownLinks, resolveRelativeLink } from "./markdown-links.js";
 import { chunkWiki } from "./chunker.js";
 
-// Issue #47 — opt-in until the embedder + vec0 index land. Setting
-// ARKEON_WIKI_CHUNKING=1 makes syncWikiFile populate entity_chunks.
-// Read at call time, not module load, so tests and CLI flags can flip
-// it after the module is imported.
+// Issue #47 — chunking is on by default. Set ARKEON_WIKI_CHUNKING=0 to
+// skip writes to entity_chunks (e.g. for tarball smoke tests that don't
+// need the chunker). Read at call time, not module load, so tests and
+// CLI flags can flip it after the module is imported.
 function chunkingEnabled(): boolean {
-  return process.env.ARKEON_WIKI_CHUNKING === "1";
+  return process.env.ARKEON_WIKI_CHUNKING !== "0";
 }
 
 export interface Space {

--- a/packages/arkeon/src/server/lib/sync.ts
+++ b/packages/arkeon/src/server/lib/sync.ts
@@ -240,6 +240,17 @@ async function syncWikiFile(
         }
       }
 
+      // chunk_ids left as un-claimed candidates are about to be deleted.
+      // entity_embeddings cascades from entity_chunks; chunk_vectors is a
+      // virtual table without FK support so we delete its rows directly.
+      // Doing this here (instead of as a periodic worker scan) means the
+      // embedder loop never has to do a global LEFT JOIN to find orphans.
+      const droppedIds: number[] = [];
+      for (const ids of existingByHash.values()) droppedIds.push(...ids);
+      for (const id of droppedIds) {
+        await tx`DELETE FROM chunk_vectors WHERE chunk_id = ${id}`;
+      }
+
       await tx`
         DELETE FROM entity_chunks
         WHERE entity_id = ${entityId} AND chunk_index < 0

--- a/packages/arkeon/src/server/server.ts
+++ b/packages/arkeon/src/server/server.ts
@@ -15,6 +15,7 @@ import { createApp } from "./app.js";
 import { loadAgentEnv } from "./agents/env-loader.js";
 import { startAllWatchers, stopAllWatchers } from "./lib/fs-watcher.js";
 import { initDb, closeDb } from "./lib/sql.js";
+import { startEmbeddingWorker, type WorkerHandle } from "./lib/embedder/worker.js";
 
 export interface ArkeonApiConfig {
   port?: number;
@@ -50,10 +51,20 @@ export async function startApi(config: ArkeonApiConfig = {}): Promise<ArkeonApi>
   // Start file watchers for all registered spaces
   await startAllWatchers();
 
+  // Start the embedding worker (issue #47). Runs alongside the watcher;
+  // drains embedding_queue until stop() is called. Disable entirely with
+  // ARKEON_WIKI_EMBEDDINGS=0 (e.g. for tarball smoke tests that don't
+  // need embeddings).
+  let embeddingWorker: WorkerHandle | null = null;
+  if (process.env.ARKEON_WIKI_EMBEDDINGS !== "0") {
+    embeddingWorker = startEmbeddingWorker();
+  }
+
   async function stop(opts: { drainTimeoutMs?: number } = {}): Promise<void> {
     const DRAIN_TIMEOUT_MS = opts.drainTimeoutMs ?? 10_000;
 
     await stopAllWatchers();
+    if (embeddingWorker) await embeddingWorker.stop();
     closeDb();
 
     const drainPromise = new Promise<void>((resolve, reject) =>

--- a/packages/arkeon/test/e2e/embeddings.test.ts
+++ b/packages/arkeon/test/e2e/embeddings.test.ts
@@ -20,7 +20,7 @@ import yaml from "js-yaml";
 import { createSql } from "../../src/server/lib/sql.js";
 import { waitForEntityBySourcePath } from "./helpers.js";
 import { waitForDrain, queueStats } from "../../src/server/lib/embedding-queue.js";
-import { EMBEDDING_DIM } from "../../src/server/lib/embedder/index.js";
+import { EMBEDDING_DIM, resetEmbedder } from "../../src/server/lib/embedder/index.js";
 
 const API_PORT = 18791;
 const BASE_URL = `http://localhost:${API_PORT}`;
@@ -130,6 +130,10 @@ afterAll(async () => {
   } else {
     process.env.ARKEON_WIKI_EMBEDDER = prevEmbedderEnv;
   }
+  // Clear the module-level embedder singleton so a later test file in
+  // the same vitest process (isolate: false) doesn't get our cached
+  // mock when it expects to resolve fresh.
+  resetEmbedder();
 }, 30_000);
 
 describe("embedding pipeline (mock embedder)", () => {

--- a/packages/arkeon/test/e2e/embeddings.test.ts
+++ b/packages/arkeon/test/e2e/embeddings.test.ts
@@ -47,6 +47,7 @@ interface PivotRow {
   chunk_id: number;
   model: string;
   content_hash: string;
+  created_at: string;
 }
 
 interface ChunkRow {
@@ -68,7 +69,7 @@ async function getChunks(entityId: string): Promise<ChunkRow[]> {
 async function getPivots(entityId: string): Promise<PivotRow[]> {
   const sql = createSql();
   return (await sql`
-    SELECT chunk_id, model, content_hash
+    SELECT chunk_id, model, content_hash, created_at
     FROM entity_embeddings
     WHERE chunk_id IN (
       SELECT id FROM entity_chunks WHERE entity_id = ${entityId}
@@ -171,16 +172,28 @@ describe("embedding pipeline (mock embedder)", () => {
     }
   });
 
-  it("re-embeds the whole wiki on edit (per-chunk caching is a follow-up)", async () => {
-    // sync.ts DELETEs+re-INSERTs entity_chunks on every wiki write,
-    // which assigns fresh AUTOINCREMENT chunk_ids. The content_hash
-    // column exists on entity_chunks + entity_embeddings so a future
-    // worker can match unchanged content across re-creations and skip
-    // the embed call. For now, every sync re-embeds every chunk.
+  it("preserves embeddings for unchanged sections; re-embeds only the changed one", async () => {
+    // The cache hit. syncWikiFile diffs new chunks against existing rows
+    // by content_hash and updates in place — chunk_ids stay stable for
+    // unchanged content, so entity_embeddings rows survive and the
+    // worker's content_hash short-circuit fires. Only the edited section
+    // gets a fresh pivot row (new content_hash → re-embed → new
+    // created_at).
     const entity = await waitForEntityBySourcePath(spaceId, "wiki/person/shannon.md");
-    const beforeChunkIds = new Set(
-      (await getChunks(entity.id)).map((c) => c.id),
-    );
+    const beforeChunks = await getChunks(entity.id);
+    const beforePivots = await getPivots(entity.id);
+    const beforePivotByChunkId = new Map(beforePivots.map((p) => [p.chunk_id, p]));
+
+    // Find each section's pre-edit chunk_id by heading_path semantics
+    // (read via the chunks' text — heading_path isn't selected here
+    // but the text starts with the heading path).
+    const earlyLifeBefore = beforeChunks.find((c) => c.text.startsWith("Claude Shannon > Early Life"))!;
+    const careerBefore = beforeChunks.find((c) => c.text.startsWith("Claude Shannon > Career"))!;
+    const cardBefore = beforeChunks.find((c) => !c.text.startsWith("Claude Shannon >"))!;
+
+    // Wait one second so the SQLite datetime('now') resolution can
+    // distinguish a new pivot's created_at from the pre-edit values.
+    await new Promise((r) => setTimeout(r, 1100));
 
     writeWiki("wiki/person/shannon.md", {
       id: entity.id,
@@ -199,32 +212,109 @@ describe("embedding pipeline (mock embedder)", () => {
       "Worked at Bell Labs and AT&T.",
     ].join("\n"));
 
-    // Wait for new chunk rows (different ids) and a drained queue.
+    // Wait for the Career chunk's content_hash to change in the DB
+    // (proves the watcher picked up the edit), then drain.
     const deadline = Date.now() + 15_000;
     while (Date.now() < deadline) {
-      const chunks = await getChunks(entity.id);
-      if (chunks.length > 0 && chunks.every((c) => !beforeChunkIds.has(c.id))) {
-        await waitForDrain(15_000);
-        break;
-      }
-      await new Promise((r) => setTimeout(r, 200));
+      const after = await getChunks(entity.id);
+      const careerNow = after.find((c) => c.text.startsWith("Claude Shannon > Career"));
+      if (careerNow && careerNow.content_hash !== careerBefore.content_hash) break;
+      await new Promise((r) => setTimeout(r, 100));
     }
+    await waitForDrain(15_000);
+
+    const afterChunks = await getChunks(entity.id);
+    const afterPivots = await getPivots(entity.id);
+    const afterPivotByChunkId = new Map(afterPivots.map((p) => [p.chunk_id, p]));
+
+    const earlyLifeAfter = afterChunks.find((c) => c.text.startsWith("Claude Shannon > Early Life"))!;
+    const careerAfter = afterChunks.find((c) => c.text.startsWith("Claude Shannon > Career"))!;
+    const cardAfter = afterChunks.find((c) => !c.text.startsWith("Claude Shannon >"))!;
+
+    // Unchanged chunks (Early Life, card): same chunk_id (UPDATE in
+    // place by content_hash). Their pivot rows survived — no cascade
+    // fired, no re-embed happened.
+    expect(earlyLifeAfter.id).toBe(earlyLifeBefore.id);
+    expect(cardAfter.id).toBe(cardBefore.id);
+    expect(afterPivotByChunkId.get(earlyLifeAfter.id)!.created_at)
+      .toBe(beforePivotByChunkId.get(earlyLifeBefore.id)!.created_at);
+    expect(afterPivotByChunkId.get(cardAfter.id)!.created_at)
+      .toBe(beforePivotByChunkId.get(cardBefore.id)!.created_at);
+
+    // Career CHANGED. Its new content_hash has no match in the
+    // pre-edit chunk set, so it's INSERTed as a new row with a fresh
+    // chunk_id; the old Career row gets DELETEd at the end of the diff.
+    expect(careerAfter.id).not.toBe(careerBefore.id);
+    expect(careerAfter.content_hash).not.toBe(careerBefore.content_hash);
+    expect(careerAfter.text).toContain("Bell Labs and AT&T");
+    expect(afterPivotByChunkId.get(careerAfter.id)!.content_hash)
+      .toBe(careerAfter.content_hash);
+  });
+
+  it("preserves chunk_id and pivot when only frontmatter changes (lead unchanged)", async () => {
+    // An unrelated frontmatter field that doesn't feed into any chunk
+    // text. Every chunk_id should survive the resync, and every pivot's
+    // created_at should be preserved (no re-embed).
+    writeWiki("wiki/person/probe.md", {
+      label: "Probe Subject",
+      subject_type: "person",
+      short_description: "Test fixture for the cache-hit assertion.",
+    }, [
+      "Some lead paragraph for the probe.",
+      "",
+      "## A Section",
+      "",
+      "Body of A.",
+    ].join("\n"));
+
+    const entity = await waitForEntityBySourcePath(spaceId, "wiki/person/probe.md");
+    await waitForDrain(15_000);
+
+    const beforeChunks = await getChunks(entity.id);
+    const beforePivots = await getPivots(entity.id);
+    const beforeIds = new Set(beforeChunks.map((c) => c.id));
+
+    await new Promise((r) => setTimeout(r, 1100));
+
+    writeWiki("wiki/person/probe.md", {
+      id: entity.id,
+      label: "Probe Subject",
+      subject_type: "person",
+      short_description: "Test fixture for the cache-hit assertion.",
+      birth_year: 1900, // does not feed into any chunk text
+    }, [
+      "Some lead paragraph for the probe.",
+      "",
+      "## A Section",
+      "",
+      "Body of A.",
+    ].join("\n"));
+
+    // Wait for the source_hash to change (proves the watcher reran sync)
+    // then drain.
+    const sql = createSql();
+    const deadline = Date.now() + 15_000;
+    const beforeRows = await sql`SELECT source_hash FROM entities WHERE id = ${entity.id}`;
+    const beforeHash = beforeRows[0]?.source_hash;
+    while (Date.now() < deadline) {
+      const rows = await sql`SELECT source_hash FROM entities WHERE id = ${entity.id}`;
+      if (rows[0]?.source_hash && rows[0].source_hash !== beforeHash) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    await waitForDrain(15_000);
 
     const afterChunks = await getChunks(entity.id);
     const afterPivots = await getPivots(entity.id);
 
-    // Every current chunk has a matching pivot with content_hash agreement.
-    expect(afterPivots).toHaveLength(afterChunks.length);
-    const pivotByChunk = new Map(afterPivots.map((p) => [p.chunk_id, p]));
-    for (const chunk of afterChunks) {
-      const pivot = pivotByChunk.get(chunk.id);
-      expect(pivot).toBeDefined();
-      expect(pivot!.content_hash).toBe(chunk.content_hash);
+    expect(afterChunks).toHaveLength(beforeChunks.length);
+    for (const c of afterChunks) {
+      expect(beforeIds.has(c.id)).toBe(true);
     }
 
-    // Career section's chunk_text reflects the edit.
-    const career = afterChunks.find((c) => c.text.includes("Career"))!;
-    expect(career.text).toContain("Bell Labs and AT&T");
+    const beforeByChunk = new Map(beforePivots.map((p) => [p.chunk_id, p.created_at]));
+    for (const p of afterPivots) {
+      expect(p.created_at).toBe(beforeByChunk.get(p.chunk_id));
+    }
   });
 
   it("cleans up vec0 rows when chunks are removed", async () => {

--- a/packages/arkeon/test/e2e/embeddings.test.ts
+++ b/packages/arkeon/test/e2e/embeddings.test.ts
@@ -1,0 +1,310 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * End-to-end test for the embedding pipeline (issue #47).
+ *
+ * Forces ARKEON_WIKI_EMBEDDER=mock so the test doesn't depend on
+ * Ollama or pull real model weights. Verifies the full path:
+ *   wiki sync → chunks written → entity enqueued → worker drains →
+ *   chunk_vectors + entity_embeddings populated.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdirSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+import yaml from "js-yaml";
+
+import { createSql } from "../../src/server/lib/sql.js";
+import { waitForEntityBySourcePath } from "./helpers.js";
+import { waitForDrain, queueStats } from "../../src/server/lib/embedding-queue.js";
+import { EMBEDDING_DIM } from "../../src/server/lib/embedder/index.js";
+
+const API_PORT = 18791;
+const BASE_URL = `http://localhost:${API_PORT}`;
+
+let testDir: string;
+let stateDir: string;
+let serverHandle: { stop: () => Promise<void> } | null = null;
+let spaceId: string;
+const prevEmbedderEnv = process.env.ARKEON_WIKI_EMBEDDER;
+
+function writeWiki(
+  relativePath: string,
+  properties: Record<string, unknown>,
+  body: string,
+): void {
+  const absPath = join(testDir, relativePath);
+  const dir = absPath.substring(0, absPath.lastIndexOf("/"));
+  mkdirSync(dir, { recursive: true });
+  const fm = yaml.dump(properties, { schema: yaml.JSON_SCHEMA, sortKeys: false }).trimEnd();
+  writeFileSync(absPath, `---\n${fm}\n---\n\n${body}\n`);
+}
+
+interface PivotRow {
+  chunk_id: number;
+  model: string;
+  content_hash: string;
+}
+
+interface ChunkRow {
+  id: number;
+  text: string;
+  content_hash: string;
+}
+
+async function getChunks(entityId: string): Promise<ChunkRow[]> {
+  const sql = createSql();
+  return (await sql`
+    SELECT id, text, content_hash
+    FROM entity_chunks
+    WHERE entity_id = ${entityId}
+    ORDER BY chunk_index
+  `) as unknown as ChunkRow[];
+}
+
+async function getPivots(entityId: string): Promise<PivotRow[]> {
+  const sql = createSql();
+  return (await sql`
+    SELECT chunk_id, model, content_hash
+    FROM entity_embeddings
+    WHERE chunk_id IN (
+      SELECT id FROM entity_chunks WHERE entity_id = ${entityId}
+    )
+  `) as unknown as PivotRow[];
+}
+
+async function getVectorRowIds(entityId: string): Promise<number[]> {
+  const sql = createSql();
+  const rows = await sql`
+    SELECT chunk_id
+    FROM chunk_vectors
+    WHERE chunk_id IN (
+      SELECT id FROM entity_chunks WHERE entity_id = ${entityId}
+    )
+    ORDER BY chunk_id
+  `;
+  return rows.map((r) => r.chunk_id as number);
+}
+
+beforeAll(async () => {
+  process.env.ARKEON_WIKI_EMBEDDER = "mock";
+
+  const base = join(tmpdir(), `arkeon-emb-${randomBytes(4).toString("hex")}`);
+  testDir = join(base, "repo");
+  stateDir = join(base, "state");
+  mkdirSync(testDir, { recursive: true });
+  mkdirSync(join(stateDir, "data"), { recursive: true });
+  mkdirSync(join(testDir, "wiki"), { recursive: true });
+
+  process.env.ARKEON_WIKI_HOME = stateDir;
+
+  const dbFile = join(stateDir, "data", "arke.db");
+
+  const { runMigrations } = await import("../../src/schema/index.js");
+  await runMigrations({ dbPath: dbFile });
+
+  const { startApi } = await import("../../src/server/server.js");
+  const apiHandle = await startApi({ port: API_PORT, dbPath: dbFile });
+  serverHandle = { stop: () => apiHandle.stop() };
+
+  const res = await fetch(`${BASE_URL}/spaces`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: "embeddings-test", watch_dir: testDir }),
+  });
+  const data = (await res.json()) as { id: string };
+  spaceId = data.id;
+}, 60_000);
+
+afterAll(async () => {
+  if (serverHandle) await serverHandle.stop();
+  if (testDir && existsSync(testDir)) {
+    rmSync(testDir.substring(0, testDir.lastIndexOf("/")), { recursive: true, force: true });
+  }
+  if (prevEmbedderEnv === undefined) {
+    delete process.env.ARKEON_WIKI_EMBEDDER;
+  } else {
+    process.env.ARKEON_WIKI_EMBEDDER = prevEmbedderEnv;
+  }
+}, 30_000);
+
+describe("embedding pipeline (mock embedder)", () => {
+  it("populates chunk_vectors + entity_embeddings for every chunk", async () => {
+    writeWiki("wiki/person/shannon.md", {
+      label: "Claude Shannon",
+      subject_type: "person",
+      short_description: "American mathematician.",
+    }, [
+      "Lead paragraph about Shannon.",
+      "",
+      "## Early Life",
+      "",
+      "Born in 1916.",
+      "",
+      "## Career",
+      "",
+      "Worked at Bell Labs.",
+    ].join("\n"));
+
+    const entity = await waitForEntityBySourcePath(spaceId, "wiki/person/shannon.md");
+    await waitForDrain(15_000);
+
+    const chunks = await getChunks(entity.id);
+    expect(chunks.length).toBeGreaterThanOrEqual(3); // card + 2 sections
+
+    const pivots = await getPivots(entity.id);
+    expect(pivots).toHaveLength(chunks.length);
+
+    const vectorIds = await getVectorRowIds(entity.id);
+    expect(vectorIds).toHaveLength(chunks.length);
+
+    // Pivot rows match the chunks they cover, by id and content_hash.
+    const chunkById = new Map(chunks.map((c) => [c.id, c]));
+    for (const p of pivots) {
+      expect(p.model).toBe("mock@256");
+      const chunk = chunkById.get(p.chunk_id);
+      expect(chunk).toBeDefined();
+      expect(p.content_hash).toBe(chunk!.content_hash);
+    }
+  });
+
+  it("re-embeds the whole wiki on edit (per-chunk caching is a follow-up)", async () => {
+    // sync.ts DELETEs+re-INSERTs entity_chunks on every wiki write,
+    // which assigns fresh AUTOINCREMENT chunk_ids. The content_hash
+    // column exists on entity_chunks + entity_embeddings so a future
+    // worker can match unchanged content across re-creations and skip
+    // the embed call. For now, every sync re-embeds every chunk.
+    const entity = await waitForEntityBySourcePath(spaceId, "wiki/person/shannon.md");
+    const beforeChunkIds = new Set(
+      (await getChunks(entity.id)).map((c) => c.id),
+    );
+
+    writeWiki("wiki/person/shannon.md", {
+      id: entity.id,
+      label: "Claude Shannon",
+      subject_type: "person",
+      short_description: "American mathematician.",
+    }, [
+      "Lead paragraph about Shannon.",
+      "",
+      "## Early Life",
+      "",
+      "Born in 1916.",
+      "",
+      "## Career",
+      "",
+      "Worked at Bell Labs and AT&T.",
+    ].join("\n"));
+
+    // Wait for new chunk rows (different ids) and a drained queue.
+    const deadline = Date.now() + 15_000;
+    while (Date.now() < deadline) {
+      const chunks = await getChunks(entity.id);
+      if (chunks.length > 0 && chunks.every((c) => !beforeChunkIds.has(c.id))) {
+        await waitForDrain(15_000);
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 200));
+    }
+
+    const afterChunks = await getChunks(entity.id);
+    const afterPivots = await getPivots(entity.id);
+
+    // Every current chunk has a matching pivot with content_hash agreement.
+    expect(afterPivots).toHaveLength(afterChunks.length);
+    const pivotByChunk = new Map(afterPivots.map((p) => [p.chunk_id, p]));
+    for (const chunk of afterChunks) {
+      const pivot = pivotByChunk.get(chunk.id);
+      expect(pivot).toBeDefined();
+      expect(pivot!.content_hash).toBe(chunk.content_hash);
+    }
+
+    // Career section's chunk_text reflects the edit.
+    const career = afterChunks.find((c) => c.text.includes("Career"))!;
+    expect(career.text).toContain("Bell Labs and AT&T");
+  });
+
+  it("cleans up vec0 rows when chunks are removed", async () => {
+    // Drop the Career section. The chunk should be removed from
+    // entity_chunks (cascade clears entity_embeddings); the worker
+    // is responsible for purging the now-orphan chunk_vectors row.
+    const entity = await waitForEntityBySourcePath(spaceId, "wiki/person/shannon.md");
+
+    writeWiki("wiki/person/shannon.md", {
+      id: entity.id,
+      label: "Claude Shannon",
+      subject_type: "person",
+      short_description: "American mathematician.",
+    }, [
+      "Lead paragraph about Shannon.",
+      "",
+      "## Early Life",
+      "",
+      "Born in 1916.",
+    ].join("\n"));
+
+    // Wait for chunks to drop and queue to drain.
+    const deadline = Date.now() + 15_000;
+    while (Date.now() < deadline) {
+      const chunks = await getChunks(entity.id);
+      if (!chunks.some((c) => c.text.includes("Career"))) {
+        await waitForDrain(15_000);
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 200));
+    }
+
+    const chunks = await getChunks(entity.id);
+    const vectorIds = await getVectorRowIds(entity.id);
+    const pivots = await getPivots(entity.id);
+
+    expect(vectorIds.length).toBe(chunks.length);
+    expect(pivots.length).toBe(chunks.length);
+
+    // No vec0 rows reference a chunk_id that no longer exists.
+    const chunkIdSet = new Set(chunks.map((c) => c.id));
+    for (const id of vectorIds) {
+      expect(chunkIdSet.has(id)).toBe(true);
+    }
+  });
+
+  it("cascades delete (chunk_vectors + entity_embeddings)", async () => {
+    writeWiki("wiki/person/temp.md", {
+      label: "Temp Embed Wiki",
+      subject_type: "person",
+    }, "## Section\n\nBody.");
+
+    const entity = await waitForEntityBySourcePath(spaceId, "wiki/person/temp.md");
+    await waitForDrain(15_000);
+
+    const chunksBefore = await getChunks(entity.id);
+    expect(chunksBefore.length).toBeGreaterThan(0);
+    expect((await getPivots(entity.id)).length).toBe(chunksBefore.length);
+
+    const res = await fetch(`${BASE_URL}/wikis/${entity.id}`, { method: "DELETE" });
+    expect(((await res.json()) as { deleted: boolean }).deleted).toBe(true);
+
+    // Cascades: chunks gone → pivots gone (FK CASCADE). Vec0 cleanup
+    // happens on the next drain — trigger one by enqueuing any
+    // existing entity (or just write something that lands in the
+    // queue). The simpler path is to assert the vec0 is empty for
+    // chunk_ids belonging to the deleted entity, which trivially
+    // holds because the chunk_ids no longer exist.
+    expect(await getChunks(entity.id)).toHaveLength(0);
+    expect(await getPivots(entity.id)).toHaveLength(0);
+  });
+
+  it("dimension matches the vec0 schema", () => {
+    expect(EMBEDDING_DIM).toBe(256);
+  });
+
+  it("waitForDrain returns empty stats once idle", async () => {
+    await waitForDrain(15_000);
+    const stats = await queueStats();
+    expect(stats.pending).toBe(0);
+    expect(stats.in_flight).toBe(0);
+  });
+});

--- a/packages/arkeon/test/unit/embedder.test.ts
+++ b/packages/arkeon/test/unit/embedder.test.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { MockEmbedder, EMBEDDING_DIM } from "../../src/server/lib/embedder/index.js";
+
+describe("MockEmbedder", () => {
+  it("produces vectors of the configured dimension", async () => {
+    const e = new MockEmbedder();
+    const [v] = await e.embed(["hello"]);
+    expect(v.length).toBe(EMBEDDING_DIM);
+    expect(v).toBeInstanceOf(Float32Array);
+  });
+
+  it("is deterministic across calls", async () => {
+    const e = new MockEmbedder();
+    const [a] = await e.embed(["the same input"]);
+    const [b] = await e.embed(["the same input"]);
+    expect(Array.from(a)).toEqual(Array.from(b));
+  });
+
+  it("produces different vectors for different inputs", async () => {
+    const e = new MockEmbedder();
+    const [a] = await e.embed(["alpha"]);
+    const [b] = await e.embed(["beta"]);
+    let same = true;
+    for (let i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) {
+        same = false;
+        break;
+      }
+    }
+    expect(same).toBe(false);
+  });
+
+  it("produces unit-length vectors (cosine-friendly)", async () => {
+    const e = new MockEmbedder();
+    const [v] = await e.embed(["arbitrary text"]);
+    let mag = 0;
+    for (const x of v) mag += x * x;
+    expect(Math.sqrt(mag)).toBeCloseTo(1, 5);
+  });
+
+  it("batches preserve input order", async () => {
+    const e = new MockEmbedder();
+    const inputs = ["one", "two", "three"];
+    const vectors = await e.embed(inputs);
+    expect(vectors).toHaveLength(3);
+
+    const [oneA] = await e.embed(["one"]);
+    const [twoA] = await e.embed(["two"]);
+    expect(Array.from(vectors[0])).toEqual(Array.from(oneA));
+    expect(Array.from(vectors[1])).toEqual(Array.from(twoA));
+  });
+
+  it("identifies itself with a stable modelId", () => {
+    const e = new MockEmbedder();
+    expect(e.modelId).toBe("mock@256");
+    expect(e.dim).toBe(EMBEDDING_DIM);
+  });
+});


### PR DESCRIPTION
## Summary

PR 2 of 3 for issue #47. Builds the persistence half of semantic search: chunks become 256-dim vectors stored in `sqlite-vec`, written by an in-process queue worker. The query path (KNN, RRF fusion, public `/search` integration) is deferred to PR 3.

Three commits:

1. **`feat: chunking on by default`** — flips the gate landed in #67. Chunks are written on every wiki sync; opt out with `ARKEON_WIKI_CHUNKING=0`.
2. **`feat: embedding pipeline (chunks → queue → vec0)`** — the main work.
3. **`fix: in-place chunk upsert keeps embeddings stable across edits`** — closes #68. Replaces the DELETE+INSERT chunk reconciliation with a content_hash-keyed diff so unchanged chunks keep their chunk_id and the embedding pivot survives. Edits now embed only the changed sections.

## What lands

- **`sqlite-vec@0.1.9`** loaded in `initDb()`. `vec_version()` sanity-checked at startup so a broken extension fails loud, not silent.
- **`003-embeddings.sql`** adds three tables:
  - `chunk_vectors` — `vec0` virtual table, `float[256] distance_metric=cosine`.
  - `entity_embeddings` — pivot tracking which model + content_hash produced each vector. Cascades from `entity_chunks`.
  - `embedding_queue` — per-entity FIFO with the same lease semantics as `agent_queue`.
- **`embedding-queue.ts`** — pure SQL helpers (`enqueue`, `claimNext`, `complete`, `fail`, `reclaimOrphans`, `queueStats`, `waitForDrain`).
- **`embedder/`** — runtime + backends. Resolution order: `ARKEON_WIKI_EMBEDDER` override → Ollama (auto-detected at `localhost:11434` with the model pulled) → deterministic mock fallback.
  - **`mock.ts`** — SHA-derived 256-d unit vectors. Exercises the pipeline without pulling 200 MB of weights into CI.
  - **`ollama.ts`** — HTTP client for `embeddinggemma:300m`, Matryoshka-truncated to 256d. `tryOllama()` probes `/api/tags` and only returns an embedder if the model is already pulled — we never auto-pull.
  - **`worker.ts`** — claims off the queue, embeds new chunks, writes vec0 + pivot, purges orphan vec0 rows. Started as part of the daemon lifecycle.
- **`syncWikiFile()`** now does a content_hash-keyed diff against existing chunks (UPDATE in place for matches, INSERT for new content, DELETE for removed) instead of DELETE+INSERT. Then enqueues the entity for the worker.
- **`ARKEON_WIKI_EMBEDDINGS=0`** disables the queue and worker entirely (parallel to `ARKEON_WIKI_CHUNKING=0`).

## Implementation notes worth flagging

- **vec0 PRIMARY KEY binding workaround.** `sqlite-vec` 0.1.9 rejects integers bound through better-sqlite3's parameter path with "Only integers are allows for primary key values on chunk_vectors." Reproduced and verified — virtual-table `xUpdate` callbacks don't get column affinity coercion, so a JS Number bound through better-sqlite3's parameter path arrives as `SQLITE_FLOAT` (sqlite-vec's PK validator wants `SQLITE_INTEGER`). Inlining the chunk_id as a SQL literal sidesteps the binding path entirely. The chunk_id is a trusted integer from `entity_chunks.id` (validated with `Number.isInteger()` before substitution), so there's no injection surface.
- **Per-chunk embedding cache.** The chunk reconciliation in `syncWikiFile` does an in-place upsert keyed on `(entity_id, content_hash)`. Trick: negate every existing `chunk_index` first to free up the `UNIQUE(entity_id, chunk_index)` space, then UPDATE matches and INSERT misses to their final positive indices, then DELETE rows still at negative indices. Result: a wiki save that edits one section embeds one section.

## What's NOT in this PR

- No public query endpoint, query encoder, or RRF fusion (PR 3).
- No bundled ONNX runtime (PR 3). Real embeddings today require a local Ollama install + `ollama pull embeddinggemma:300m`. Without it, the worker logs a warning and falls back to mock.
- No backfill CLI (`reindex`). Users upgrading existing wikis can `touch wiki/**/*.md` to re-trigger sync. A proper CLI lands with PR 3.

## Test plan

- [x] `npm run typecheck -w packages/arkeon` — clean
- [x] `npm test -w packages/arkeon` — 156/156 (6 new mock-embedder unit tests)
- [x] `npm run test:e2e -w packages/arkeon` — 141/141 (7 new pipeline e2e tests; existing tests unaffected)
  - Includes two cache-hit assertions: edit one section → unchanged chunks keep `chunk_id` and `pivot.created_at`, only the changed section gets a fresh row + pivot. Frontmatter-only edit → every chunk_id and pivot survives.
- [x] Tested vec0 binding workaround in isolation — confirmed parameterized PK fails, SQL literal succeeds.
- [x] Verified migrations are idempotent (existing schema-idempotency e2e covers all `*.sql` files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)