### PR TITLE
test: full-product e2e coverage (corpus walkthrough, queue reclaim, CLI journey)

### DIFF
--- a/packages/arkeon/test/e2e/cli-journey.test.ts
+++ b/packages/arkeon/test/e2e/cli-journey.test.ts
@@ -1,0 +1,256 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Full-product journey through the actual CLI binary (issue #47).
+ *
+ * Most other e2e tests use `startApi()` in-process — fast, but
+ * leaves the spawn/detach/CLI/HTTP-round-trip code uncovered. This
+ * test runs the published CLI (via tsx) as a separate process,
+ * starts a detached daemon, hits its HTTP API for the parts the
+ * existing test pattern covers, then exercises `arkeon-wiki search`
+ * end-to-end against it.
+ *
+ * The bug class this catches: the CLI builds correctly, the daemon
+ * comes up, the search command speaks the same wire format the
+ * server returns, and the namespaced response shape (keyword/vector)
+ * survives JSON serialization through both the daemon and the CLI's
+ * output layer.
+ *
+ * Mock embedder via setup.ts so we don't pull weights every CI run.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execFile } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import yaml from "js-yaml";
+
+const execFileP = promisify(execFile);
+
+const CLI_ENTRY = join(__dirname, "..", "..", "src", "index.ts");
+const NAME = "e2e-cli-journey";
+
+let testHome: string;
+let watchDir: string;
+let testEnv: NodeJS.ProcessEnv;
+let apiUrl: string;
+let spaceId: string;
+
+interface CliResult {
+  stdout: string;
+  stderr: string;
+  json: any;
+}
+
+async function runCli(
+  args: string[],
+  opts: { expectOk?: boolean } = {},
+): Promise<CliResult> {
+  const { stdout, stderr } = await execFileP(
+    "npx",
+    ["tsx", CLI_ENTRY, ...args],
+    { env: testEnv, timeout: 30_000 },
+  ).catch((err: NodeJS.ErrnoException & { stdout?: string; stderr?: string }) => {
+    if (err.stdout != null || err.stderr != null) {
+      return { stdout: err.stdout ?? "", stderr: err.stderr ?? "" };
+    }
+    throw err;
+  });
+
+  let json: any = null;
+  try { json = JSON.parse(stdout); } catch { /* non-JSON */ }
+  if (json == null) {
+    const m = stderr.match(/\{[\s\S]*\}\s*$/);
+    if (m) {
+      try { json = JSON.parse(m[0]); } catch { /* still non-JSON */ }
+    }
+  }
+
+  if (opts.expectOk !== false && json && json.ok === false) {
+    throw new Error(
+      `CLI ${args.join(" ")} returned ok:false — ${JSON.stringify(json.error)}`,
+    );
+  }
+  return { stdout, stderr, json };
+}
+
+function writeWiki(
+  relativePath: string,
+  properties: Record<string, unknown>,
+  body: string,
+): void {
+  const absPath = join(watchDir, relativePath);
+  const dir = absPath.substring(0, absPath.lastIndexOf("/"));
+  mkdirSync(dir, { recursive: true });
+  const fm = yaml.dump(properties, { schema: yaml.JSON_SCHEMA, sortKeys: false }).trimEnd();
+  writeFileSync(absPath, `---\n${fm}\n---\n\n${body}\n`);
+}
+
+beforeAll(async () => {
+  testHome = mkdtempSync(join(tmpdir(), "arkeon-cli-journey-"));
+  watchDir = join(testHome, "repo");
+  mkdirSync(join(watchDir, "wiki"), { recursive: true });
+
+  testEnv = { ...process.env };
+  // Each test gets its own ~/.arkeon-wiki/<NAME>/ — let it land there
+  // (matches the production path) but ensure we don't inherit a
+  // stray ARKEON_WIKI_HOME from a sibling test run.
+  delete testEnv.ARKEON_WIKI_HOME;
+  // Force mock — no model download.
+  testEnv.ARKEON_WIKI_EMBEDDER = "mock";
+
+  // Spawn the detached daemon via the CLI.
+  const up = await runCli(["up", "--name", NAME]);
+  expect(up.json.ok).toBe(true);
+  apiUrl = up.json.api_url as string;
+  expect(apiUrl).toMatch(/^http:\/\/localhost:\d+$/);
+
+  // Register a space pointing at our temp watchDir via HTTP. The
+  // CLI's `init` command requires being cwd'd into the directory and
+  // writes a .arkeon/state.json — mirrors the user's first-time
+  // experience but is harder to thread through a test wrapper. The
+  // HTTP call exercises the same server path.
+  const created = await fetch(`${apiUrl}/spaces`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: "cli-journey-space", watch_dir: watchDir }),
+  });
+  spaceId = ((await created.json()) as { id: string }).id;
+
+  // Seed a few wikis. The watcher in the spawned daemon picks them up.
+  writeWiki(
+    "wiki/person/marie-curie.md",
+    { label: "Marie Curie", subject_type: "person" },
+    "Marie Curie was a Polish-French physicist and chemist who pioneered research on radioactivity.",
+  );
+  writeWiki(
+    "wiki/person/alan-turing.md",
+    { label: "Alan Turing", subject_type: "person" },
+    "Alan Turing was a British mathematician and theoretical computer scientist.",
+  );
+  writeWiki(
+    "wiki/concept/photosynthesis.md",
+    { label: "Photosynthesis", subject_type: "concept" },
+    "Photosynthesis is the biological process by which plants convert sunlight into energy.",
+  );
+
+  // Wait for the watcher to sync all three wikis.
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const res = await fetch(`${apiUrl}/wikis?space_id=${spaceId}&limit=10`);
+    const data = (await res.json()) as { wikis: unknown[] };
+    if ((data.wikis ?? []).length === 3) break;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+}, 60_000);
+
+afterAll(async () => {
+  // Best-effort cleanup.
+  try {
+    await runCli(["down", "--name", NAME], { expectOk: false });
+  } catch { /* ignore */ }
+
+  const home = join(process.env.HOME ?? "", ".arkeon-wiki", NAME);
+  if (existsSync(home)) rmSync(home, { recursive: true, force: true });
+
+  const registry = join(process.env.HOME ?? "", ".arkeon-wiki", "instances", `${NAME}.json`);
+  if (existsSync(registry)) rmSync(registry);
+
+  if (existsSync(testHome)) rmSync(testHome, { recursive: true, force: true });
+}, 30_000);
+
+describe("CLI search journey through detached daemon", () => {
+  it("daemon is healthy and reports the three seeded wikis via /wikis", async () => {
+    const health = await fetch(`${apiUrl}/health`);
+    expect(health.ok).toBe(true);
+
+    const wikis = await fetch(`${apiUrl}/wikis?space_id=${spaceId}&limit=10`);
+    const data = (await wikis.json()) as { wikis: { label: string }[] };
+    const labels = data.wikis.map((w) => w.label).sort();
+    expect(labels).toEqual(["Alan Turing", "Marie Curie", "Photosynthesis"]);
+  });
+
+  it("`arkeon-wiki search` against the running daemon returns the namespaced response", async () => {
+    const res = await runCli([
+      "search",
+      "Turing",
+      "--api-url",
+      apiUrl,
+      "--space",
+      spaceId,
+      "--mode",
+      "both",
+    ]);
+
+    // The CLI's output.result writes the daemon's response shape with
+    // an `operation: "search"` envelope. Verify both namespaces are
+    // present and Alan Turing surfaces in keyword (vector with mock is
+    // not semantically meaningful but the array shape is intact).
+    expect(res.json.ok).toBe(true);
+    expect(res.json.operation).toBe("search");
+    expect(res.json.keyword).toBeDefined();
+    expect(res.json.vector).toBeDefined();
+
+    const keywordLabels = (res.json.keyword.hits as { label: string }[]).map((h) => h.label);
+    expect(keywordLabels).toContain("Alan Turing");
+
+    expect(res.json.vector.model).toBe("mock@256");
+  });
+
+  it("`--mode keyword` returns only the keyword namespace", async () => {
+    const res = await runCli([
+      "search",
+      "Curie",
+      "--api-url",
+      apiUrl,
+      "--space",
+      spaceId,
+      "--mode",
+      "keyword",
+    ]);
+
+    expect(res.json.keyword).toBeDefined();
+    expect(res.json.vector).toBeUndefined();
+    const labels = (res.json.keyword.hits as { label: string }[]).map((h) => h.label);
+    expect(labels).toContain("Marie Curie");
+  });
+
+  it("`--mode vector` returns only the vector namespace with chunk-level hits", async () => {
+    const res = await runCli([
+      "search",
+      "biology",
+      "--api-url",
+      apiUrl,
+      "--space",
+      spaceId,
+      "--mode",
+      "vector",
+      "--limit",
+      "5",
+    ]);
+
+    expect(res.json.vector).toBeDefined();
+    expect(res.json.keyword).toBeUndefined();
+    expect(Array.isArray(res.json.vector.hits)).toBe(true);
+    for (const hit of res.json.vector.hits) {
+      expect(typeof hit.chunk_id).toBe("number");
+      expect(typeof hit.heading_path).toBe("string");
+      expect(typeof hit.similarity).toBe("number");
+    }
+  });
+
+  it("daemon survives across multiple search invocations and reports `running` in status", async () => {
+    const status = await runCli(["status", "--name", NAME]);
+    expect(status.json.state).toBe("running");
+    expect(status.json.pid).toBeTypeOf("number");
+  });
+});

