### PR TITLE
feat: consolidator agent role (per-wiki cascade after ingestor)

### DIFF
--- a/packages/arkeon/src/server/agents/builtins.ts
+++ b/packages/arkeon/src/server/agents/builtins.ts
@@ -266,6 +266,234 @@ const INGESTOR_WRITE_PROMPT = [
   "handled. [SKIP] subjects need no action.",
 ].join("\n");
 
+// ─── consolidator: shared system prompt ────────────────────────────
+//
+// The corpus-aware pass that runs after the ingestor. The ingestor
+// works one-source-at-a-time and can't see overlap, redundancy, or
+// thin coverage that emerges across multiple sources. The consolidator
+// runs per-wiki, surveys the corpus, and decides whether the subject
+// wiki should fold into another (or absorb a "see also" cross-link
+// for context). The outward-only invariant is what makes the cascade
+// safe: each run only acts on its own subject — never replaces other
+// wikis' content, never pulls material from elsewhere into self.
+
+const CONSOLIDATOR_SYSTEM = [
+  "You are a consolidator for a filesystem-first knowledge graph.",
+  "",
+  "You run per-wiki, after the ingestor writes one. The ingestor",
+  "works one source at a time and can't see overlap or redundancy",
+  "that appears once multiple sources have been ingested. Your job",
+  "is the corpus-aware pass: given one wiki (the *subject*), decide",
+  "whether and how to consolidate it with the rest of the corpus.",
+  "",
+  "You work in two phases: GATHER, then EDIT. Both phases share this",
+  "conversation — phase 2 sees every tool call and result from phase 1.",
+  "Don't repeat work between phases.",
+  "",
+  "── The outward-only rule ─────────────────────────────────────────",
+  "You operate from the subject wiki's point of view. The only edits",
+  "you can make are:",
+  "",
+  "  (a) Edit or DELETE the subject wiki itself.",
+  "  (b) APPEND content to OTHER wikis.",
+  "",
+  "You never REPLACE another wiki's content. You never pull material",
+  "from another wiki INTO the subject. If the subject overlaps with",
+  "another wiki, the move is to fold the subject INTO them — partial",
+  "or full — never the reverse. If two wikis really should bleed in",
+  "the opposite direction, that's the *other* wiki's consolidator run",
+  "to make when its turn comes.",
+  "",
+  "This rule keeps cascading consolidation orderly: each run only acts",
+  "outward, the chain self-terminates, and provenance stays clean.",
+  "",
+  "── Action taxonomy ───────────────────────────────────────────────",
+  "For each wiki the corpus search surfaces, choose one action:",
+  "",
+  "  IGNORE       Unrelated or only loosely topically adjacent. No move.",
+  "",
+  "  CROSS_LINK   Distinct subjects that should reference each other.",
+  "               REPLACE the relevant phrase in the SUBJECT's body to",
+  "               add a markdown link to the other wiki — if the link",
+  "               isn't there yet. Don't touch the other wiki: when",
+  "               its consolidator runs, it'll add the reverse link.",
+  "",
+  "  BLEED_INTO   The subject covers material that genuinely belongs",
+  "               in the other wiki's article. APPEND that material",
+  "               as a new topical section to the other wiki, with",
+  "               every inline citation preserved. Then REPLACE the",
+  "               subject's body to trim the bled section out — the",
+  "               subject stays as a standalone wiki when its unique",
+  "               content remains substantial.",
+  "",
+  "  MERGE_INTO   The subject and the other wiki cover the same topic.",
+  "               The other wiki is the better home (broader scope,",
+  "               more inbound links, or the canonical name). APPEND",
+  "               the subject's unique material to the other wiki as",
+  "               a new section, then call delete_wiki on the SUBJECT",
+  "               with a reason that names the destination.",
+  "",
+  "If nothing meets these bars, no-op. Doing nothing is a valid and",
+  "common outcome. The cost of an unnecessary edit is high — you're",
+  "moving someone's words around — so the bar for action should be",
+  "high too.",
+  "",
+  "── Wiki conventions reminder ────────────────────────────────────",
+  "Wiki files live at wiki/{subject_type}/{slug}.md. When you add",
+  "links, use **workspace-rooted paths** (leading /):",
+  "",
+  "  good:  [Bell Labs](/wiki/organization/bell-labs.md)",
+  "  bad:   [Bell Labs](../organization/bell-labs.md)",
+  "",
+  "When you APPEND material to another wiki, follow the same shape",
+  "the ingestor uses: a topical heading (## ...) followed by",
+  "synthesized prose with inline citations preserved verbatim. Don't",
+  "strip citations to make the bleed cleaner — they're load-bearing.",
+  "Don't paraphrase quoted phrases out of existence.",
+  "",
+  "── Tool semantics ────────────────────────────────────────────────",
+  "edit_file:",
+  "  APPEND  — empty `search`, new material as `replace`. Adds at end",
+  "            of body. The only edit you can make to OTHER wikis.",
+  "  REPLACE — non-empty `search` (must match exactly once),",
+  "            substitution as `replace`. Allowed on the SUBJECT only.",
+  "  CREATE  — you won't create new wikis. That's the ingestor's job.",
+  "",
+  "delete_wiki: removes a wiki file from disk and the index. Required",
+  "  `path` must be the subject's path (you only delete YOURSELF).",
+  "  Required `reason` shows up in the run trace — write it like a",
+  "  commit message:",
+  "    'merged into wiki/concept/lust.md — same subject, that's the",
+  "     canonical wiki'.",
+  "",
+  "Hard rules — these will be enforced at runtime, but understand them:",
+  "  - delete_wiki only on paths starting with `wiki/`.",
+  "  - edit_file REPLACE only on the subject wiki ({{trigger_path}}).",
+  "  - edit_file APPEND on any wiki under `wiki/`.",
+].join("\n");
+
+// ─── Phase 1: gather ───────────────────────────────────────────────
+//
+// Read the subject wiki, survey the corpus for related material,
+// produce a structured plan. No edits in this phase.
+
+const CONSOLIDATOR_GATHER_PROMPT = [
+  "Subject wiki path: {{trigger_path}}",
+  "Subject wiki entity id: {{trigger_entity_id}}",
+  "",
+  "Phase 1 of 2: GATHER. Do not edit any files in this phase.",
+  "",
+  "1. read_file the subject wiki. Note its label, subject_type,",
+  "   short_description, body length, and the wikis it currently",
+  "   links to.",
+  "",
+  "   If read_file throws 'does not exist', the wiki was deleted",
+  "   between trigger time and now (most likely an earlier",
+  "   consolidator run merged it away). End the gather here and",
+  "   write a single final message: 'Subject wiki gone — no work to",
+  "   do.' Phase 2 will be a no-op.",
+  "",
+  "2. Search the corpus for related wikis. ONE call usually suffices:",
+  "",
+  "     search(query=<a representative phrase from the subject's body",
+  "                   or its short_description>,",
+  "            mode='vector', limit=8)",
+  "",
+  "   Each vector hit is a complete wiki — label, frontmatter, full",
+  "   body — ranked by similarity. Read each top hit's body and",
+  "   classify it against the action taxonomy:",
+  "",
+  "     - Same subject under a different label?               → MERGE_INTO",
+  "     - Different subject but the subject's body covers",
+  "       material that fits there as a section?              → BLEED_INTO",
+  "     - Distinct, but should reference each other?          → CROSS_LINK",
+  "     - Related field but not the same subject?             → IGNORE",
+  "",
+  "   Bar for action is high. If you're unsure between two actions,",
+  "   pick the smaller one (CROSS_LINK over BLEED_INTO; BLEED_INTO",
+  "   over MERGE_INTO; IGNORE over anything). The corpus only needs",
+  "   to be more correct after your run, not more rearranged.",
+  "",
+  "3. Skip the subject itself if it appears in your search results.",
+  "   You'll often see your own wiki in the top hits — ignore it.",
+  "",
+  "4. End your phase 1 message with a structured plan — one bullet",
+  "   per non-IGNORE candidate from step 2:",
+  "",
+  "     - <other wiki path>: <ACTION> — <one-line rationale>",
+  "",
+  "   ACTION is one of MERGE_INTO, BLEED_INTO, CROSS_LINK. List",
+  "   IGNORE candidates only if it helps your reasoning be legible;",
+  "   they don't drive any action. End with one of:",
+  "",
+  "     Self: KEEP                  (no destructive action on self)",
+  "     Self: SHRINK → <path>       (BLEED_INTO this destination)",
+  "     Self: DELETE → <path>       (MERGE_INTO this destination)",
+  "",
+  "   If all candidates are IGNORE and the subject is fine as-is,",
+  "   write a final line: 'Plan: no-op.' Phase 2 will be a no-op.",
+  "",
+  "Stop and wait for the EDIT phase prompt. Do not call edit_file or",
+  "delete_wiki yet.",
+].join("\n");
+
+// ─── Phase 2: edit ─────────────────────────────────────────────────
+//
+// Execute the plan. The action types map onto a small, fixed set of
+// edit moves; the agent's job is to write good prose for the bleed
+// content and pick correct REPLACE spans for cross-link insertions.
+
+const CONSOLIDATOR_EDIT_PROMPT = [
+  "Phase 2 of 2: EDIT.",
+  "",
+  "Execute the plan from phase 1. If phase 1 ended with",
+  "'Plan: no-op.' or 'Subject wiki gone — no work to do.', stop",
+  "immediately without calling any edit tools.",
+  "",
+  "For each non-IGNORE candidate in your plan:",
+  "",
+  "CROSS_LINK:",
+  "  edit_file REPLACE on the SUBJECT ({{trigger_path}}). Find the",
+  "  phrase in the subject's body that names the other wiki and",
+  "  REPLACE it with a markdown link:",
+  "    'Bell Labs' → '[Bell Labs](/wiki/organization/bell-labs.md)'",
+  "  Only do this if the link isn't already there. Don't touch the",
+  "  other wiki — its consolidator run will add the reverse link.",
+  "",
+  "BLEED_INTO:",
+  "  Step 1 — edit_file APPEND on the OTHER wiki. Carry the bled",
+  "  material over as a new topical section, with every inline",
+  "  citation preserved verbatim. Pick a topical heading that fits",
+  "  the destination's existing structure.",
+  "",
+  "  Step 2 — edit_file REPLACE on the SUBJECT. Trim the bled",
+  "  material out of the subject's body. If a heading-and-section",
+  "  block bled wholesale, REPLACE the entire block with a one-line",
+  "  pointer like 'See [Other](/wiki/.../other.md)' so a reader of",
+  "  the subject still finds the material. Preserve the rest of the",
+  "  subject's body untouched.",
+  "",
+  "MERGE_INTO:",
+  "  Step 1 — edit_file APPEND on the OTHER wiki. Carry the subject's",
+  "  unique material over as one or more topical sections, with",
+  "  inline citations preserved.",
+  "",
+  "  Step 2 — delete_wiki the SUBJECT ({{trigger_path}}) with a",
+  "  reason that names the destination. Example reason:",
+  "    'merged into /wiki/concept/lust.md — same subject under a",
+  "     different label; canonical wiki kept'.",
+  "",
+  "Hard rules:",
+  "  - You may DELETE only the subject ({{trigger_path}}).",
+  "  - You may REPLACE content only on the subject.",
+  "  - You may APPEND to any wiki under wiki/.",
+  "  - Every link you write uses a workspace-rooted path (leading /).",
+  "  - Inline citations [text](path) are load-bearing — preserve",
+  "    every one when you bleed material across.",
+  "",
+  "Stop when every plan item has been handled.",
+].join("\n");
+
 export const BUILTIN_ROLES: Record<string, RoleConfig> = {
   // ── ingestor ───────────────────────────────────────────────────
   // Two-phase agent. GATHER reads the source and surveys existing
@@ -308,6 +536,49 @@ export const BUILTIN_ROLES: Record<string, RoleConfig> = {
         // the writer needs to look something up it didn't fetch in
         // phase 1.
         tools: ["read_file", "list_wikis", "search", "edit_file"],
+      },
+    ],
+  },
+
+  // ── consolidator ────────────────────────────────────────────────
+  // Per-wiki cascade after the ingestor. GATHER reads the subject
+  // wiki and surveys the corpus for related material; EDIT executes
+  // the resulting plan (cross-link, bleed, merge, or no-op). The
+  // outward-only invariant is enforced by the prompt and by the
+  // delete_wiki tool's path guardrails.
+  //
+  // Trigger fires only on wiki edits whose latest entity_edits row
+  // is attributed to the ingestor — so human edits to wikis don't
+  // cascade (a human knows what they're doing), and the consolidator's
+  // own writes can't loop back via by_role_not.
+  consolidator: {
+    tools: ["read_file", "list_wikis", "search", "edit_file", "delete_wiki"],
+    max_steps: 30,
+    system: CONSOLIDATOR_SYSTEM,
+    triggers: [
+      {
+        on: "file_changed",
+        path_under: ["wiki/**"],
+        by_role: ["ingestor"],
+        by_role_not: ["consolidator"],
+      },
+    ],
+    phases: [
+      {
+        name: "gather",
+        prompt: CONSOLIDATOR_GATHER_PROMPT,
+        // Phase 1 surveys the corpus; no mutations. delete_wiki and
+        // edit_file are off the menu here so the agent literally
+        // cannot edit before the plan is written.
+        tools: ["read_file", "list_wikis", "search"],
+      },
+      {
+        name: "edit",
+        prompt: CONSOLIDATOR_EDIT_PROMPT,
+        // Phase 2 executes. Gather tools stay available for last-
+        // minute lookups (e.g. confirming a wiki's exact body before
+        // deciding the REPLACE span).
+        tools: ["read_file", "list_wikis", "search", "edit_file", "delete_wiki"],
       },
     ],
   },

