### PR TITLE
fix: --api-url override + ARKEON_WIKI_HOME for agents.yaml

### DIFF
--- a/packages/arkeon/src/cli/commands/repo/init.ts
+++ b/packages/arkeon/src/cli/commands/repo/init.ts
@@ -16,19 +16,19 @@ import { DEFAULT_API_PORT } from "../../lib/local-runtime.js";
 import { output } from "../../lib/output.js";
 import { loadRepoState, type RepoState } from "../../lib/repo-state.js";
 
-interface InitOptions {
-  apiUrl?: string;
-}
+// --api-url is declared on the root program (src/index.ts); the
+// preAction hook moves the value into ARKE_API_URL. Don't redeclare
+// it here — duplicate options have a precedence bug in Commander
+// where the value lands on globals but the subcommand reads locally.
 
 export function registerInitCommand(program: Command): void {
   program
     .command("init")
     .argument("[name]", "Space name (defaults to directory name)")
     .description("Register this directory as an Arkeon space")
-    .option("--api-url <url>", "API URL (default: http://localhost:8000)")
-    .action(async (name: string | undefined, options: InitOptions) => {
+    .action(async (name: string | undefined) => {
       try {
-        await runInit(name, options);
+        await runInit(name);
       } catch (error) {
         output.error(error, { operation: "init" });
         process.exitCode = 1;
@@ -36,10 +36,10 @@ export function registerInitCommand(program: Command): void {
     });
 }
 
-async function runInit(name: string | undefined, options: InitOptions): Promise<void> {
+async function runInit(name: string | undefined): Promise<void> {
   const cwd = process.cwd();
   const spaceName = name ?? basename(cwd);
-  const apiUrl = options.apiUrl ?? process.env.ARKE_API_URL ?? `http://localhost:${DEFAULT_API_PORT}`;
+  const apiUrl = process.env.ARKE_API_URL ?? `http://localhost:${DEFAULT_API_PORT}`;
 
   // Check if already initialized
   const existing = loadRepoState();

--- a/packages/arkeon/src/cli/commands/repo/search.ts
+++ b/packages/arkeon/src/cli/commands/repo/search.ts
@@ -21,7 +21,6 @@ import { output } from "../../lib/output.js";
 import { loadRepoState } from "../../lib/repo-state.js";
 
 interface SearchOptions {
-  apiUrl?: string;
   space?: string;
   all?: boolean;
   limit?: string;
@@ -64,7 +63,10 @@ export function registerSearchCommand(program: Command): void {
     .command("search")
     .argument("<query>", "Search query")
     .description("Search across registered spaces (keyword via ripgrep, vector via sqlite-vec)")
-    .option("--api-url <url>", "API URL (default: http://localhost:8000)")
+    // --api-url is declared on the root program (src/index.ts); the
+    // preAction hook moves the value into ARKE_API_URL. Declaring it
+    // here too created a precedence bug where Commander routed the
+    // value to globals but runSearch read subcommand-local opts.
     .option("--space <id>", "Space ID to search (default: bound space, or all)")
     .option("--all", "Search every registered space")
     .option(
@@ -87,10 +89,12 @@ export function registerSearchCommand(program: Command): void {
 
 async function runSearch(query: string, options: SearchOptions): Promise<void> {
   const repoState = loadRepoState();
+  // Explicit override (--api-url, captured by the root preAction hook
+  // into ARKE_API_URL) wins over the bound state file. Otherwise the
+  // user couldn't override the bound URL without deleting state.json.
   const apiUrl =
-    options.apiUrl ??
-    repoState?.api_url ??
     process.env.ARKE_API_URL ??
+    repoState?.api_url ??
     `http://localhost:${DEFAULT_API_PORT}`;
 
   const mode = options.mode ?? "both";

--- a/packages/arkeon/src/server/agents/config.ts
+++ b/packages/arkeon/src/server/agents/config.ts
@@ -66,7 +66,19 @@ export type AgentConfig = z.infer<typeof AGENT_CONFIG_SCHEMA>;
 // ── Loader ────────────────────────────────────────────────────────
 
 const REPO_RELATIVE_PATH = join(".arkeon", "agents.yaml");
-const USER_GLOBAL_PATH = join(homedir(), ".arkeon-wiki", "agents.yaml");
+
+/**
+ * Resolve the user-global agents.yaml path at call time so
+ * ARKEON_WIKI_HOME (set by `--data-dir` or by the named-instance
+ * lifecycle helpers) actually relocates it. A module-level constant
+ * captured `homedir()` once at import, which made isolated test
+ * environments and named-instance installs silently fall back to the
+ * real `~/.arkeon-wiki/agents.yaml`.
+ */
+function userGlobalPath(): string {
+  const base = process.env.ARKEON_WIKI_HOME ?? join(homedir(), ".arkeon-wiki");
+  return join(base, "agents.yaml");
+}
 
 export interface LoadAgentConfigOptions {
   /** The space's watch_dir. The repo-local config is at
@@ -82,12 +94,12 @@ export interface LoadAgentConfigOptions {
  * empty) AgentConfig.
  */
 export function loadAgentConfig(opts: LoadAgentConfigOptions = {}): AgentConfig {
-  const userGlobalPath = opts.userGlobalPath ?? USER_GLOBAL_PATH;
+  const resolvedUserGlobal = opts.userGlobalPath ?? userGlobalPath();
   const repoLocalPath = opts.spaceDir
     ? join(opts.spaceDir, REPO_RELATIVE_PATH)
     : null;
 
-  const userGlobal = readConfigFile(userGlobalPath);
+  const userGlobal = readConfigFile(resolvedUserGlobal);
   const repoLocal = repoLocalPath ? readConfigFile(repoLocalPath) : {};
 
   return mergeConfigs(userGlobal, repoLocal);

--- a/packages/arkeon/test/e2e/cli-journey.test.ts
+++ b/packages/arkeon/test/e2e/cli-journey.test.ts
@@ -53,12 +53,12 @@ interface CliResult {
 
 async function runCli(
   args: string[],
-  opts: { expectOk?: boolean } = {},
+  opts: { expectOk?: boolean; cwd?: string } = {},
 ): Promise<CliResult> {
   const { stdout, stderr } = await execFileP(
     "npx",
     ["tsx", CLI_ENTRY, ...args],
-    { env: testEnv, timeout: 30_000 },
+    { env: testEnv, timeout: 30_000, cwd: opts.cwd },
   ).catch((err: NodeJS.ErrnoException & { stdout?: string; stderr?: string }) => {
     if (err.stdout != null || err.stderr != null) {
       return { stdout: err.stdout ?? "", stderr: err.stderr ?? "" };
@@ -252,5 +252,54 @@ describe("CLI search journey through detached daemon", () => {
     const status = await runCli(["status", "--name", NAME]);
     expect(status.json.state).toBe("running");
     expect(status.json.pid).toBeTypeOf("number");
+  });
+
+  it("--api-url overrides a stale .arkeon/state.json (regression for the silent-ignore bug)", async () => {
+    // The smoke-test agent caught: when both the root and the search
+    // subcommand declared --api-url, Commander routed the value to
+    // globals but runSearch read subcommand-local opts, so the user's
+    // override silently lost to repoState.api_url. Then in runSearch's
+    // precedence, repoState beat process.env.ARKE_API_URL anyway.
+    //
+    // After the fix:
+    //   - --api-url is declared once, at the root program
+    //   - precedence is ARKE_API_URL > repoState > default
+    //   - explicit overrides win over a stale state.json
+    //
+    // This test creates a state.json pointing at a dead port, runs
+    // `arkeon-wiki search` from that directory with --api-url pointing
+    // at the real daemon, and verifies the search succeeds.
+    const cwd = join(testHome, "stale-bound-dir");
+    mkdirSync(join(cwd, ".arkeon"), { recursive: true });
+    writeFileSync(
+      join(cwd, ".arkeon", "state.json"),
+      JSON.stringify({
+        api_url: "http://localhost:65530", // a port nothing listens on
+        space_id: "stale-space",
+        space_name: "stale",
+        created_at: new Date().toISOString(),
+      }),
+    );
+
+    const res = await runCli(
+      [
+        "search",
+        "Turing",
+        "--api-url",
+        apiUrl,
+        "--space",
+        spaceId,
+        "--mode",
+        "keyword",
+      ],
+      { cwd },
+    );
+
+    // If --api-url wins, the search reaches the real daemon and Turing
+    // is found. If repoState had won, we'd have hit a connect refused
+    // on port 65530.
+    expect(res.json.ok).toBe(true);
+    const labels = (res.json.keyword.hits as { label: string }[]).map((h) => h.label);
+    expect(labels).toContain("Alan Turing");
   });
 });

--- a/packages/arkeon/test/unit/agents-config.test.ts
+++ b/packages/arkeon/test/unit/agents-config.test.ts
@@ -152,6 +152,48 @@ describe("loadAgentConfig", () => {
       }),
     ).toThrow(/not valid YAML/);
   });
+
+  it("honors ARKEON_WIKI_HOME for the user-global agents.yaml path", () => {
+    // Regression for the case the smoke test surfaced: a module-level
+    // constant captured homedir() at import, so isolated installs that
+    // override ARKEON_WIKI_HOME silently fell back to the real
+    // ~/.arkeon-wiki/agents.yaml. Now path resolution happens at call
+    // time and ARKEON_WIKI_HOME relocates it.
+    const fakeHome = join(dir, "isolated-home");
+    mkdirSync(fakeHome, { recursive: true });
+    writeFileSync(
+      join(fakeHome, "agents.yaml"),
+      "defaults:\n  provider: openai\n  model: from-arkeon-home\n",
+    );
+
+    const prev = process.env.ARKEON_WIKI_HOME;
+    try {
+      process.env.ARKEON_WIKI_HOME = fakeHome;
+      // No userGlobalPath override — exercise the code path that
+      // computes the path from env.
+      const config = loadAgentConfig({ spaceDir: dir });
+      expect(config.defaults?.model).toBe("from-arkeon-home");
+    } finally {
+      if (prev === undefined) delete process.env.ARKEON_WIKI_HOME;
+      else process.env.ARKEON_WIKI_HOME = prev;
+    }
+  });
+
+  it("falls back to ~/.arkeon-wiki/agents.yaml when ARKEON_WIKI_HOME is unset", () => {
+    // The fallback shouldn't be tested by writing to the user's real
+    // home. Just assert that an unset ARKEON_WIKI_HOME doesn't crash
+    // and returns an empty config when ~/.arkeon-wiki/agents.yaml
+    // happens not to exist on this machine. If it DOES exist, we
+    // skip — we're not validating its contents, only the resolution.
+    const prev = process.env.ARKEON_WIKI_HOME;
+    try {
+      delete process.env.ARKEON_WIKI_HOME;
+      // Should not throw; behaviour beyond that depends on the host.
+      expect(() => loadAgentConfig({ spaceDir: dir })).not.toThrow();
+    } finally {
+      if (prev !== undefined) process.env.ARKEON_WIKI_HOME = prev;
+    }
+  });
 });
 
 // ── buildAgentRole ───────────────────────────────────────────────


### PR DESCRIPTION
Two bugs surfaced by a real-user smoke test (a subagent that ran the product end-to-end against a Sherlock Holmes corpus from Project Gutenberg).

## 1. \`--api-url\` silently ignored in \`arkeon-wiki search\`

The CLI declared \`--api-url\` both globally (\`src/index.ts\`, where a preAction hook moves the value into \`ARKE_API_URL\`) **and** on the \`search\` and \`init\` subcommands. Commander routed the value to globals when both decls existed, but \`runSearch\`/\`runInit\` read subcommand-local opts → user's override did nothing.

Even after that, \`runSearch\`'s precedence was:
\`\`\`
options.apiUrl > repoState.api_url > ARKE_API_URL > default
\`\`\`
so the bound \`.arkeon/state.json\` shadowed any explicit override.

**Fix**: drop the duplicate decls; keep the root-level one. In \`runSearch\`, \`ARKE_API_URL\` now beats \`repoState\` — explicit override wins over the bound state file. \`runInit\`'s precedence chain didn't include repoState so it's already correct after the dedup.

## 2. \`agents.yaml\` lookup ignored \`ARKEON_WIKI_HOME\`

\`src/server/agents/config.ts\` captured \`homedir()\` in a module-level constant, so isolated test environments and named-instance setups that override \`ARKEON_WIKI_HOME\` silently fell back to the real \`~/.arkeon-wiki/agents.yaml\`. The smoke-test agent hit this on their first attempt — \`agents.yaml\` was placed where the docs suggested but the loader looked elsewhere, and the ingestor scheduler logged \"no provider resolved\" with no obvious clue.

**Fix**: resolve the path at call time via \`process.env.ARKEON_WIKI_HOME ?? join(homedir(), \".arkeon-wiki\")\`, matching the pattern in \`local-runtime.ts\` and \`onnx.ts\`.

## Tests

- \`agents-config.test.ts\`: ARKEON_WIKI_HOME relocates the user-global path; unset env doesn't crash. (+2 tests)
- \`cli-journey.test.ts\`: \`--api-url\` overrides a stale \`.arkeon/state.json\` pointing at a dead port. If the override didn't win, the test would hit ECONNREFUSED on port 65530. (+1 test)

Suite: **161 unit** (was 159 → +2), **175 e2e** (was 174 → +1). All green.

## Out of scope

The smoke test also surfaced **ingestor-quality** issues — zero wiki↔wiki cross-references, duplicate subjects across \`subject_type\`, \`short_description\` never populated, missing supporting entities. Those are bigger work (LLM prompt + tooling iteration) and tracked separately as a follow-up — not folded into this small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)