--- a/packages/arkeon/test/e2e/queue-reclaim.test.ts
+++ b/packages/arkeon/test/e2e/queue-reclaim.test.ts
@@ -1,0 +1,222 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Daemon restart resilience for the embedding queue (issue #47).
+ *
+ * Exercises the lease-expiration reclaim path that the embedding
+ * worker runs on startup. Without this test the path is dead code
+ * until a real user's daemon crashes — which means we'd discover any
+ * regression after someone loses an embedding job.
+ *
+ * Scenario:
+ *   1. Daemon A starts, writes wikis, embedding queue accumulates.
+ *   2. Daemon A claims an item but is killed before completing it
+ *      (we simulate by directly inserting into embedding_queue with
+ *      a started_at older than the lease TTL).
+ *   3. Daemon B starts. Its first action is reclaimOrphans(); the
+ *      stale rows reset to pending.
+ *   4. The worker drains them; the chunks end up embedded.
+ *
+ * Runs in CI with the mock embedder.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdirSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+import yaml from "js-yaml";
+
+import { createSql } from "../../src/server/lib/sql.js";
+import {
+  reclaimOrphans,
+  queueStats,
+  waitForDrain,
+  ORPHAN_LEASE_MINUTES,
+} from "../../src/server/lib/embedding-queue.js";
+import { resetEmbedder } from "../../src/server/lib/embedder/index.js";
+import { waitForEntityBySourcePath } from "./helpers.js";
+
+const API_PORT = 18795;
+const BASE_URL = `http://localhost:${API_PORT}`;
+
+let testDir: string;
+let stateDir: string;
+let dbFile: string;
+let serverHandle: { stop: () => Promise<void> } | null = null;
+let spaceId: string;
+
+function writeWiki(
+  relativePath: string,
+  properties: Record<string, unknown>,
+  body: string,
+): void {
+  const absPath = join(testDir, relativePath);
+  const dir = absPath.substring(0, absPath.lastIndexOf("/"));
+  mkdirSync(dir, { recursive: true });
+  const fm = yaml.dump(properties, { schema: yaml.JSON_SCHEMA, sortKeys: false }).trimEnd();
+  writeFileSync(absPath, `---\n${fm}\n---\n\n${body}\n`);
+}
+
+async function startServer(): Promise<{ stop: () => Promise<void> }> {
+  resetEmbedder();
+  const { startApi } = await import("../../src/server/server.js");
+  const apiHandle = await startApi({ port: API_PORT, dbPath: dbFile });
+  return { stop: async () => apiHandle.stop() };
+}
+
+beforeAll(async () => {
+  // setup.ts forces ARKEON_WIKI_EMBEDDER=mock for e2e — no model
+  // download triggered.
+
+  const base = join(tmpdir(), `arkeon-reclaim-${randomBytes(4).toString("hex")}`);
+  testDir = join(base, "repo");
+  stateDir = join(base, "state");
+  mkdirSync(testDir, { recursive: true });
+  mkdirSync(join(stateDir, "data"), { recursive: true });
+  mkdirSync(join(testDir, "wiki"), { recursive: true });
+
+  process.env.ARKEON_WIKI_HOME = stateDir;
+  dbFile = join(stateDir, "data", "arke.db");
+
+  const { runMigrations } = await import("../../src/schema/index.js");
+  await runMigrations({ dbPath: dbFile });
+
+  serverHandle = await startServer();
+
+  const created = await fetch(`${BASE_URL}/spaces`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: "reclaim-space", watch_dir: testDir }),
+  });
+  spaceId = ((await created.json()) as { id: string }).id;
+}, 60_000);
+
+afterAll(async () => {
+  if (serverHandle) await serverHandle.stop();
+  if (testDir && existsSync(testDir)) {
+    rmSync(testDir.substring(0, testDir.lastIndexOf("/")), {
+      recursive: true,
+      force: true,
+    });
+  }
+}, 30_000);
+
+describe("embedding queue — orphan reclaim on daemon restart", () => {
+  it("reclaims rows whose started_at is older than the lease TTL", async () => {
+    // Land a wiki and let the worker process it, so we have a real
+    // entity_id we can attach a fake stale queue row to.
+    writeWiki(
+      "wiki/person/probe-stale.md",
+      { label: "Probe Stale", subject_type: "person" },
+      "Subject under test for the lease-expiration reclaim path.",
+    );
+    const entity = await waitForEntityBySourcePath(spaceId, "wiki/person/probe-stale.md");
+    await waitForDrain(15_000);
+
+    // Forcibly insert (or upsert) a queue row with a started_at that's
+    // older than the lease TTL — simulating a daemon that claimed the
+    // row and then died. We use SQLite's datetime() with a negative
+    // offset rather than a client-side ISO timestamp because the two
+    // formats compare differently (`2026-05-02 15:00:00` vs
+    // `2026-05-02T15:00:00.000Z`) and the reclaim WHERE clause uses
+    // SQLite's space-separated format.
+    const sql = createSql();
+    const staleOffset = `-${ORPHAN_LEASE_MINUTES + 5} minutes`;
+    await sql`
+      INSERT INTO embedding_queue (entity_id, started_at, attempts)
+      VALUES (${entity.id}, datetime('now', ${staleOffset}), 1)
+      ON CONFLICT(entity_id) DO UPDATE SET
+        started_at = datetime('now', ${staleOffset}),
+        attempts = 1,
+        last_error = NULL
+    `;
+
+    const beforeStats = await queueStats();
+    expect(beforeStats.in_flight).toBe(1);
+
+    // The reclaim helper is what the worker calls on its startup. We
+    // can either restart the server (slow, exercises the wiring) or
+    // call the function directly (fast, exercises the SQL). Both have
+    // value — call directly first for a tight test, restart below
+    // for the integration view.
+    const reclaimed = await reclaimOrphans();
+    expect(reclaimed).toBe(1);
+
+    const afterStats = await queueStats();
+    expect(afterStats.in_flight).toBe(0);
+    expect(afterStats.pending).toBe(1);
+
+    // The worker is still running and will pick the row up on its next
+    // poll cycle (default 500ms). Wait for the queue to drain.
+    await waitForDrain(15_000);
+    expect((await queueStats()).pending).toBe(0);
+  });
+
+  it("does NOT reclaim rows whose started_at is fresh (still within lease)", async () => {
+    writeWiki(
+      "wiki/person/probe-fresh.md",
+      { label: "Probe Fresh", subject_type: "person" },
+      "Subject for the negative-side reclaim test.",
+    );
+    const entity = await waitForEntityBySourcePath(spaceId, "wiki/person/probe-fresh.md");
+    await waitForDrain(15_000);
+
+    // Insert with a started_at that's well within the lease window.
+    const sql = createSql();
+    await sql`
+      INSERT INTO embedding_queue (entity_id, started_at, attempts)
+      VALUES (${entity.id}, datetime('now', '-30 seconds'), 1)
+      ON CONFLICT(entity_id) DO UPDATE SET
+        started_at = datetime('now', '-30 seconds'),
+        attempts = 1
+    `;
+
+    const reclaimed = await reclaimOrphans();
+    expect(reclaimed).toBe(0);
+
+    // Clean up — the worker will keep waiting for the lease to
+    // expire, which won't happen in this test. Manually drop the
+    // queue row.
+    await sql`DELETE FROM embedding_queue WHERE entity_id = ${entity.id}`;
+  });
+
+  it("end-to-end: full daemon restart reclaims orphaned rows automatically", async () => {
+    writeWiki(
+      "wiki/person/probe-restart.md",
+      { label: "Probe Restart", subject_type: "person" },
+      "Subject for the full daemon-restart reclaim test.",
+    );
+    const entity = await waitForEntityBySourcePath(spaceId, "wiki/person/probe-restart.md");
+    await waitForDrain(15_000);
+
+    // Plant a stale row. The currently-running worker won't see it
+    // because we set started_at NOT NULL — claimNext only picks up
+    // rows with started_at IS NULL. But the running worker's
+    // reclaimOrphans was already called once at startup; we want to
+    // exercise the case where a NEW daemon starts and the reclaim
+    // fires on its startup.
+    const sql = createSql();
+    const staleOffset = `-${ORPHAN_LEASE_MINUTES + 5} minutes`;
+    await sql`
+      INSERT INTO embedding_queue (entity_id, started_at, attempts)
+      VALUES (${entity.id}, datetime('now', ${staleOffset}), 1)
+      ON CONFLICT(entity_id) DO UPDATE SET
+        started_at = datetime('now', ${staleOffset}),
+        attempts = 1,
+        last_error = NULL
+    `;
+
+    // Stop the running daemon and start a fresh one — the new
+    // daemon's startEmbeddingWorker calls reclaimOrphans() before
+    // beginning to drain.
+    if (serverHandle) await serverHandle.stop();
+    serverHandle = await startServer();
+
+    // The new worker reclaims, then drains. Give it time.
+    await waitForDrain(15_000);
+    expect((await queueStats()).pending).toBe(0);
+    expect((await queueStats()).in_flight).toBe(0);
+  });
+});