--- a/packages/arkeon/src/server/agents/tools.ts
+++ b/packages/arkeon/src/server/agents/tools.ts
@@ -307,6 +307,74 @@ const editFileTool = defineTool("edit_file", {
   summarize: (r) => ({ path: r.path, mode: r.mode }),
 });
 
+// ── delete_wiki ───────────────────────────────────────────────────
+
+/**
+ * Remove a wiki file from disk and its entity from the index.
+ *
+ * Off-limits to the ingestor by default — the consolidator role uses
+ * this to merge a wiki into another and then delete the now-empty
+ * source. The convention the consolidator's prompt enforces is "you
+ * only delete YOUR OWN subject's wiki, never someone else's", which
+ * keeps cascading consolidation runs orderly.
+ *
+ * `reason` is required and surfaces in the agent trace alongside the
+ * tool call. There's no permanent audit row in `entity_edits` because
+ * its FK cascades on entity deletion — provenance for deletes lives in
+ * `agent_runs` + the structured trace, not in the per-entity history.
+ *
+ * Restricted to `wiki/**` paths so an agent can never accidentally
+ * delete a source file or .arkeon state.
+ */
+const deleteWikiTool = defineTool("delete_wiki", {
+  description:
+    "Delete a wiki file from disk and remove it from the index. " +
+    "Use this when consolidating: you've folded the subject's content " +
+    "into another wiki (via edit_file APPEND on that wiki) and the " +
+    "current wiki should no longer exist. Only paths under `wiki/` are " +
+    "allowed — you cannot delete source files. The `reason` is recorded " +
+    "in the run trace; write it as if it were a commit message.",
+  inputSchema: z.object({
+    path: z
+      .string()
+      .describe(
+        "Relative path inside the space's watch_dir. Must start with `wiki/`.",
+      ),
+    reason: z
+      .string()
+      .min(1)
+      .describe(
+        "One-line explanation of why this wiki is being deleted (e.g. " +
+          "'merged into wiki/concept/lust.md — same subject under different label'). " +
+          "Surfaces in the agent trace; future operators read this when " +
+          "auditing what the consolidator did.",
+      ),
+  }),
+  call: async ({ path, reason }, ctx) => {
+    if (!path.startsWith("wiki/")) {
+      throw new Error(
+        `delete_wiki: path '${path}' must be under wiki/ (only wiki files can be deleted)`,
+      );
+    }
+    const result = await ctx.applyEdit(
+      { kind: "delete", path },
+      { edit_kind: "delete", note: reason },
+    );
+    if (result.kind !== "delete") {
+      throw new Error(`delete_wiki: unexpected applyEdit result kind`);
+    }
+    return {
+      path: result.path,
+      removed_entity_id: result.removedEntityId,
+      reason,
+    };
+  },
+  summarize: (r) => ({
+    path: r.path,
+    removed_entity_id: r.removed_entity_id,
+  }),
+});
+
 // ── Registry ──────────────────────────────────────────────────────
 
 export const ALL_TOOLS: Record<string, ToolFactory> = {
@@ -314,4 +382,5 @@ export const ALL_TOOLS: Record<string, ToolFactory> = {
   search: searchTool,
   list_wikis: listWikisTool,
   edit_file: editFileTool,
+  delete_wiki: deleteWikiTool,
 };

--- a/packages/arkeon/test/e2e/agent-tools.test.ts
+++ b/packages/arkeon/test/e2e/agent-tools.test.ts
@@ -127,6 +127,33 @@ describe("path safety", () => {
       }),
     ).rejects.toThrow(/escapes/);
   });
