### PR TITLE
feat: structured agent run traces (off by default)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,21 @@ E2e tests start a real stack in-process — no running instance needed.
 
 Override the state dir with `ARKEON_WIKI_HOME` env var or `--data-dir`.
 
+## Debugging agent runs
+
+Agents emit verbose, human-readable logs to the daemon log unconditionally (`[agent/<role>/<level>] ...`). For *structured* per-event traces — every tool call, every edit, every phase boundary, with timing and token usage — set `ARKEON_WIKI_AGENT_TRACE=1`. Off by default (production).
+
+When enabled, one JSON object per line is appended to `<arkeonHome>/agent-trace.jsonl` (override path with `ARKEON_WIKI_AGENT_TRACE_FILE`). Each event carries `ts`, `run_id`, `role`, `space_id`, `phase`, plus event-specific fields:
+
+- `run.start` — phases planned, idempotency key, trigger path
+- `run.skipped` — when alreadyProcessed short-circuits
+- `phase.start` / `phase.end` — model, tool whitelist, step count, token usage, duration
+- `tool.call` / `tool.result` — args (truncated to 500 chars), per-tool `summary` (e.g. `search` reports `keyword_hits`, `vector_hits`, `vector_model`; `list_wikis` reports `total`/`returned`), `duration_ms`, `ok`
+- `edit` — path, edit_kind (create|append|replace), char counts (no body content)
+- `run.end` / `run.error` — total steps, edits, usage, duration
+
+Tail with `tail -f <path> | jq` or query with `jq -c 'select(.event=="tool.call" and .tool=="search")'`. The schema is unversioned debug-time output; consumers (jq queries, test harnesses) update with the producer.
+
 ## Schema migrations
 
 `src/schema/*.sql`, applied in alphabetical order. Currently `001-foundation.sql` (entities, spaces, relationships, agent runtime), `002-chunks.sql` (`entity_chunks`), and `003-embeddings.sql` (`chunk_vectors` vec0 table, `entity_embeddings` pivot, `embedding_queue`). Must be idempotent (all `IF NOT EXISTS`). Runs on every startup. Note: `003-embeddings.sql` requires the sqlite-vec extension to be loaded; `initDb()` does this automatically before migrations run.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,8 @@ When enabled, one JSON object per line is appended to `<arkeonHome>/agent-trace.
 
 Tail with `tail -f <path> | jq` or query with `jq -c 'select(.event=="tool.call" and .tool=="search")'`. The schema is unversioned debug-time output; consumers (jq queries, test harnesses) update with the producer.
 
+The writer is append-only — there is no built-in rotation, so the file grows as long as tracing stays on. That's fine for the intended use (turn it on for an investigation, off afterwards). Reset between investigations with `truncate -s 0 <path>` or `rm <path>` (the writer recreates it on next emit).
+
 ## Schema migrations
 
 `src/schema/*.sql`, applied in alphabetical order. Currently `001-foundation.sql` (entities, spaces, relationships, agent runtime), `002-chunks.sql` (`entity_chunks`), and `003-embeddings.sql` (`chunk_vectors` vec0 table, `entity_embeddings` pivot, `embedding_queue`). Must be idempotent (all `IF NOT EXISTS`). Runs on every startup. Note: `003-embeddings.sql` requires the sqlite-vec extension to be loaded; `initDb()` does this automatically before migrations run.

--- a/packages/arkeon/src/server/agents/define-tool.ts
+++ b/packages/arkeon/src/server/agents/define-tool.ts
@@ -19,6 +19,7 @@ import type { Tool } from "ai";
 import { z } from "zod";
 
 import type { AgentContext } from "./runtime.js";
+import { truncateForTrace } from "./tracer.js";
 
 export interface DefineToolOptions<TInput, TOutput> {
   description: string;
@@ -26,6 +27,11 @@ export interface DefineToolOptions<TInput, TOutput> {
   /** What actually runs. Receives the validated input and the agent
    *  context (space, applyEdit, log, ...). */
   call: (input: TInput, ctx: AgentContext) => Promise<TOutput> | TOutput;