--- a/packages/arkeon/test/manual/full-journey-onnx.test.ts
+++ b/packages/arkeon/test/manual/full-journey-onnx.test.ts
@@ -1,0 +1,587 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Full product journey, real ONNX (issue #47).
+ *
+ * Loads a 15-wiki Information Theory corpus with realistic multi-
+ * section content and cross-references, waits for the chunker +
+ * embedder pipeline to drain, then exercises a battery of semantic
+ * queries against the real EmbeddingGemma model. Each query has a
+ * known expected top-1 wiki — wrong answers indicate retrieval
+ * regression.
+ *
+ * Not run in CI. Requires:
+ *   - Network access to HuggingFace Hub on first run (model
+ *     download, ~309 MB to ~/.arkeon-wiki/models/)
+ *   - ~3-5 minutes on first run (download + 15 wikis × multiple
+ *     chunks each through real ONNX)
+ *   - Subsequent runs are faster (cache hit, ~30-60s)
+ *
+ * Run:   npm run test:manual -w packages/arkeon
+ *
+ * What this catches that nothing else does:
+ *   - Retrieval-quality regressions (mock-backed tests can't tell
+ *     us whether the model is actually finding the right wiki)
+ *   - Real-world chunk shape: multi-section wikis, cross-references,
+ *     code blocks, tables — content the synthetic fixtures don't
+ *     have
+ *   - Cumulative pipeline behavior: 15 wikis × ~5 chunks each = 75+
+ *     embeddings, exercises the worker drain at non-trivial scale
+ *   - Within-corpus discrimination: queries that could match
+ *     several wikis must rank the *most relevant* first
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdirSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+import yaml from "js-yaml";
+
+import { waitForDrain, queueStats } from "../../src/server/lib/embedding-queue.js";
+import { getEmbedder, resetEmbedder } from "../../src/server/lib/embedder/index.js";
+
+const API_PORT = 18794;
+const BASE_URL = `http://localhost:${API_PORT}`;
+
+let testDir: string;
+let stateDir: string;
+let serverHandle: { stop: () => Promise<void> } | null = null;
+let spaceId: string;
+const prevEmbedderEnv = process.env.ARKEON_WIKI_EMBEDDER;
+const prevModelsDirEnv = process.env.ARKEON_WIKI_MODELS_DIR;
+
+interface VectorHit {
+  entity_id: string;
+  label: string;
+  chunk_id: number;
+  chunk_kind: string;
+  heading_path: string;
+  text: string;
+  similarity: number;
+}
+
+function writeWiki(
+  relativePath: string,
+  properties: Record<string, unknown>,
+  body: string,
+): void {
+  const absPath = join(testDir, relativePath);
+  const dir = absPath.substring(0, absPath.lastIndexOf("/"));
+  mkdirSync(dir, { recursive: true });
+  const fm = yaml.dump(properties, { schema: yaml.JSON_SCHEMA, sortKeys: false }).trimEnd();
+  writeFileSync(absPath, `---\n${fm}\n---\n\n${body}\n`);
+}
+
+async function api(path: string): Promise<any> {
+  const res = await fetch(`${BASE_URL}${path}`);
+  if (res.headers.get("content-type")?.includes("json")) return res.json();
+  return res.text();
+}
+
+async function vectorSearch(query: string, limit = 10): Promise<VectorHit[]> {
+  const data = await api(
+    `/search?space_id=${spaceId}&q=${encodeURIComponent(query)}&mode=vector&limit=${limit}`,
+  );
+  return data.vector?.hits ?? [];
+}
+
+// ─── The corpus ─────────────────────────────────────────────────────
+// 15 wikis on a coherent theme (Information Theory). Each has multiple
+// H2 sections with real content. Cross-references via standard
+// markdown links. Subjects span people, concepts, places.
+
+const CORPUS: Array<{ path: string; props: Record<string, unknown>; body: string }> = [
+  {
+    path: "wiki/person/claude-shannon.md",
+    props: {
+      label: "Claude Shannon",
+      subject_type: "person",
+      short_description: "American mathematician, father of information theory.",
+    },
+    body: [
+      "Claude Elwood Shannon (1916–2001) was an American mathematician, electrical engineer, and cryptographer. He is widely regarded as the father of information theory.",
+      "",
+      "## Mathematical Theory of Communication",
+      "",
+      "In 1948, Shannon published *A Mathematical Theory of Communication* in the Bell System Technical Journal. The paper laid the foundation for [Information Theory](../concept/information-theory.md), introducing the concept of [Entropy](../concept/entropy.md) as a measure of uncertainty and the [Bit](../concept/bit.md) as the fundamental unit of information.",
+      "",
+      "## Career at Bell Labs",
+      "",
+      "Shannon joined [Bell Labs](../organization/bell-labs.md) in 1941 and remained there for fifteen years. His work on switching circuits, cryptography, and information theory transformed the field of digital communication. He later became a professor at [MIT](../organization/mit.md).",
+      "",
+      "## Boolean Algebra Connection",
+      "",
+      "Shannon's 1937 master's thesis at MIT showed that [Boolean Algebra](../concept/boolean-algebra.md) could be applied to electromechanical relay circuits, laying the groundwork for digital circuit design.",
+    ].join("\n"),
+  },
+  {
+    path: "wiki/person/alan-turing.md",
+    props: {
+      label: "Alan Turing",
+      subject_type: "person",
+      short_description: "British mathematician and theoretical computer scientist.",
+    },
+    body: [
+      "Alan Mathison Turing (1912–1954) was a British mathematician, logician, and theoretical computer scientist. He is considered the father of theoretical computer science and artificial intelligence.",
+      "",
+      "## Theory of Computation",
+      "",
+      "Turing formalized the concept of an [Algorithm](../concept/algorithm.md) and the abstract notion of computation through his [Turing Machine](../concept/turing-machine.md), introduced in his 1936 paper on computable numbers.",
+      "",
+      "## Wartime Cryptography",
+      "",
+      "During World War II, Turing led Hut 8 at [Bletchley Park](../organization/bletchley-park.md), where he devised techniques for breaking the German Enigma cipher. His work shortened the war by an estimated two years.",
+      "",
+      "## Artificial Intelligence",
+      "",
+      "Turing proposed what is now called the Turing Test in his 1950 paper *Computing Machinery and Intelligence*, asking whether machines can think.",
+    ].join("\n"),
+  },
+  {
+    path: "wiki/person/john-von-neumann.md",
+    props: {
+      label: "John von Neumann",
+      subject_type: "person",
+      short_description: "Hungarian-American mathematician and polymath.",
+    },
+    body: [
+      "John von Neumann (1903–1957) was a Hungarian-American mathematician, physicist, computer scientist, engineer, and polymath. He made foundational contributions to mathematics, quantum mechanics, economics, and computing.",
+      "",
+      "## Computer Architecture",
+      "",
+      "Von Neumann developed the von Neumann architecture, the design of stored-program computers in which both data and instructions reside in the same memory. This remains the dominant architecture in modern computing.",
+      "",
+      "## Game Theory",
+      "",
+      "His 1944 book *Theory of Games and Economic Behavior*, co-authored with Oskar Morgenstern, founded modern game theory.",
+      "",
+      "## Cellular Automata",
+      "",
+      "Von Neumann pioneered the study of self-replicating cellular automata, anticipating later work in artificial life and complex systems.",
+    ].join("\n"),
+  },
+  {
+    path: "wiki/person/norbert-wiener.md",
+    props: {
+      label: "Norbert Wiener",
+      subject_type: "person",
+      short_description: "American mathematician, founder of cybernetics.",
+    },
+    body: [
+      "Norbert Wiener (1894–1964) was an American mathematician and philosopher. He is best known as the founder of [Cybernetics](../concept/cybernetics.md), a discipline that formalizes the study of control and communication in animals, machines, and organizations.",
+      "",
+      "## Cybernetics",
+      "",
+      "Wiener's 1948 book *Cybernetics: Or Control and Communication in the Animal and the Machine* established the field. He drew on feedback theory, [Information Theory](../concept/information-theory.md), and his wartime work on anti-aircraft fire control.",
+      "",
+      "## MIT and Stochastic Processes",
+      "",
+      "Wiener spent most of his career at [MIT](../organization/mit.md), where he made foundational contributions to stochastic processes — the Wiener process is named for him.",
+    ].join("\n"),
+  },
+  {
+    path: "wiki/person/andrey-kolmogorov.md",
+    props: {
+      label: "Andrey Kolmogorov",
+      subject_type: "person",
+      short_description: "Soviet mathematician, founder of modern probability theory.",
+    },
+    body: [
+      "Andrey Nikolaevich Kolmogorov (1903–1987) was a Soviet mathematician who made fundamental contributions to probability theory, topology, intuitionistic logic, turbulence, classical mechanics, algorithmic [Information Theory](../concept/information-theory.md), and computational complexity.",
+      "",
+      "## Axiomatic Probability",
+      "",
+      "His 1933 monograph *Foundations of the Theory of Probability* gave probability its modern axiomatic basis.",
+      "",
+      "## Algorithmic Complexity",
+      "",
+      "Kolmogorov complexity measures the length of the shortest computer program that produces a given object. It connects [Information Theory](../concept/information-theory.md) with the theory of [Algorithms](../concept/algorithm.md).",
+    ].join("\n"),
+  },
+  {
+    path: "wiki/concept/information-theory.md",
+    props: {
+      label: "Information Theory",
+      subject_type: "concept",
+      short_description: "Mathematical study of the quantification, storage, and communication of information.",
+    },
+    body: [
+      "Information theory is the mathematical study of the quantification, storage, and communication of information. It was founded by [Claude Shannon](../person/claude-shannon.md) in his 1948 paper *A Mathematical Theory of Communication*.",
+      "",
+      "## Core Quantities",
+      "",
+      "The central measures are [Entropy](./entropy.md), conditional entropy, mutual information, and channel capacity. The unit of information is the [Bit](./bit.md).",
+      "",
+      "## Source and Channel Coding",
+      "",
+      "Shannon's source coding theorem establishes the limits of lossless data compression. His noisy channel coding theorem establishes the maximum reliable communication rate over a noisy channel.",
+      "",
+      "## Connections",
+      "",
+      "Information theory is closely related to [Cybernetics](./cybernetics.md), statistical mechanics, and probability theory.",
+    ].join("\n"),
+  },
+  {
+    path: "wiki/concept/entropy.md",
+    props: {
+      label: "Entropy",
+      subject_type: "concept",
+      short_description: "Measure of uncertainty in a probability distribution.",
+    },
+    body: [
+      "In [Information Theory](./information-theory.md), entropy quantifies the average level of uncertainty inherent in a random variable's possible outcomes. It is measured in [Bits](./bit.md).",
+      "",
+      "## Definition",
+      "",
+      "For a discrete random variable X with probability mass function p, the Shannon entropy is H(X) = −Σ p(x) log₂ p(x). Entropy is maximized when outcomes are equally likely.",
+      "",
+      "## Interpretations",
+      "",
+      "Entropy can be interpreted as the average number of bits needed to encode an outcome, or as a measure of unpredictability.",
+      "",
+      "## Connection to Thermodynamics",
+      "",
+      "Shannon entropy is mathematically analogous to thermodynamic entropy, a connection [Claude Shannon](../person/claude-shannon.md) discussed with John von Neumann.",
+    ].join("\n"),
+  },
+  {
+    path: "wiki/concept/cybernetics.md",
+    props: {
+      label: "Cybernetics",
+      subject_type: "concept",
+      short_description: "Mathematical study of control and communication in animals, machines, and organizations.",
+    },
+    body: [
+      "Cybernetics is the transdisciplinary study of regulatory and purposive systems — their structures, constraints, and possibilities. It was founded by [Norbert Wiener](../person/norbert-wiener.md) in 1948.",
+      "",
+      "## Feedback and Control",
+      "",
+      "Central to cybernetics is the concept of negative feedback: a system observes its own output and adjusts its behaviour to maintain a desired state. Examples range from thermostats to biological homeostasis.",
+      "",
+      "## Relationship to Information Theory",
+      "",
+      "Cybernetics overlaps with [Information Theory](./information-theory.md) and systems theory; both formalize how information flows through and shapes a system's behaviour.",
+    ].join("\n"),
+  },
+  {
+    path: "wiki/concept/turing-machine.md",
+    props: {
+      label: "Turing Machine",
+      subject_type: "concept",
+      short_description: "Abstract mathematical model of computation.",
+    },
+    body: [
+      "A Turing machine is an abstract mathematical model of computation, introduced by [Alan Turing](../person/alan-turing.md) in 1936. It consists of an infinite tape, a head that reads and writes symbols, and a finite state controller.",
+      "",
+      "## Computability",
+      "",
+      "The Church–Turing thesis posits that any function computable by an [Algorithm](./algorithm.md) is computable by some Turing machine. This makes the Turing machine the canonical model of what it means for something to be computable.",
+      "",
+      "## Variants",
+      "",
+      "Variants include multi-tape machines, non-deterministic Turing machines, and probabilistic Turing machines. All are computationally equivalent in terms of what they can compute, though they differ in efficiency.",
+    ].join("\n"),
+  },
+  {
+    path: "wiki/concept/boolean-algebra.md",
+    props: {
+      label: "Boolean Algebra",
+      subject_type: "concept",
+      short_description: "Algebra of truth values and logical operations.",
+    },
+    body: [
+      "Boolean algebra is a branch of algebra in which the values of variables are the truth values true and false, usually denoted 1 and 0. The operations are conjunction (AND), disjunction (OR), and negation (NOT).",
+      "",
+      "## Origins",
+      "",
+      "Boolean algebra was introduced by George Boole in his 1854 book *An Investigation of the Laws of Thought*.",
+      "",
+      "## Application to Circuits",
+      "",
+      "[Claude Shannon](../person/claude-shannon.md) showed in 1937 that Boolean algebra could describe the behaviour of switching circuits, founding modern digital logic design.",
+    ].join("\n"),
+  },
+  {
+    path: "wiki/concept/bit.md",
+    props: {
+      label: "Bit",
+      subject_type: "concept",
+      short_description: "Basic unit of information; binary digit with two possible values.",
+    },
+    body: [
+      "A bit (short for binary digit) is the basic unit of information in computing and digital communications. A bit can hold one of two values, conventionally written as 0 and 1.",
+      "",
+      "## Origin of the Term",
+      "",
+      "The term *bit* was coined by John Tukey and popularized by [Claude Shannon](../person/claude-shannon.md) in his 1948 paper. Shannon used the bit as the unit for [Entropy](./entropy.md) and channel capacity.",
+      "",
+      "## Bytes and Higher Units",
+      "",
+      "Eight bits make a byte, the standard unit for representing a character. Multiples (kilobit, megabit, gigabit) are used in data-rate measurement.",
+    ].join("\n"),
+  },
+  {
+    path: "wiki/concept/algorithm.md",
+    props: {
+      label: "Algorithm",
+      subject_type: "concept",
+      short_description: "Finite sequence of well-defined steps for solving a problem.",
+    },
+    body: [
+      "An algorithm is a finite sequence of well-defined, computer-implementable instructions for solving a class of problems or performing a computation.",
+      "",
+      "## Formalization",
+      "",
+      "[Alan Turing](../person/alan-turing.md) gave the modern formal definition of an algorithm via the [Turing Machine](./turing-machine.md). The Church–Turing thesis equates the intuitive notion of \"effective procedure\" with Turing-computability.",
+      "",
+      "## Complexity",
+      "",
+      "Algorithms are analyzed in terms of their time and space complexity, typically expressed using big-O notation. [Andrey Kolmogorov](../person/andrey-kolmogorov.md) extended this with algorithmic information theory.",
+    ].join("\n"),
+  },
+  {
+    path: "wiki/organization/bell-labs.md",
+    props: {
+      label: "Bell Labs",
+      subject_type: "organization",
+      short_description: "American industrial research laboratory.",
+    },
+    body: [
+      "Bell Telephone Laboratories (Bell Labs) was an American industrial research and scientific development company, originally part of AT&T. It produced foundational work in radio astronomy, the transistor, the laser, the photovoltaic cell, the charge-coupled device, and [Information Theory](../concept/information-theory.md).",
+      "",
+      "## Notable Researchers",
+      "",
+      "Researchers who worked at Bell Labs include [Claude Shannon](../person/claude-shannon.md), Walter Brattain, John Bardeen, William Shockley, and Dennis Ritchie. Shannon's *A Mathematical Theory of Communication* was published in the Bell System Technical Journal.",
+      "",
+      "## Murray Hill",
+      "",
+      "The flagship research site is in Murray Hill, New Jersey. Many of the lab's foundational discoveries were made there.",
+    ].join("\n"),
+  },
+  {
+    path: "wiki/organization/bletchley-park.md",
+    props: {
+      label: "Bletchley Park",
+      subject_type: "organization",
+      short_description: "World War II codebreaking centre in Buckinghamshire, England.",
+    },
+    body: [
+      "Bletchley Park was the principal centre of Allied code-breaking during the Second World War. It was the workplace of cryptanalysts who deciphered the Enigma cipher used by Nazi Germany.",
+      "",
+      "## Hut 8 and Enigma",
+      "",
+      "[Alan Turing](../person/alan-turing.md) led Hut 8, which focused on naval Enigma. The bombe machine, designed by Turing, mechanized the search for Enigma settings.",
+      "",
+      "## Historical Significance",
+      "",
+      "The intelligence produced at Bletchley Park, codenamed Ultra, is credited with shortening the war by two to four years. Its existence remained secret until the 1970s.",
+    ].join("\n"),
+  },
+  {
+    path: "wiki/organization/mit.md",
+    props: {
+      label: "MIT",
+      subject_type: "organization",
+      short_description: "Massachusetts Institute of Technology, private research university.",
+    },
+    body: [
+      "The Massachusetts Institute of Technology (MIT) is a private research university in Cambridge, Massachusetts. It is known for its strength in science, engineering, mathematics, and economics.",
+      "",
+      "## Affiliated Researchers",
+      "",
+      "[Claude Shannon](../person/claude-shannon.md), [Norbert Wiener](../person/norbert-wiener.md), and many other founders of computing and information theory had long associations with MIT.",
+      "",
+      "## Notable Programs",
+      "",
+      "MIT's Computer Science and Artificial Intelligence Laboratory (CSAIL) is one of the largest academic AI research centres in the world.",
+    ].join("\n"),
+  },
+];
+
+// ─── Setup ──────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  process.env.ARKEON_WIKI_EMBEDDER = "onnx";
+  process.env.ARKEON_WIKI_MODELS_DIR = join(homedir(), ".arkeon-wiki", "models");
+  resetEmbedder();
+
+  const base = join(tmpdir(), `arkeon-journey-${randomBytes(4).toString("hex")}`);
+  testDir = join(base, "repo");
+  stateDir = join(base, "state");
+  mkdirSync(testDir, { recursive: true });
+  mkdirSync(join(stateDir, "data"), { recursive: true });
+  mkdirSync(join(testDir, "wiki"), { recursive: true });
+  process.env.ARKEON_WIKI_HOME = stateDir;
+
+  const dbFile = join(stateDir, "data", "arke.db");
+  const { runMigrations } = await import("../../src/schema/index.js");
+  await runMigrations({ dbPath: dbFile });
+
+  const { startApi } = await import("../../src/server/server.js");
+  const apiHandle = await startApi({ port: API_PORT, dbPath: dbFile });
+  serverHandle = { stop: async () => apiHandle.stop() };
+
+  // Seed the corpus before registering the space so reconciliation
+  // picks it all up at once.
+  for (const w of CORPUS) writeWiki(w.path, w.props, w.body);
+
+  const created = await fetch(`${BASE_URL}/spaces`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: "journey-space", watch_dir: testDir }),
+  });
+  spaceId = ((await created.json()) as { id: string }).id;
+
+  // Wait for all wikis to land in entities.
+  const wikiDeadline = Date.now() + 60_000;
+  while (Date.now() < wikiDeadline) {
+    const wikis = await api(`/wikis?space_id=${spaceId}&limit=100`);
+    if ((wikis.wikis ?? []).length === CORPUS.length) break;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  const wikis = await api(`/wikis?space_id=${spaceId}&limit=100`);
+  expect(wikis.wikis).toHaveLength(CORPUS.length);
+
+  // Wait for the embedder to be ready (model load on cold cache may
+  // take 60-90s; warm cache is ~2s).
+  const embedder = await getEmbedder();
+  const warmDeadline = Date.now() + 5 * 60_000;
+  while (Date.now() < warmDeadline) {
+    if (embedder.state() === "ready") break;
+    if (embedder.state() === "failed") throw new Error("OnnxEmbedder failed to load");
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  expect(embedder.state()).toBe("ready");
+
+  // Drain the queue. With 15 wikis × ~5 chunks × ~50ms each, this is
+  // a few seconds on warm-ORT cache.
+  await waitForDrain(5 * 60_000);
+  const stats = await queueStats();
+  expect(stats.pending).toBe(0);
+  expect(stats.in_flight).toBe(0);
+}, 10 * 60_000);
+
+afterAll(async () => {
+  if (serverHandle) await serverHandle.stop();
+  if (testDir && existsSync(testDir)) {
+    rmSync(testDir.substring(0, testDir.lastIndexOf("/")), { recursive: true, force: true });
+  }
+  if (prevEmbedderEnv === undefined) {
+    delete process.env.ARKEON_WIKI_EMBEDDER;
+  } else {
+    process.env.ARKEON_WIKI_EMBEDDER = prevEmbedderEnv;
+  }
+  if (prevModelsDirEnv === undefined) {
+    delete process.env.ARKEON_WIKI_MODELS_DIR;
+  } else {
+    process.env.ARKEON_WIKI_MODELS_DIR = prevModelsDirEnv;
+  }
+  resetEmbedder();
+}, 60_000);
+
+// ─── Tests ──────────────────────────────────────────────────────────
+
+describe("full-journey: corpus shape and embedding coverage", () => {
+  it("every wiki has at least one chunk", async () => {
+    // Assert via vector search with a very generic query — every wiki
+    // should be retrievable somehow with limit=100.
+    const hits = await vectorSearch("introduction", 100);
+    const labelsHit = new Set(hits.map((h) => h.label));
+    for (const w of CORPUS) {
+      expect(labelsHit.has(w.props.label as string)).toBe(true);
+    }
+  });
+
+  it("returns chunks with sensible shape across the corpus", async () => {
+    const hits = await vectorSearch("research", 30);
+    expect(hits.length).toBeGreaterThan(10);
+    for (const h of hits) {
+      expect(typeof h.chunk_id).toBe("number");
+      expect(["card", "section", "section_part"]).toContain(h.chunk_kind);
+      expect(typeof h.heading_path).toBe("string");
+      expect(h.text.length).toBeGreaterThan(0);
+      expect(h.similarity).toBeGreaterThanOrEqual(-1);
+      expect(h.similarity).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe("full-journey: semantic ranking", () => {
+  // Each query has an expected top-1 label. The query is phrased so it
+  // does NOT contain the wiki's label as a substring — pure substring
+  // matching wouldn't find it. This is a real semantic test.
+  const cases: Array<{ q: string; expected: string }> = [
+    { q: "father of information theory", expected: "Claude Shannon" },
+    { q: "British computer science pioneer who broke German codes", expected: "Alan Turing" },
+    { q: "Hungarian-American polymath who founded modern computer architecture", expected: "John von Neumann" },
+    { q: "founder of the study of feedback and control systems", expected: "Norbert Wiener" },
+    { q: "abstract mathematical model of computation with an infinite tape", expected: "Turing Machine" },
+    { q: "measure of uncertainty in a probability distribution", expected: "Entropy" },
+    { q: "smallest unit of digital information, two possible values", expected: "Bit" },
+    { q: "step-by-step procedure for solving a problem", expected: "Algorithm" },
+    { q: "study of self-regulating purposive systems", expected: "Cybernetics" },
+    { q: "World War II Allied codebreaking centre in England", expected: "Bletchley Park" },
+    { q: "industrial laboratory where the transistor was invented", expected: "Bell Labs" },
+    { q: "Soviet mathematician who founded modern probability theory", expected: "Andrey Kolmogorov" },
+  ];
+
+  for (const c of cases) {
+    it(`ranks "${c.expected}" first for "${c.q}"`, async () => {
+      const hits = await vectorSearch(c.q, 5);
+      expect(hits.length).toBeGreaterThan(0);
+      expect(hits[0].label).toBe(c.expected);
+    });
+  }
+});
+
+describe("full-journey: discrimination + edge behaviour", () => {
+  it("repeated identical queries return identical top-1 (determinism)", async () => {
+    const a = await vectorSearch("father of information theory", 1);
+    const b = await vectorSearch("father of information theory", 1);
+    expect(a[0]?.entity_id).toBe(b[0]?.entity_id);
+    expect(a[0]?.similarity).toBeCloseTo(b[0]?.similarity ?? -1, 6);
+  });
+
+  it("discriminates between adjacent topics: 'feedback' favours Cybernetics over Information Theory", async () => {
+    const hits = await vectorSearch("feedback in regulatory systems", 5);
+    const cybIdx = hits.findIndex((h) => h.label === "Cybernetics");
+    const itIdx = hits.findIndex((h) => h.label === "Information Theory");
+    expect(cybIdx).toBeGreaterThanOrEqual(0);
+    if (itIdx >= 0) {
+      expect(cybIdx).toBeLessThan(itIdx);
+    }
+  });
+
+  it("a query about a genuinely irrelevant topic returns lower similarity than on-topic queries", async () => {
+    const onTopic = await vectorSearch("Shannon entropy and information content", 1);
+    const offTopic = await vectorSearch(
+      "best recipes for chocolate chip cookies and baking tips",
+      1,
+    );
+    expect(onTopic[0]?.similarity ?? 0).toBeGreaterThan(offTopic[0]?.similarity ?? 0);
+  });
+
+  it("query/document prefix asymmetry — same text as query vs document differs", async () => {
+    // The model applies different prefixes; embedding the same string
+    // as document then querying with it should still rank it highly,
+    // but the ranking order across the corpus may differ from
+    // embedding it as a query against itself. We just assert the
+    // self-match is still in the top-3 (sanity), not that it's #1
+    // (the prefix difference is real).
+    const hits = await vectorSearch(
+      "Claude Elwood Shannon was an American mathematician",
+      3,
+    );
+    expect(hits.some((h) => h.label === "Claude Shannon")).toBe(true);
+  });
+
+  it("hybrid mode: keyword and vector independently surface Shannon for 'Shannon'", async () => {
+    const data = await api(
+      `/search?space_id=${spaceId}&q=Shannon&mode=both&limit=5`,
+    );
+    expect(data.keyword.hits.some((h: any) => h.label === "Claude Shannon")).toBe(true);
+    expect(data.vector.hits.some((h: any) => h.label === "Claude Shannon")).toBe(true);
+  });
+});


### PR DESCRIPTION
Follow-up to #72 (bundled ONNX embedder). PR #72 merged before this commit could be added to it; this PR brings in the test coverage I'd intended to ship alongside that work.

Three new test files filling gaps that component-level coverage left behind:

## 1. \`test/manual/full-journey-onnx.test.ts\` (19 tests, real ONNX, manual)

A 15-wiki Information Theory corpus (Shannon, Turing, von Neumann, Wiener, Kolmogorov, Information Theory, Entropy, Cybernetics, Turing Machine, Boolean Algebra, Bit, Algorithm, Bell Labs, Bletchley Park, MIT) with multi-section content and cross-references. Runs **12 semantic queries with expected top-1 wikis**:

| Query | Expected top hit |
|---|---|
| "father of information theory" | Claude Shannon |
| "British computer science pioneer who broke German codes" | Alan Turing |
| "Hungarian-American polymath who founded modern computer architecture" | John von Neumann |
| "founder of the study of feedback and control systems" | Norbert Wiener |
| "abstract mathematical model of computation with an infinite tape" | Turing Machine |
| "measure of uncertainty in a probability distribution" | Entropy |
| "smallest unit of digital information, two possible values" | Bit |
| "step-by-step procedure for solving a problem" | Algorithm |
| "study of self-regulating purposive systems" | Cybernetics |
| "World War II Allied codebreaking centre in England" | Bletchley Park |
| "industrial laboratory where the transistor was invented" | Bell Labs |
| "Soviet mathematician who founded modern probability theory" | Andrey Kolmogorov |

All 12 confirmed against real EmbeddingGemma. Plus discrimination ("feedback in regulatory systems" prefers Cybernetics over Information Theory), determinism (same query → same top-1), on-topic vs off-topic similarity, and hybrid mode.

**What this catches**: retrieval-quality regressions that the mock-backed e2e suite structurally cannot. Mock embeds via SHA — it can't tell us the model is finding the right wiki.

## 2. \`test/e2e/queue-reclaim.test.ts\` (3 tests, mock, runs in CI)

Exercises the lease-expiration reclaim path (\`reclaimOrphans()\`) that was untested until now — it would have lived as dead code until a real user's daemon crashed.

- Plants a queue row with \`started_at\` older than the lease TTL → \`reclaimOrphans()\` resets it
- Negative case: fresh row stays in flight
- Full daemon restart path: \`server.stop()\` → fresh \`startApi()\` → worker reclaims on startup → queue drains

**Caught a real bug while writing it**: SQLite's \`datetime('now')\` returns \`'YYYY-MM-DD HH:MM:SS'\` (space-separated), but \`Date.toISOString()\` returns \`'YYYY-MM-DDTHH:MM:SSZ'\` (T-separated). The two compare differently lexicographically, so timestamps planted from JS would have silently failed the WHERE clause in \`reclaimOrphans\`. Test now uses SQLite's own datetime arithmetic to match the format the worker writes.

## 3. \`test/e2e/cli-journey.test.ts\` (5 tests, mock, runs in CI)

Spawns the actual CLI binary (via \`tsx\`, same pattern as \`daemon-lifecycle.test.ts\`) for \`arkeon-wiki up/search/status/down\`, exercising the spawn/detach/HTTP-round-trip code that the in-process \`startApi()\` tests don't touch. Verifies all three search modes (keyword | vector | both) round-trip the namespaced response shape correctly through both the daemon's JSON serialization and the CLI's output layer.

## Test plan

- [x] \`npm run typecheck -w packages/arkeon\` — clean
- [x] \`npm test -w packages/arkeon\` — 159/159 (unchanged)
- [x] \`npm run test:e2e -w packages/arkeon\` — 174/174 (was 166 → +8 new)
- [x] \`npm run test:manual -w packages/arkeon\` — 26 manual tests against real EmbeddingGemma (19 new + 7 prior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)