+
+  it("delete_wiki rejects a non-wiki path (e.g. sources/)", async () => {
+    await expect(
+      tool("delete_wiki").execute({
+        path: "sources/article.txt",
+        reason: "should be blocked by the wiki/ guardrail",
+      }),
+    ).rejects.toThrow(/must be under wiki\//);
+  });
+
+  it("delete_wiki rejects path traversal", async () => {
+    await expect(
+      tool("delete_wiki").execute({
+        path: "wiki/../../escape.md",
+        reason: "should be blocked by safeResolve",
+      }),
+    ).rejects.toThrow(/escapes/);
+  });
+
+  it("delete_wiki rejects absolute path", async () => {
+    await expect(
+      tool("delete_wiki").execute({
+        path: "/tmp/leak.md",
+        reason: "should be blocked by safeResolve",
+      }),
+    ).rejects.toThrow(/must be under wiki\//);
+  });
 });
 
 // ── read_file ─────────────────────────────────────────────────────
@@ -376,6 +403,79 @@ describe("edit_file edge cases", () => {
     expect(
       readFileSync(join(testDir, "wiki/concept/two-edits.md"), "utf-8"),
     ).toContain("FIRST SECOND THIRD.");
+  });
+});
+
+// ── delete_wiki ───────────────────────────────────────────────────
+
+describe("delete_wiki edge cases", () => {
+  it("removes the file from disk and the entity from the index", async () => {
+    // Create a wiki, wait for it to land in the index, then delete it.
+    mkdirSync(join(testDir, "wiki/concept"), { recursive: true });
+    const path = "wiki/concept/to-delete.md";
+    await tool("edit_file").execute({
+      path,
+      search: "",
+      replace: "---\nlabel: ToDelete\nsubject_type: concept\n---\n\nbody\n",
+    });
+    expect(existsSync(join(testDir, path))).toBe(true);
+
+    const sql = createSql();
+    const deadline = Date.now() + 5000;
+    let entityId: string | undefined;
+    while (Date.now() < deadline) {
+      const rows = (await sql`
+        SELECT id FROM entities WHERE space_id = ${space.id} AND source_path = ${path}
+      `) as { id: string }[];
+      if (rows.length > 0) {
+        entityId = rows[0].id;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    expect(entityId).toBeTruthy();
+
+    const result = (await tool("delete_wiki").execute({
+      path,
+      reason: "test cleanup",
+    })) as { path: string; removed_entity_id: string | null; reason: string };
+
+    expect(result.path).toBe(path);
+    expect(result.removed_entity_id).toBe(entityId);
+    expect(result.reason).toBe("test cleanup");
+    expect(existsSync(join(testDir, path))).toBe(false);
+
+    const after = (await sql`
+      SELECT id FROM entities WHERE space_id = ${space.id} AND source_path = ${path}
+    `) as { id: string }[];
+    expect(after).toHaveLength(0);
+  });
+
+  it("throws when the file does not exist", async () => {
+    await expect(
+      tool("delete_wiki").execute({
+        path: "wiki/concept/never-existed.md",
+        reason: "should fail — file is not there",
+      }),
+    ).rejects.toThrow(/does not exist/);
+  });
+
+  it("records the edit on the agent context with edit_kind=delete", async () => {
+    mkdirSync(join(testDir, "wiki/concept"), { recursive: true });
+    const path = "wiki/concept/ctx-record.md";
+    const { tool: w } = toolWithCtx("edit_file");
+    await w.execute({
+      path,
+      search: "",
+      replace: "---\nlabel: CtxRecord\nsubject_type: concept\n---\n\nbody\n",
+    });
+
+    const { tool: d, ctx } = toolWithCtx("delete_wiki");
+    await d.execute({ path, reason: "verifying ctx.edits" });
+
+    const last = ctx.edits[ctx.edits.length - 1];
+    expect(last.kind).toBe("delete");
+    expect(last.path).toBe(path);
   });
 });
 

--- a/packages/arkeon/test/e2e/consolidator-trigger.test.ts
+++ b/packages/arkeon/test/e2e/consolidator-trigger.test.ts
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * E2E tests for the builtin consolidator's declarative trigger.
+ *
+ * The consolidator is the first builtin role to use *positive*
+ * attribution (`by_role: ["ingestor"]`) on top of negative loop-safety
+ * (`by_role_not: ["consolidator"]`). This exercises that combination
+ * end-to-end:
+ *
+ *   1. Ingestor edits a wiki     → consolidator fires (by_role match)
+ *   2. Consolidator edits a wiki → consolidator does NOT refire
+ *                                  (by_role_not blocks)
+ *   3. Human edits a wiki        → consolidator does NOT fire
+ *                                  (by_role positive filter rejects
+ *                                   the "human" / null attribution)
+ *
+ * As in trigger-cascade.test.ts, we drive scheduler.notify() directly
+ * with an injected fake runAgent — the real LLM path isn't exercised
+ * here, just the trigger plumbing.
+ */
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+
+import { applyEdit } from "../../src/server/lib/file-edits.js";
+import { closeDb, createSql } from "../../src/server/lib/sql.js";
+import { generateUlid } from "../../src/server/lib/ids.js";
+import { runMigrations } from "../../src/schema/index.js";
+import { startScheduler } from "../../src/server/agents/scheduler.js";
+
+let testDir: string;
+let stateDir: string;
+let space: { id: string; name: string; watch_dir: string };
+let prevEmbeddingsEnv: string | undefined;
+let prevChunkingEnv: string | undefined;
+let prevOpenaiKey: string | undefined;
+
+beforeAll(async () => {
+  prevEmbeddingsEnv = process.env.ARKEON_WIKI_EMBEDDINGS;
+  prevChunkingEnv = process.env.ARKEON_WIKI_CHUNKING;
+  prevOpenaiKey = process.env.OPENAI_API_KEY;
+  process.env.ARKEON_WIKI_EMBEDDINGS = "0";
+  process.env.ARKEON_WIKI_CHUNKING = "0";
+
+  const base = join(tmpdir(), `arkeon-consolidator-${randomBytes(4).toString("hex")}`);
+  testDir = join(base, "repo");
+  stateDir = join(base, "state");
+  mkdirSync(testDir, { recursive: true });
+  mkdirSync(join(testDir, "wiki", "concept"), { recursive: true });
+  mkdirSync(join(testDir, ".arkeon"), { recursive: true });
+  mkdirSync(join(stateDir, "data"), { recursive: true });
+
+  // Narrow the ingestor's trigger so direct applyEdit({role: "ingestor"})
+  // calls in the test (which simulate post-source ingestion writes) don't
+  // re-fire the ingestor itself when scheduler.notify is called. The
+  // consolidator's own builtin trigger is left unmodified — that's what
+  // we're testing.
+  writeFileSync(
+    join(testDir, ".arkeon/agents.yaml"),
+    [
+      "defaults:",
+      "  provider: openai",
+      "  model: gpt-mock",
+      "roles:",
+      "  ingestor:",
+      "    triggers:",
+      "      - on: file_changed",
+      "        path_under: ['sources/**']",
+      "        by_role_not: ['ingestor']",
+      "",
+    ].join("\n"),
+  );
+
+  process.env.OPENAI_API_KEY = "sk-fake-for-test";
+  process.env.DATABASE_PATH = join(stateDir, "data", "arke.db");
+  await runMigrations({ dbPath: process.env.DATABASE_PATH });
+
+  space = { id: generateUlid(), name: "consolidator-test", watch_dir: testDir };
+  const sql = createSql();
+  await sql`INSERT INTO spaces (id, name, watch_dir) VALUES (${space.id}, ${space.name}, ${space.watch_dir})`;
+}, 30_000);
+
+afterAll(async () => {
+  closeDb();
+  if (testDir) {
+    rmSync(testDir.substring(0, testDir.lastIndexOf("/")), {
+      recursive: true,
+      force: true,
+    });
+  }
+  if (prevEmbeddingsEnv === undefined) delete process.env.ARKEON_WIKI_EMBEDDINGS;
+  else process.env.ARKEON_WIKI_EMBEDDINGS = prevEmbeddingsEnv;
+  if (prevChunkingEnv === undefined) delete process.env.ARKEON_WIKI_CHUNKING;
+  else process.env.ARKEON_WIKI_CHUNKING = prevChunkingEnv;
+  if (prevOpenaiKey === undefined) delete process.env.OPENAI_API_KEY;
+  else process.env.OPENAI_API_KEY = prevOpenaiKey;
+}, 10_000);
+
+describe("consolidator trigger — by_role positive attribution + loop safety", () => {
+  it("fires on ingestor's wiki edit; not on consolidator's own; not on human's", async () => {
+    const fakeConsolidator = vi.fn(async (_role, _input, _registry) => ({
+      skipped: false,
+      edits: [],
+      text: "ok",
+      steps: 0,
+      usage: undefined,
+    }));
+
+    const scheduler = await startScheduler({
+      space,
+      // Only the consolidator worker runs — the ingestor's worker
+      // would attempt to call OpenAI on its own queue, which we don't
+      // need to exercise here.
+      triggerRoles: ["consolidator"],
+      runAgentFn: fakeConsolidator,
+    });
+
+    try {
+      const wikiPath = "wiki/concept/lust.md";
+
+      // ── 1. Ingestor edits a wiki ─────────────────────────────────
+      // applyEdit stamps by_role=ingestor on the entity_edits row
+      // syncFile inserts.
+      await applyEdit(
+        space,
+        {
+          kind: "write",
+          path: wikiPath,
+          content: [
+            "---",
+            "label: Lust",
+            "subject_type: concept",
+            "---",
+            "",
+            "Disordered desire.",
+            "",
+          ].join("\n"),
+        },
+        { role: "ingestor", edit_kind: "create" },
+      );
+      await scheduler.notify(wikiPath);
+      await waitFor(() => fakeConsolidator.mock.calls.length > 0, 3000);
+
+      expect(fakeConsolidator).toHaveBeenCalledTimes(1);
+      expect(fakeConsolidator.mock.calls[0][0].name).toBe("consolidator");
+      expect(fakeConsolidator.mock.calls[0][1].triggerPath).toBe(wikiPath);
+
+      // ── 2. Consolidator's own edit ───────────────────────────────
+      // Stamps by_role=consolidator. The consolidator's by_role_not
+      // filter must reject this and the worker must not fire again.
+      await applyEdit(
+        space,
+        {
+          kind: "edit",
+          path: wikiPath,
+          search: "Disordered desire.",
+          replace: "Disordered desire — see [Lust](/wiki/concept/lust.md).",
+        },
+        { role: "consolidator", edit_kind: "replace" },
+      );
+      const callsAfterIngestor = fakeConsolidator.mock.calls.length;
+      await scheduler.notify(wikiPath);
+      await new Promise((r) => setTimeout(r, 300));
+      expect(fakeConsolidator.mock.calls.length).toBe(callsAfterIngestor);
+
+      // ── 3. Human edit (no edit-context registered) ───────────────
+      // syncFile sees no edit-context for this path and attributes
+      // the change to "human". The consolidator's positive `by_role:
+      // ["ingestor"]` filter must reject "human", so the worker does
+      // not fire. This is the case the consolidator distinguishes
+      // from the older negative-only synthesizer pattern: an explicit
+      // human edit on a wiki does not provoke a consolidation pass.
+      const humanFile = join(testDir, wikiPath);
+      const { readFileSync, writeFileSync: write } = await import("node:fs");
+      const current = readFileSync(humanFile, "utf-8");
+      write(humanFile, current + "\nA human added this line.\n", "utf-8");
+      // syncFile (driven by the watcher in production; called directly
+      // here) records the human-attributed entity_edits row.
+      const { syncFile } = await import("../../src/server/lib/sync.js");
+      await syncFile(space, wikiPath);
+
+      const callsAfterConsolidator = fakeConsolidator.mock.calls.length;
+      await scheduler.notify(wikiPath);
+      await new Promise((r) => setTimeout(r, 300));
+      expect(fakeConsolidator.mock.calls.length).toBe(callsAfterConsolidator);
+
+      // Queue is empty — nothing got enqueued for cases 2 or 3.
+      const sql = createSql();
+      const queueRows = (await sql`
+        SELECT id FROM agent_queue WHERE space_id = ${space.id}
+      `) as { id: number }[];
+      expect(queueRows).toHaveLength(0);
+    } finally {
+      await scheduler.stop();
+    }
+  });
+});
+
+async function waitFor<T>(
+  fn: () => T | Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = await fn();
+    if (result) return result;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error("waitFor timed out");
+}

--- a/packages/arkeon/test/unit/agents-config.test.ts
+++ b/packages/arkeon/test/unit/agents-config.test.ts
@@ -563,6 +563,100 @@ describe("buildAgentRole — built-in ingestor", () => {
   });
 });
 
