### PR TITLE
feat: delete_wiki agent tool

### DIFF
--- a/packages/arkeon/src/server/agents/tools.ts
+++ b/packages/arkeon/src/server/agents/tools.ts
@@ -307,6 +307,74 @@ const editFileTool = defineTool("edit_file", {
   summarize: (r) => ({ path: r.path, mode: r.mode }),
 });
 
+// ── delete_wiki ───────────────────────────────────────────────────
+
+/**
+ * Remove a wiki file from disk and its entity from the index.
+ *
+ * Off-limits to the ingestor by default — the consolidator role uses
+ * this to merge a wiki into another and then delete the now-empty
+ * source. The convention the consolidator's prompt enforces is "you
+ * only delete YOUR OWN subject's wiki, never someone else's", which
+ * keeps cascading consolidation runs orderly.
+ *
+ * `reason` is required and surfaces in the agent trace alongside the
+ * tool call. There's no permanent audit row in `entity_edits` because
+ * its FK cascades on entity deletion — provenance for deletes lives in
+ * `agent_runs` + the structured trace, not in the per-entity history.
+ *
+ * Restricted to `wiki/**` paths so an agent can never accidentally
+ * delete a source file or .arkeon state.
+ */
+const deleteWikiTool = defineTool("delete_wiki", {
+  description:
+    "Delete a wiki file from disk and remove it from the index. " +
+    "Use this when consolidating: you've folded the subject's content " +
+    "into another wiki (via edit_file APPEND on that wiki) and the " +
+    "current wiki should no longer exist. Only paths under `wiki/` are " +
+    "allowed — you cannot delete source files. The `reason` is recorded " +
+    "in the run trace; write it as if it were a commit message.",
+  inputSchema: z.object({
+    path: z
+      .string()
+      .describe(
+        "Relative path inside the space's watch_dir. Must start with `wiki/`.",
+      ),
+    reason: z
+      .string()
+      .min(1)
+      .describe(
+        "One-line explanation of why this wiki is being deleted (e.g. " +
+          "'merged into wiki/concept/lust.md — same subject under different label'). " +
+          "Surfaces in the agent trace; future operators read this when " +
+          "auditing what the consolidator did.",
+      ),
+  }),
+  call: async ({ path, reason }, ctx) => {
+    if (!path.startsWith("wiki/")) {
+      throw new Error(
+        `delete_wiki: path '${path}' must be under wiki/ (only wiki files can be deleted)`,
+      );
+    }
+    const result = await ctx.applyEdit(
+      { kind: "delete", path },
+      { edit_kind: "delete", note: reason },
+    );
+    if (result.kind !== "delete") {
+      throw new Error(`delete_wiki: unexpected applyEdit result kind`);
+    }
+    return {
+      path: result.path,
+      removed_entity_id: result.removedEntityId,
+      reason,
+    };
+  },
+  summarize: (r) => ({
+    path: r.path,
+    removed_entity_id: r.removed_entity_id,
+  }),
+});
+
 // ── Registry ──────────────────────────────────────────────────────
 
 export const ALL_TOOLS: Record<string, ToolFactory> = {
@@ -314,4 +382,5 @@ export const ALL_TOOLS: Record<string, ToolFactory> = {
   search: searchTool,
   list_wikis: listWikisTool,
   edit_file: editFileTool,
+  delete_wiki: deleteWikiTool,
 };

--- a/packages/arkeon/test/e2e/agent-tools.test.ts
+++ b/packages/arkeon/test/e2e/agent-tools.test.ts
@@ -127,6 +127,33 @@ describe("path safety", () => {
       }),
     ).rejects.toThrow(/escapes/);
   });
+
+  it("delete_wiki rejects a non-wiki path (e.g. sources/)", async () => {
+    await expect(
+      tool("delete_wiki").execute({
+        path: "sources/article.txt",
+        reason: "should be blocked by the wiki/ guardrail",
+      }),
+    ).rejects.toThrow(/must be under wiki\//);
+  });
+
+  it("delete_wiki rejects path traversal", async () => {
+    await expect(
+      tool("delete_wiki").execute({
+        path: "wiki/../../escape.md",
+        reason: "should be blocked by safeResolve",
+      }),
+    ).rejects.toThrow(/escapes/);
+  });
+
+  it("delete_wiki rejects absolute path", async () => {
+    await expect(
+      tool("delete_wiki").execute({
+        path: "/tmp/leak.md",
+        reason: "should be blocked by safeResolve",
+      }),
+    ).rejects.toThrow(/must be under wiki\//);
+  });
 });
 
 // ── read_file ─────────────────────────────────────────────────────