+  /** Optional small summary of the tool's result for trace events.
+   *  Tools whose results can be large (search, list_wikis, read_file)
+   *  should supply this so traces stay legible. If omitted, the tracer
+   *  records the byte size of the full result instead. */
+  summarize?: (result: TOutput) => unknown;
 }
 
 /** A function that, given a context, returns the AI-SDK tool. */
@@ -41,11 +47,31 @@ export function defineTool<TInput, TOutput>(
       inputSchema: opts.inputSchema,
       execute: async (input: TInput) => {
         ctx.log("info", `tool/${name}`, { input });
+        ctx.trace("tool.call", {
+          tool: name,
+          args: truncateForTrace(input),
+        });
+        const startedAt = Date.now();
         try {
-          return await opts.call(input, ctx);
+          const result = await opts.call(input, ctx);
+          ctx.trace("tool.result", {
+            tool: name,
+            ok: true,
+            duration_ms: Date.now() - startedAt,
+            summary: opts.summarize
+              ? opts.summarize(result)
+              : { result_chars: estimateChars(result) },
+          });
+          return result;
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           ctx.log("error", `tool/${name} failed`, { error: message });
+          ctx.trace("tool.result", {
+            tool: name,
+            ok: false,
+            duration_ms: Date.now() - startedAt,
+            error: message,
+          });
           throw err;
         }
       },
@@ -58,4 +84,13 @@ export function defineTool<TInput, TOutput>(
     // calls, and that's what `definition` provides.
     return definition as unknown as Tool;
   };
+}
+
+function estimateChars(value: unknown): number {
+  if (value == null) return 0;
+  try {
+    return JSON.stringify(value)?.length ?? 0;
+  } catch {
+    return String(value).length;
+  }
 }

