### PR TITLE
fix: close DB singleton in agent-trigger test; guard search against missing watch_dir

### DIFF
--- a/packages/arkeon/src/server/lib/search.ts
+++ b/packages/arkeon/src/server/lib/search.ts
@@ -14,6 +14,7 @@
  */
 
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { rgPath } from "@vscode/ripgrep";
 
 import { createSql } from "./sql.js";
@@ -214,6 +215,11 @@ export async function search(opts: SearchOptions): Promise<SearchResult> {
     const watchDir = space.watch_dir as string | null;
     const spaceId = space.id as string;
     if (!watchDir) continue;
+    // A registered space's directory can vanish out from under us (user
+    // rm'd it, or removable media unmounted). spawn() with a missing cwd
+    // surfaces as ENOENT on the rg path, which looks like a missing
+    // binary — skip cleanly instead.
+    if (!existsSync(watchDir)) continue;
 
     const fileResults = await runRipgrep({
       cwd: watchDir,

--- a/packages/arkeon/test/e2e/agent-trigger.test.ts
+++ b/packages/arkeon/test/e2e/agent-trigger.test.ts
@@ -27,7 +27,7 @@ import { randomBytes } from "node:crypto";
 
 import { startScheduler } from "../../src/server/agents/scheduler.js";
 import { applyEdit } from "../../src/server/lib/file-edits.js";
-import { createSql } from "../../src/server/lib/sql.js";
+import { closeDb, createSql } from "../../src/server/lib/sql.js";
 import type { Space } from "../../src/server/lib/sync.js";
 import type { AgentRunResult } from "../../src/server/agents/runtime.js";
 
@@ -71,6 +71,12 @@ beforeAll(async () => {
 
 afterAll(async () => {
   delete process.env.OPENAI_API_KEY;
+  // Close the singleton DB handle so the next e2e file's runMigrations()
+  // opens a fresh connection at its own path. Without this, initDb() short-
+  // circuits on the existing _db and the next test inherits this test's
+  // tables — including spaces whose watch_dir we rm -rf below, which makes
+  // ripgrep's spawn() fail with ENOENT on macOS.
+  closeDb();
   if (testDir && existsSync(testDir)) {
     rmSync(testDir.substring(0, testDir.lastIndexOf("/")), {
       recursive: true,


### PR DESCRIPTION
## Summary

Fixes a macOS-only flake in `search.test.ts` that surfaces when run after `agent-trigger.test.ts` in the same e2e session.

The reported diagnosis (\"agent-trigger deletes its testDir without restoring `process.cwd()`\") was off — no test calls `chdir`. The real bug is the `_db` singleton in `src/server/lib/sql.ts` leaking across e2e files.

`vitest.e2e.config.ts` sets `isolate: false`, so all e2e files share one Node process. Every e2e file except `agent-trigger.test.ts` calls `startApi`, whose `stop()` invokes `closeDb()`. agent-trigger calls `runMigrations` directly and never closes the DB. So the singleton `_db` keeps its handle to the trigger DB after the test ends. When the next file calls `runMigrations(newPath)`, `initDb()` short-circuits on the existing `_db` and the new file inherits agent-trigger's `spaces` rows — including `trigger-space`, whose `watch_dir` the `afterAll` just `rm -rf`'d.

`search.test.ts`'s \"all spaces\" case then spawns ripgrep with `cwd: <deleted dir>`. macOS's `posix_spawn` returns `ENOENT`, which Node attaches to the rg binary path — making it look like ripgrep itself is missing.

Two changes:

- **`test/e2e/agent-trigger.test.ts`** — `afterAll` calls `closeDb()` so the next file's `initDb` opens fresh at its own path.
- **`src/server/lib/search.ts`** — skip spaces whose `watch_dir` no longer exists. Real prod concern too (user deletes a watched dir mid-session); also makes the suite less brittle to future singleton leaks.

## Test plan

- [x] Reproduced the failure: `npx vitest run --config vitest.e2e.config.ts --sequence.shuffle=false` → `search.test.ts > searches all spaces when space_id is omitted` fails with `Cannot read properties of undefined (reading 'length')` (caused by `spawn ... rg ENOENT`).
- [x] After the fix: same command → 141/141 pass.
- [x] `npx vitest run --config vitest.e2e.config.ts test/e2e/agent-trigger.test.ts test/e2e/search.test.ts` (forces the failing pair) → 15/15 pass.
- [x] `npm run typecheck -w packages/arkeon` clean.
- [x] `npm test -w packages/arkeon` → 156/156 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)