@@ -376,6 +403,79 @@ describe("edit_file edge cases", () => {
     expect(
       readFileSync(join(testDir, "wiki/concept/two-edits.md"), "utf-8"),
     ).toContain("FIRST SECOND THIRD.");
+  });
+});
+
+// ── delete_wiki ───────────────────────────────────────────────────
+
+describe("delete_wiki edge cases", () => {
+  it("removes the file from disk and the entity from the index", async () => {
+    // Create a wiki, wait for it to land in the index, then delete it.
+    mkdirSync(join(testDir, "wiki/concept"), { recursive: true });
+    const path = "wiki/concept/to-delete.md";
+    await tool("edit_file").execute({
+      path,
+      search: "",
+      replace: "---\nlabel: ToDelete\nsubject_type: concept\n---\n\nbody\n",
+    });
+    expect(existsSync(join(testDir, path))).toBe(true);
+
+    const sql = createSql();
+    const deadline = Date.now() + 5000;
+    let entityId: string | undefined;
+    while (Date.now() < deadline) {
+      const rows = (await sql`
+        SELECT id FROM entities WHERE space_id = ${space.id} AND source_path = ${path}
+      `) as { id: string }[];
+      if (rows.length > 0) {
+        entityId = rows[0].id;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    expect(entityId).toBeTruthy();
+
+    const result = (await tool("delete_wiki").execute({
+      path,
+      reason: "test cleanup",
+    })) as { path: string; removed_entity_id: string | null; reason: string };
+
+    expect(result.path).toBe(path);
+    expect(result.removed_entity_id).toBe(entityId);
+    expect(result.reason).toBe("test cleanup");
+    expect(existsSync(join(testDir, path))).toBe(false);
+
+    const after = (await sql`
+      SELECT id FROM entities WHERE space_id = ${space.id} AND source_path = ${path}
+    `) as { id: string }[];
+    expect(after).toHaveLength(0);
+  });
+
+  it("throws when the file does not exist", async () => {
+    await expect(
+      tool("delete_wiki").execute({
+        path: "wiki/concept/never-existed.md",
+        reason: "should fail — file is not there",
+      }),
+    ).rejects.toThrow(/does not exist/);
+  });
+
+  it("records the edit on the agent context with edit_kind=delete", async () => {
+    mkdirSync(join(testDir, "wiki/concept"), { recursive: true });
+    const path = "wiki/concept/ctx-record.md";
+    const { tool: w } = toolWithCtx("edit_file");
+    await w.execute({
+      path,
+      search: "",
+      replace: "---\nlabel: CtxRecord\nsubject_type: concept\n---\n\nbody\n",
+    });
+
+    const { tool: d, ctx } = toolWithCtx("delete_wiki");
+    await d.execute({ path, reason: "verifying ctx.edits" });
+
+    const last = ctx.edits[ctx.edits.length - 1];
+    expect(last.kind).toBe("delete");
+    expect(last.path).toBe(path);
   });
 });
 


### PR DESCRIPTION
## Summary

- New `delete_wiki` agent tool that wraps `applyEdit({kind: "delete"})`. First step of the consolidator role (PR2 follows).
- Required `reason` argument surfaces in the structured agent trace alongside the `tool.call` event.
- Restricted to `wiki/**` paths so an agent can never accidentally delete a source file or `.arkeon/**` state.
- Off by default — only roles that explicitly include `"delete_wiki"` in their tool whitelist get it. Ingestor's whitelist is unchanged.

### Why no `entity_edits` row for deletes

`entity_edits.entity_id` has `ON DELETE CASCADE`, so any pre-delete audit row would be wiped along with the entity it references. Inserting one would be a no-op. Provenance for deletes lives in `agent_runs` (the consolidator's run record) and the structured trace at `<arkeonHome>/agent-trace.jsonl` (the `tool.call` event captures the `reason`).

The existing `applyEdit({kind: "delete"})` plumbing was already in place — `EditKind` includes `"delete"`, the schema CHECK constraint already accepts it, and `applyEdit` already wires `unlinkSync` + `removeByPath`. This PR just adds the agent-facing tool on top.

### Out of scope

- The HTTP `DELETE /wikis/:id` route has its own (separate) wart where it deletes the entity from SQLite but doesn't unlink the file from disk. Not touching it in this PR — orthogonal concern.
- The consolidator role itself ships in the follow-up.

## Test plan
- [x] Typecheck clean
- [x] Unit tests (198 / 198)
- [x] E2E tests (197 / 197) — includes new `delete_wiki edge cases` describe block + path-safety guards
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)