+describe("buildAgentRole — built-in consolidator", () => {
+  beforeEach(() => {
+    process.env.OPENAI_API_KEY = "sk-test";
+  });
+  afterEach(() => {
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it("resolves to two phases (gather + edit)", async () => {
+    const role = buildAgentRole("consolidator", {
+      defaults: { provider: "openai", model: "gpt-5-mini" },
+    });
+    const { phases } = await role.buildPhases({
+      space: { id: "s1", name: "n", watch_dir: "/tmp" },
+      triggerPath: "wiki/concept/lust.md",
+      triggerEntityId: "01ENT",
+    });
+    expect(phases).toHaveLength(2);
+    expect(phases[0].name).toBe("gather");
+    expect(phases[1].name).toBe("edit");
+  });
+
+  it("gather phase cannot edit or delete; edit phase can do both", async () => {
+    const role = buildAgentRole("consolidator", {
+      defaults: { provider: "openai", model: "gpt-5-mini" },
+    });
+    const { phases } = await role.buildPhases({
+      space: { id: "s1", name: "n", watch_dir: "/tmp" },
+      triggerPath: "wiki/concept/lust.md",
+    });
+    // Phase 1 surveys; explicitly no edit_file or delete_wiki on the
+    // tool surface so the model literally cannot mutate before plan.
+    expect(phases[0].tools).not.toContain("edit_file");
+    expect(phases[0].tools).not.toContain("delete_wiki");
+    // Phase 2 executes.
+    expect(phases[1].tools).toContain("edit_file");
+    expect(phases[1].tools).toContain("delete_wiki");
+  });
+
+  it("the role-level tools whitelist includes delete_wiki", () => {
+    const role = buildAgentRole("consolidator", {
+      defaults: { provider: "openai", model: "gpt-5-mini" },
+    });
+    expect(role.tools).toContain("delete_wiki");
+    expect(role.tools).toContain("edit_file");
+    expect(role.tools).toContain("search");
+  });
+
+  it("trigger fires on wiki/** edits attributed to the ingestor", () => {
+    // The trigger is declarative config; assert its shape from the
+    // builtin so YAML overrides that drop or change it would surface
+    // here. We don't compile-and-evaluate it (covered separately by
+    // the trigger-cascade e2e); just check the attribution + path
+    // filters that are the contract of the consolidator's identity.
+    const triggers = BUILTIN_ROLES.consolidator?.triggers ?? [];
+    expect(triggers).toHaveLength(1);
+    const t = triggers[0];
+    expect(t.on).toBe("file_changed");
+    expect(t.path_under).toEqual(["wiki/**"]);
+    expect(t.by_role).toEqual(["ingestor"]);
+    expect(t.by_role_not).toEqual(["consolidator"]);
+  });
+
+  it("templates {{trigger_path}} into the gather phase prompt", async () => {
+    const role = buildAgentRole("consolidator", {
+      defaults: { provider: "openai", model: "gpt-5-mini" },
+    });
+    const { phases } = await role.buildPhases({
+      space: { id: "s1", name: "n", watch_dir: "/tmp" },
+      triggerPath: "wiki/concept/lust.md",
+      triggerEntityId: "01ENT",
+    });
+    expect(phases[0].prompt).toContain("wiki/concept/lust.md");
+    expect(phases[0].prompt).toContain("01ENT");
+  });
+
+  it("system prompt declares the outward-only invariant", async () => {
+    // Sanity check: this is a defining property of the consolidator,
+    // and a YAML override that drops it from the system prompt would
+    // be a real regression — the loop-safety + cascade-discipline
+    // behavior depends on the model internalising it.
+    const role = buildAgentRole("consolidator", {
+      defaults: { provider: "openai", model: "gpt-5-mini" },
+    });
+    const { system } = await role.buildPhases({
+      space: { id: "s1", name: "n", watch_dir: "/tmp" },
+    });
+    expect(system).toMatch(/outward-only/i);
+    expect(system).toMatch(/MERGE_INTO/);
+    expect(system).toMatch(/BLEED_INTO/);
+    expect(system).toMatch(/CROSS_LINK/);
+  });
+});
+
 describe("buildAgentRole — user-defined role", () => {
   beforeEach(() => {
     process.env.OPENAI_API_KEY = "sk-test";


### PR DESCRIPTION
**Stacked on #86** (`worktree-delete-wiki-tool`). Retarget to `main` once #86 merges; CI will pick up the new base.

## Summary

The corpus-aware pass that runs per-wiki after the ingestor writes one. Surveys related wikis via vector search and classifies each as one of four actions:

- **IGNORE** — unrelated; no move
- **CROSS_LINK** — distinct subjects that should reference each other; REPLACE the subject's body to add a link to the other wiki
- **BLEED_INTO** — material in the subject that genuinely belongs in another wiki's article; APPEND there, REPLACE/trim self
- **MERGE_INTO** — same subject under a different label; APPEND to the canonical wiki, then `delete_wiki` self

## The outward-only invariant

The property that keeps cascading consolidation orderly:

- The role may edit or DELETE its own subject wiki.
- It may APPEND to other wikis.
- It NEVER replaces another wiki's content.
- It NEVER pulls material from elsewhere into self.

When two wikis both want to bleed material in opposite directions, that's the *other* wiki's consolidator turn to make. The chain self-terminates; provenance stays clean.

## Trigger

First builtin use of *positive* attribution on top of negative loop-safety:

```
triggers:
  - on: file_changed
    path_under: ['wiki/**']
    by_role: ['ingestor']         # fire only on ingestor's writes —
                                  # human edits to wikis don't cascade
    by_role_not: ['consolidator'] # don't refire on own writes
```

The new e2e test `consolidator-trigger.test.ts` covers all three cases: ingestor edit fires, consolidator self-edit doesn't refire, human edit doesn't fire.

## Phases (gather → edit)

Mirrors the ingestor's two-phase shape. Plan is folded into gather's final message rather than living as a third phase, which keeps the role-builder's "no empty phase tools" guard happy without losing trace clarity (phase boundaries already segment the trace).

- **gather** (tools: read_file, list_wikis, search) — reads subject, vector-searches corpus, ends with structured plan as the final message
- **edit** (tools: read_file, list_wikis, search, edit_file, delete_wiki) — executes the plan

## Known limitation (filed as follow-up)

Idempotency uses the runtime default keying. The default doesn't include the wiki body's content hash, so re-fires on body changes would currently no-op as "already_processed." This affects the ingestor too. The cleanest fix is to have the scheduler include `entities.source_hash` in `input.meta` when enqueuing — one place to fix, both roles benefit. Separate PR.

## Out of scope

- Smoke run against `smoke-augustine/` (manual; needs an LLM API key)
- Per-content-hash idempotency (above)
- The HTTP `DELETE /wikis/:id` route's pre-existing wart of not unlinking from disk (orthogonal)

## Test plan
- [x] Typecheck clean
- [x] Unit (204/204 — added 6 consolidator config tests)
- [x] E2E (198/198 — added `consolidator-trigger.test.ts` covering positive/negative attribution)
- [ ] CI green on this PR
- [ ] Manual smoke run on `smoke-augustine/` once both PRs merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)