### PR TITLE
test: bind e2e API to an OS-assigned port; fill in LICENSE copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026, Arkeon Technologies, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/arkeon/test/e2e/embeddings.test.ts
+++ b/packages/arkeon/test/e2e/embeddings.test.ts
@@ -22,8 +22,10 @@ import { waitForEntityBySourcePath } from "./helpers.js";
 import { waitForDrain, queueStats } from "../../src/server/lib/embedding-queue.js";
 import { EMBEDDING_DIM, resetEmbedder } from "../../src/server/lib/embedder/index.js";
 
-const API_PORT = 18791;
-const BASE_URL = `http://localhost:${API_PORT}`;
+// Port is assigned by the OS (port 0) and read back from the server's
+// bound address. Hardcoding ports collides with anything the developer
+// happens to be running locally.
+let baseUrl: string;
 
 let testDir: string;
 let stateDir: string;
@@ -108,10 +110,11 @@ beforeAll(async () => {
   await runMigrations({ dbPath: dbFile });
 
   const { startApi } = await import("../../src/server/server.js");
-  const apiHandle = await startApi({ port: API_PORT, dbPath: dbFile });
+  const apiHandle = await startApi({ port: 0, dbPath: dbFile });
+  baseUrl = `http://localhost:${apiHandle.address.port}`;
   serverHandle = { stop: () => apiHandle.stop() };
 
-  const res = await fetch(`${BASE_URL}/spaces`, {
+  const res = await fetch(`${baseUrl}/spaces`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ name: "embeddings-test", watch_dir: testDir }),
@@ -378,7 +381,7 @@ describe("embedding pipeline (mock embedder)", () => {
     expect(chunksBefore.length).toBeGreaterThan(0);
     expect((await getPivots(entity.id)).length).toBe(chunksBefore.length);
 
-    const res = await fetch(`${BASE_URL}/wikis/${entity.id}`, { method: "DELETE" });
+    const res = await fetch(`${baseUrl}/wikis/${entity.id}`, { method: "DELETE" });
     expect(((await res.json()) as { deleted: boolean }).deleted).toBe(true);
 
     // Cascades: chunks gone → pivots gone (FK CASCADE). Vec0 cleanup

--- a/packages/arkeon/test/e2e/search.test.ts
+++ b/packages/arkeon/test/e2e/search.test.ts
@@ -21,8 +21,10 @@ import yaml from "js-yaml";
 import { waitForDrain } from "../../src/server/lib/embedding-queue.js";
 import { resetEmbedder } from "../../src/server/lib/embedder/index.js";
 
-const API_PORT = 18791;
-const BASE_URL = `http://localhost:${API_PORT}`;
+// Port is assigned by the OS (port 0) and read back from the server's
+// bound address. Hardcoding ports collides with anything the developer
+// happens to be running locally.
+let baseUrl: string;
 
 let testDir: string;
 let stateDir: string;
@@ -45,7 +47,7 @@ function writeWiki(
 }
 
 async function api(path: string): Promise<any> {
-  const res = await fetch(`${BASE_URL}${path}`);
+  const res = await fetch(`${baseUrl}${path}`);
   if (res.headers.get("content-type")?.includes("json")) {
     return res.json();
   }
@@ -84,7 +86,8 @@ beforeAll(async () => {
   await runMigrations({ dbPath: dbFile });
 
   const { startApi } = await import("../../src/server/server.js");
-  const apiHandle = await startApi({ port: API_PORT, dbPath: dbFile });
+  const apiHandle = await startApi({ port: 0, dbPath: dbFile });
+  baseUrl = `http://localhost:${apiHandle.address.port}`;
   serverHandle = { stop: async () => apiHandle.stop() };
 
   // Seed files BEFORE creating the space so reconciliation picks them up.
@@ -104,7 +107,7 @@ beforeAll(async () => {
     "Computability theory was advanced by Alan Turing.",
   );
 
-  const created = await fetch(`${BASE_URL}/spaces`, {
+  const created = await fetch(`${baseUrl}/spaces`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ name: "search-space", watch_dir: testDir }),
@@ -452,7 +455,7 @@ describe("GET /search — vector edge cases", () => {
     expect(probeId).not.toBeNull();
 
     // Delete via the API. /wikis/{id} cascades.
-    const del = await fetch(`${BASE_URL}/wikis/${probeId}`, { method: "DELETE" });
+    const del = await fetch(`${baseUrl}/wikis/${probeId}`, { method: "DELETE" });
     expect((await del.json() as { deleted: boolean }).deleted).toBe(true);
 
     // Vector results should no longer surface this entity. The chunk row
@@ -568,7 +571,7 @@ describe("GET /search — cross-space scoping", () => {
       `---\n${fm}\n---\n\nA scoped probe: SECOND_SPACE_PROBE_TOKEN appears here.`,
     );
 
-    const created = await fetch(`${BASE_URL}/spaces`, {
+    const created = await fetch(`${baseUrl}/spaces`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary

- `embeddings.test.ts` and `search.test.ts` both hardcoded `API_PORT = 18791`. When anything else on the developer's machine was bound to 18791 (IPv4), `@hono/node-server` silently bound the test API to IPv6 only and reported success. The test then fetched `http://localhost:18791/...` which resolves IPv4 first on macOS, hit the squatter, and got a non-JSON response — surfacing as `SyntaxError: Unexpected token 'U', "Unauthorized" is not valid JSON` with no stack trace and all 7/34 tests in the suite skipped.
- Both suites now request `port: 0` and read the actual port back from `apiHandle.address.port`. The change is local to those two files.
- Drive-by: fill in the Apache-2.0 copyright placeholder in `LICENSE` (`[yyyy] [name of copyright owner]` → `2026, Arkeon Technologies, Inc.`).

The other six e2e suites still hardcode their own ports — same fragile pattern, just lower-probability collisions today. Tracked in #77.

## Test plan

- [x] `npm run typecheck -w packages/arkeon` clean
- [x] `npm test -w packages/arkeon` — 166/166 unit tests pass
- [x] `npm run test:e2e -w packages/arkeon` — 175/175 pass (was 137 passed / 41 skipped before this change, with a squatter on 18791)
- [x] Reproduced the original failure with an unrelated 401-returning service on 18791; suites pass with that service still running after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)