--- a/packages/arkeon/src/server/agents/runtime.ts
+++ b/packages/arkeon/src/server/agents/runtime.ts
@@ -18,7 +18,7 @@
  * SDK call, and persistence of the run record. Roles stay tiny.
  */
 
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import {
   generateText,
@@ -39,6 +39,7 @@ import { createSql } from "../lib/sql.js";
 import { type Space } from "../lib/sync.js";
 
 import { resolveModel, type ModelConfig } from "./model.js";
+import { getTracer, truncateForTrace, type Tracer } from "./tracer.js";
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -55,9 +56,20 @@ export interface ToolEditOpts {
 export interface AgentContext {
   space: Space;
   role: string;
+  /** Stable identifier for this run, threaded through every trace event
+   *  emitted by tools, edits, and the runtime itself. Random UUID per
+   *  invocation of `runAgent`. */
+  runId: string;
+  /** Name of the phase the runtime is currently executing, or `null`
+   *  when no phase is active (e.g. during run.start before phase 0).
+   *  Mutable so tools can read the current phase at call time. */
+  currentPhase: string | null;
   edits: ApplyEditResult[];
   applyEdit(edit: FileEdit, opts: ToolEditOpts): Promise<ApplyEditResult>;
   log(level: "info" | "warn" | "error", msg: string, meta?: Record<string, unknown>): void;
+  /** Emit a structured trace event. No-op when tracing is disabled.
+   *  Auto-fills run_id, role, space_id, and phase. */
+  trace(event: string, fields?: Record<string, unknown>): void;
 }
 
 export type ToolFactory = (ctx: AgentContext) => Tool;
@@ -147,15 +159,33 @@ export async function runAgent(
 ): Promise<AgentRunResult> {
   return withPathLock(role.concurrencyKey(input), async () => {
     const idem = role.idempotencyKey(input);
+    const ctx = makeContext(input.space, role.name);
+    const runStartedAt = Date.now();
+
     if (await alreadyProcessed(role.name, idem)) {
+      ctx.trace("run.skipped", {
+        reason: "already_processed",
+        idempotency_key: idem.key,
+        input_hash: idem.hash,
+        trigger_path: input.triggerPath,
+      });
       return { skipped: true, reason: "already_processed", edits: [], text: "", steps: 0 };
     }
 
-    const ctx = makeContext(input.space, role.name);
     const { system, phases } = await role.buildPhases(input);
     if (phases.length === 0) {
       throw new Error(`Role '${role.name}': buildPhases returned no phases`);
     }
+
+    ctx.trace("run.start", {
+      space_name: input.space.name,
+      idempotency_key: idem.key,
+      input_hash: idem.hash,
+      trigger_path: input.triggerPath,
+      trigger_entity_id: input.triggerEntityId,
+      phases: phases.map((p) => p.name),
+      system_chars: system.length,
+    });
 
     // Each phase resolves to its own model + tools. We keep the system
     // message constant across phases (it's the role's identity) and
@@ -170,6 +200,8 @@ export async function runAgent(
     try {
       for (let i = 0; i < phases.length; i++) {
         const phase = phases[i];
+        ctx.currentPhase = phase.name;
+        const phaseStartedAt = Date.now();
 
         // Resolve tools for this phase.
         const tools: Record<string, Tool> = {};
@@ -193,6 +225,15 @@ export async function runAgent(
         const model =
           options.modelOverride ?? (resolveModel(phase.model) as LanguageModel);
 
+        ctx.trace("phase.start", {
+          phase_index: i,
+          model: describeModel(phase.model),
+          tools: phase.tools,
+          max_steps: phase.maxSteps,
+          prompt_chars: phase.prompt.length,
+          prompt_preview: truncateForTrace(phase.prompt, 240),
+        });
+
         const result = await generateText({
           model,
           system,
@@ -212,9 +253,32 @@ export async function runAgent(
           outputTokens: result.totalUsage?.outputTokens,
           totalTokens: result.totalUsage?.totalTokens,
         });
+
+        ctx.trace("phase.end", {
+          phase_index: i,
+          steps: result.steps.length,
+          finish_reason: result.finishReason,
+          text_chars: result.text.length,
+          text_preview: truncateForTrace(result.text, 500),
+          usage: {
+            input_tokens: result.totalUsage?.inputTokens,
+            output_tokens: result.totalUsage?.outputTokens,
+            total_tokens: result.totalUsage?.totalTokens,
+          },
+          duration_ms: Date.now() - phaseStartedAt,
+        });
+        ctx.currentPhase = null;
       }
 
       await markProcessed(role.name, idem, "completed", null);
+
+      ctx.trace("run.end", {
+        ok: true,
+        total_steps: totalSteps,
+        total_edits: ctx.edits.length,
+        usage: aggregatedUsage,
+        duration_ms: Date.now() - runStartedAt,
+      });
 
       return {
         skipped: false,
@@ -226,6 +290,13 @@ export async function runAgent(
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       await markProcessed(role.name, idem, "failed", msg);
+      ctx.trace("run.error", {
+        error: msg,
+        total_steps: totalSteps,
+        total_edits: ctx.edits.length,
+        usage: aggregatedUsage,
+        duration_ms: Date.now() - runStartedAt,
+      });
       throw err;
     }
   });
@@ -246,11 +317,19 @@ function mergeUsage(
 
 // ── Helpers ───────────────────────────────────────────────────────
 
-export function makeContext(space: Space, role: string): AgentContext {
+export function makeContext(
+  space: Space,
+  role: string,
+  options: { runId?: string; tracer?: Tracer } = {},
+): AgentContext {
   const edits: ApplyEditResult[] = [];
-  return {
+  const runId = options.runId ?? randomUUID();
+  const tracer = options.tracer ?? getTracer();
+  const ctx: AgentContext = {
     space,
     role,
+    runId,
+    currentPhase: null,
     edits,
     applyEdit: async (edit, opts) => {
       const result = await applyEdit(space, edit, {
@@ -259,13 +338,46 @@ export function makeContext(space: Space, role: string): AgentContext {
         note: opts.note,
       });
       edits.push(result);
+      // Edit event fires after the write succeeds. We deliberately log
+      // path + size, never the body — the source of truth is the file.
+      ctx.trace("edit", {
+        path: result.path,
+        edit_kind: opts.edit_kind,
+        edit_mode: edit.kind, // "write" | "edit"
+        note: opts.note,
+        search_chars: edit.kind === "edit" ? edit.search.length : 0,
+        replace_chars:
+          edit.kind === "edit"
+            ? edit.replace.length
+            : edit.kind === "write"
+              ? edit.content.length
+              : 0,
+      });
       return result;
     },
     log: (level, msg, meta) => {
       const tail = meta ? ` ${JSON.stringify(meta)}` : "";
       console.log(`[agent/${role}/${level}] ${msg}${tail}`);
     },
+    trace: (event, fields) => {
+      if (!tracer.enabled) return;
+      tracer.emit({
+        event,
+        run_id: runId,
+        role,
+        space_id: space.id,
+        phase: ctx.currentPhase,
+        ...(fields ?? {}),
+      });
+    },
   };
+  return ctx;
+}
+
+/** Compact representation of a model config for trace events. We don't
+ *  log the API key, baseURL, or anything that could leak secrets. */
+function describeModel(model: ModelConfig): string {
+  return `${model.provider}:${model.id}`;
 }
 
 /**

--- a/packages/arkeon/src/server/agents/tools.ts
+++ b/packages/arkeon/src/server/agents/tools.ts
@@ -51,6 +51,14 @@ const readFileTool = defineTool("read_file", {
     }
     return { path, content };
   },
+  summarize: (r) => {
+    const text = "body" in r ? r.body : r.content;
+    return {
+      path: r.path,
+      body_chars: text?.length ?? 0,
+      has_frontmatter: "frontmatter" in r,
+    };
+  },
 });
 
 // ── search ────────────────────────────────────────────────────────
@@ -134,6 +142,19 @@ const searchTool = defineTool("search", {
     }
     return out;
   },
+  summarize: (r) => {
+    const k = r.keyword as { hits?: unknown[]; total?: number } | undefined;
+    const v = r.vector as { hits?: unknown[]; total?: number; model?: string } | undefined;
+    return {
+      query: r.query,
+      mode: r.mode,
+      keyword_hits: k?.hits?.length,
+      keyword_total: k?.total,
+      vector_hits: v?.hits?.length,
+      vector_total: v?.total,
+      vector_model: v?.model,
+    };
+  },
 });
 
 // ── list_wikis ────────────────────────────────────────────────────
@@ -190,6 +211,14 @@ const listWikisTool = defineTool("list_wikis", {
       limit: input.limit,
       offset: input.offset,
     }),
+  summarize: (r) => {
+    const wikis = (r as { wikis?: unknown[] }).wikis;
+    const total = (r as { total?: number }).total;
+    return {
+      total,
+      returned: Array.isArray(wikis) ? wikis.length : undefined,
+    };
+  },
 });
 
 // ── edit_file ─────────────────────────────────────────────────────
@@ -269,6 +298,7 @@ const editFileTool = defineTool("edit_file", {
     );
     return { path: result.path, mode: "replace" };
   },
+  summarize: (r) => ({ path: r.path, mode: r.mode }),
 });
 
 // ── Registry ──────────────────────────────────────────────────────

--- a/packages/arkeon/src/server/agents/tracer.ts
+++ b/packages/arkeon/src/server/agents/tracer.ts
@@ -79,7 +79,17 @@ function build(): Tracer {
           mkdirSync(dirname(filePath), { recursive: true });
           dirEnsured = true;
         }
-        const line = JSON.stringify({ ts: new Date().toISOString(), ...event });
+        // ts is assigned AFTER the spread so a caller-supplied `ts`
+        // field can never shadow the auto-generated one. The trace
+        // timestamp is authoritative; events that happen to carry
+        // their own ts (e.g. a tool result echoing a server time)
+        // retain their fields under different names but never lie
+        // about when this writer recorded them.
+        const line = JSON.stringify({ ...event, ts: new Date().toISOString() });
+        // appendFileSync is synchronous, so concurrent emit() calls
+        // from the same process serialize on the JS event loop and
+        // can't interleave. If we ever spawn a worker thread that
+        // also writes here, switch to a queue.
         appendFileSync(filePath, line + "\n");
       } catch (err) {
         live = false;

--- a/packages/arkeon/src/server/agents/tracer.ts
+++ b/packages/arkeon/src/server/agents/tracer.ts
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Structured agent run traces.
+ *
+ * Off by default. Set ARKEON_WIKI_AGENT_TRACE=1 to enable. The tracer
+ * appends one JSON object per line to a file (default
+ * `<arkeonHome>/agent-trace.jsonl`, override with
+ * ARKEON_WIKI_AGENT_TRACE_FILE) describing the lifecycle of every
+ * `runAgent` call: which subjects the agent looked up, which tools it
+ * called with what arguments, what it edited and how, token usage per
+ * phase, errors. Read it back with `jq`.
+ *
+ * Tracing must never break a run. All file I/O is best-effort — a
+ * failed write logs once and disables the writer for the rest of the
+ * process so we don't spam stderr.
+ *
+ * The schema is intentionally not versioned. It's a debug-time stream;
+ * if we change the shape, we change the consumers (jq queries, test
+ * harnesses) along with it.
+ */
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+// ── Types ─────────────────────────────────────────────────────────
+
+export interface TraceEvent {
+  /** Short event name, e.g. "run.start", "tool.call", "edit", "run.end". */
+  event: string;
+  /** Per-call fields. The writer adds `ts` automatically. */
+  [key: string]: unknown;
+}
+
+export interface Tracer {
+  enabled: boolean;
+  emit(event: TraceEvent): void;
+}
+
+// ── Public surface ────────────────────────────────────────────────
+
+/** Singleton tracer for this process. Lazy: doesn't touch the FS until
+ *  the first emit. Reads env at first call (process-stable). */
+export function getTracer(): Tracer {
+  if (cached === undefined) cached = build();
+  return cached;
+}
+
+/** Test helper: forget the cached tracer so a subsequent getTracer()
+ *  re-reads env. Not for production use. */
+export function _resetTracerForTests(): void {
+  cached = undefined;
+}
+
+// ── Implementation ────────────────────────────────────────────────
+
+let cached: Tracer | undefined;
+
+function build(): Tracer {
+  if (!isEnabled()) {
+    return {
+      enabled: false,
+      emit: () => {},
+    };
+  }
+
+  const filePath = resolveFilePath();
+  let live = true;
+  let dirEnsured = false;
+
+  return {
+    enabled: true,
+    emit(event: TraceEvent): void {
+      if (!live) return;
+      try {
+        if (!dirEnsured) {
+          mkdirSync(dirname(filePath), { recursive: true });
+          dirEnsured = true;
+        }
+        const line = JSON.stringify({ ts: new Date().toISOString(), ...event });
+        appendFileSync(filePath, line + "\n");
+      } catch (err) {
+        live = false;
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(
+          `[agent/tracer] disabling trace file (${filePath}): ${msg}`,
+        );
+      }
+    },
+  };
+}
+
+function isEnabled(): boolean {
+  const v = process.env.ARKEON_WIKI_AGENT_TRACE;
+  if (!v) return false;
+  const lower = v.toLowerCase();
+  return lower !== "" && lower !== "0" && lower !== "false" && lower !== "no";
+}
+
+function resolveFilePath(): string {
+  const override = process.env.ARKEON_WIKI_AGENT_TRACE_FILE;
+  if (override && override.length > 0) return override;
+  const home = process.env.ARKEON_WIKI_HOME ?? join(homedir(), ".arkeon-wiki");
+  return join(home, "agent-trace.jsonl");
+}
+
+// ── Helpers consumers can reuse ───────────────────────────────────
+
+/**
+ * Truncate a value for tracing. Stringifies, slices to `max` chars, and
+ * if the string was clipped returns `{value, truncated: true, full_chars}`
+ * instead so consumers can spot incomplete records.
+ */
+export function truncateForTrace(
+  value: unknown,
+  max = 500,
+): unknown {
+  let s: string;
+  try {
+    s = typeof value === "string" ? value : JSON.stringify(value);
+  } catch {
+    s = String(value);
+  }
+  if (s.length <= max) return value;
+  return {
+    value: s.slice(0, max),
+    truncated: true,
+    full_chars: s.length,
+  };
+}

--- a/packages/arkeon/test/unit/agents.test.ts
+++ b/packages/arkeon/test/unit/agents.test.ts
@@ -13,11 +13,14 @@ function makeFakeContext(): AgentContext {
   return {
     space: { id: "test-space", name: "test", watch_dir: "/tmp/nope" },
     role: "test-role",
+    runId: "test-run-id",
+    currentPhase: null,
     edits: [],
     applyEdit: vi.fn(async () => {
       throw new Error("not used in this test");
     }),
     log: vi.fn(),
+    trace: vi.fn(),
   };
 }
 
@@ -67,6 +70,71 @@ describe("defineTool", () => {
       "tool/boom failed",
       { error: "kaboom" },
     );
+  });
+
+  it("emits tool.call and tool.result trace events on success", async () => {
+    const factory = defineTool("traced", {
+      description: "trace me",
+      inputSchema: z.object({ q: z.string() }),
+      call: () => ({ hits: [1, 2, 3] }),
+      summarize: (r) => ({ count: r.hits.length }),
+    });
+    const ctx = makeFakeContext();
+    const t = factory(ctx) as { execute: (input: unknown) => Promise<unknown> };
+    await t.execute({ q: "holmes" });
+
+    expect(ctx.trace).toHaveBeenCalledWith("tool.call", {
+      tool: "traced",
+      args: { q: "holmes" },
+    });
+    const calls = (ctx.trace as ReturnType<typeof vi.fn>).mock.calls;
+    const resultCall = calls.find((c) => c[0] === "tool.result");
+    expect(resultCall).toBeDefined();
+    expect(resultCall![1]).toMatchObject({
+      tool: "traced",
+      ok: true,
+      summary: { count: 3 },
+    });
+    // duration_ms is non-deterministic but must be present and a number.
+    expect(typeof resultCall![1].duration_ms).toBe("number");
+  });
+
+  it("emits tool.result with ok:false when the tool throws", async () => {
+    const factory = defineTool("explodes", {
+      description: "explodes",
+      inputSchema: z.object({}),
+      call: () => {
+        throw new Error("nope");
+      },
+    });
+    const ctx = makeFakeContext();
+    const t = factory(ctx) as { execute: (input: unknown) => Promise<unknown> };
+    await expect(t.execute({})).rejects.toThrow("nope");
+
+    const calls = (ctx.trace as ReturnType<typeof vi.fn>).mock.calls;
+    const resultCall = calls.find((c) => c[0] === "tool.result");
+    expect(resultCall![1]).toMatchObject({
+      tool: "explodes",
+      ok: false,
+      error: "nope",
+    });
+  });
+
+  it("falls back to result_chars summary when summarize is omitted", async () => {
+    const factory = defineTool("unsummarized", {
+      description: "no summarize fn",
+      inputSchema: z.object({}),
+      call: () => ({ a: 1, b: 2 }),
+    });
+    const ctx = makeFakeContext();
+    const t = factory(ctx) as { execute: (input: unknown) => Promise<unknown> };
+    await t.execute({});
+
+    const calls = (ctx.trace as ReturnType<typeof vi.fn>).mock.calls;
+    const resultCall = calls.find((c) => c[0] === "tool.result");
+    expect(resultCall![1].summary).toEqual({
+      result_chars: JSON.stringify({ a: 1, b: 2 }).length,
+    });
   });
 });
 

--- a/packages/arkeon/test/unit/tracer.test.ts
+++ b/packages/arkeon/test/unit/tracer.test.ts
@@ -79,6 +79,24 @@ describe("tracer", () => {
     expect(parsed[2].event).toBe("run.end");
   });
 
+  it("auto-generated ts wins when an event also carries its own ts", () => {
+    const file = join(tmp, "trace.jsonl");
+    process.env.ARKEON_WIKI_AGENT_TRACE = "1";
+    process.env.ARKEON_WIKI_AGENT_TRACE_FILE = file;
+    _resetTracerForTests();
+
+    const tracer = getTracer();
+    tracer.emit({ event: "run.start", ts: "1999-01-01T00:00:00.000Z" });
+
+    const parsed = JSON.parse(readFileSync(file, "utf-8").trim());
+    // The writer must overwrite a caller-supplied ts so the trace
+    // timestamp is always the writer's notion of "now".
+    expect(parsed.ts).not.toBe("1999-01-01T00:00:00.000Z");
+    expect(parsed.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    const written = new Date(parsed.ts).getTime();
+    expect(Math.abs(written - Date.now())).toBeLessThan(5000);
+  });
+
   it("creates the parent directory lazily on first emit", () => {
     const file = join(tmp, "nested", "deeply", "trace.jsonl");
     process.env.ARKEON_WIKI_AGENT_TRACE = "1";

--- a/packages/arkeon/test/unit/tracer.test.ts
+++ b/packages/arkeon/test/unit/tracer.test.ts
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  _resetTracerForTests,
+  getTracer,
+  truncateForTrace,
+} from "../../src/server/agents/tracer.js";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "arkeon-tracer-"));
+  _resetTracerForTests();
+  delete process.env.ARKEON_WIKI_AGENT_TRACE;
+  delete process.env.ARKEON_WIKI_AGENT_TRACE_FILE;
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+  delete process.env.ARKEON_WIKI_AGENT_TRACE;
+  delete process.env.ARKEON_WIKI_AGENT_TRACE_FILE;
+  _resetTracerForTests();
+});
+
+describe("tracer", () => {
+  it("is disabled by default — emit() is a no-op and no file is created", () => {
+    const tracer = getTracer();
+    expect(tracer.enabled).toBe(false);
+
+    tracer.emit({ event: "run.start", run_id: "r1" });
+
+    // No env var, no override path: nothing should land anywhere.
+    expect(existsSync(join(tmp, "agent-trace.jsonl"))).toBe(false);
+  });
+
+  it.each([
+    ["0", false],
+    ["false", false],
+    ["FALSE", false],
+    ["", false],
+    ["no", false],
+    ["1", true],
+    ["true", true],
+    ["TRUE", true],
+    ["yes", true],
+  ])("env value '%s' -> enabled=%s", (value, expected) => {
+    process.env.ARKEON_WIKI_AGENT_TRACE = value;
+    _resetTracerForTests();
+    const tracer = getTracer();
+    expect(tracer.enabled).toBe(expected);
+  });
+
+  it("writes JSONL events to ARKEON_WIKI_AGENT_TRACE_FILE when enabled", () => {
+    const file = join(tmp, "trace.jsonl");
+    process.env.ARKEON_WIKI_AGENT_TRACE = "1";
+    process.env.ARKEON_WIKI_AGENT_TRACE_FILE = file;
+    _resetTracerForTests();
+
+    const tracer = getTracer();
+    tracer.emit({ event: "run.start", run_id: "r1", role: "ingestor" });
+    tracer.emit({ event: "tool.call", run_id: "r1", tool: "search" });
+    tracer.emit({ event: "run.end", run_id: "r1", ok: true });
+
+    const lines = readFileSync(file, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(3);
+    const parsed = lines.map((l) => JSON.parse(l));
+    expect(parsed[0].event).toBe("run.start");
+    expect(parsed[0].run_id).toBe("r1");
+    expect(parsed[0].role).toBe("ingestor");
+    expect(parsed[0].ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(parsed[1].tool).toBe("search");
+    expect(parsed[2].event).toBe("run.end");
+  });
+
+  it("creates the parent directory lazily on first emit", () => {
+    const file = join(tmp, "nested", "deeply", "trace.jsonl");
+    process.env.ARKEON_WIKI_AGENT_TRACE = "1";
+    process.env.ARKEON_WIKI_AGENT_TRACE_FILE = file;
+    _resetTracerForTests();
+
+    const tracer = getTracer();
+    expect(existsSync(file)).toBe(false);
+
+    tracer.emit({ event: "run.start" });
+    expect(existsSync(file)).toBe(true);
+  });
+});
+
+describe("truncateForTrace", () => {
+  it("returns short values unchanged", () => {
+    expect(truncateForTrace("hello")).toBe("hello");
+    expect(truncateForTrace({ x: 1 })).toEqual({ x: 1 });
+    expect(truncateForTrace(42)).toBe(42);
+  });
+
+  it("truncates long strings and reports the full length", () => {
+    const long = "a".repeat(2000);
+    const out = truncateForTrace(long, 100) as {
+      value: string;
+      truncated: boolean;
+      full_chars: number;
+    };
+    expect(out.truncated).toBe(true);
+    expect(out.full_chars).toBe(2000);
+    expect(out.value.length).toBe(100);
+  });
+
+  it("truncates long objects via JSON serialization", () => {
+    const big = { items: Array.from({ length: 200 }, (_, i) => `item-${i}`) };
+    const out = truncateForTrace(big, 80) as {
+      value: string;
+      truncated: boolean;
+      full_chars: number;
+    };
+    expect(out.truncated).toBe(true);
+    expect(out.value.length).toBe(80);
+    expect(out.full_chars).toBeGreaterThan(80);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an opt-in **JSONL agent-run trace** so we can audit what each ingestor (or any future role) actually does — subjects it looked up, tools it called with what args, wikis created vs edited, per-phase tokens + timing.
- **Off in production.** Set `ARKEON_WIKI_AGENT_TRACE=1` to enable; events append to `<arkeonHome>/agent-trace.jsonl` (override path with `ARKEON_WIKI_AGENT_TRACE_FILE`). Disabled tracer is a no-op — no FS touch, no cost beyond a flag check.
- Per-tool `summarize` hook means `tool.result` events carry compact structured info (e.g. `search` reports `keyword_hits`, `vector_hits`, `vector_model`) instead of dumping the full payload, so the file stays legible at scale.

## Why this lands first

We want to refine the ingestor against overlapping source corpora and watch wikis "get richer over time." The single biggest blocker is observability into the agent's discovery + create-vs-edit decisions. Right now we see the *outcome* (`edit_kind` in `entity_edits`), not the *reasoning* (which tools it chose, whether it actually consulted vector search, how long each phase took). This PR is that observability surface — everything downstream (synthesizer cascade, fixture corpora, tuning prompts) is much easier to land on top.

## Event surface

| Event | Fields |
|---|---|
| `run.start` | role, space_id, idempotency_key, input_hash, trigger_path, phases, system_chars |
| `run.skipped` | reason=already_processed |
| `phase.start` | phase_index, model (provider:id), tools, max_steps, prompt_chars, prompt_preview |
| `tool.call` | tool, args (truncated to 500 chars) |
| `tool.result` | tool, ok, duration_ms, summary (per-tool — see below) or error |
| `edit` | path, edit_kind (create/append/replace), edit_mode (write/edit), char counts |
| `phase.end` | steps, finish_reason, text_chars, text_preview, usage, duration_ms |
| `run.end` / `run.error` | total_steps, total_edits, usage, duration_ms |

Per-tool `summary`:
- `read_file` → `{path, body_chars, has_frontmatter}`
- `search` → `{query, mode, keyword_hits, keyword_total, vector_hits, vector_total, vector_model}`
- `list_wikis` → `{total, returned}`
- `edit_file` → `{path, mode}`
- Unknown tools → `{result_chars: N}` fallback

## Notes

- Schema is intentionally **unversioned** debug-time output. Consumers (jq queries, test harnesses) update with the producer.
- Tracing is **fail-soft**: a write error logs once and disables the writer for the rest of the process. A run never fails because tracing failed.
- All log fields are size-bounded (chars / token counts / truncated previews). No body content, no API keys, no full-file payloads end up in the trace file.

## Test plan

- [x] Unit tests for the tracer module: env-var toggle truth table, lazy directory creation, JSONL formatting, truncation helper.
- [x] Unit tests for `defineTool` instrumentation: `tool.call` + `tool.result` (success), `tool.result` with `ok:false` on throw, `result_chars` fallback when `summarize` is omitted.
- [x] `npm run typecheck`: clean.
- [x] `npm test`: 197/197 passing.
- [x] `npm run test:e2e`: 192/192 passing (exercises real `runAgent` paths through `makeContext`).
- [ ] Smoke test against a real ingestor run with `ARKEON_WIKI_AGENT_TRACE=1` and inspect the JSONL output (deferred to follow-up since it requires API keys + the Gutenberg corpus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)