### PR TITLE
fix(scheduler): thread entities.source_hash into agent input.meta

### DIFF
--- a/packages/arkeon/src/server/agents/scheduler.ts
+++ b/packages/arkeon/src/server/agents/scheduler.ts
@@ -124,6 +124,32 @@ async function lookupLatestByRole(
 }
 
 /**
+ * Read the current `entities.source_hash` for the entity at this
+ * path. Threaded into AgentInput.meta so the runtime's default
+ * idempotency hash varies with file content — without this, the same
+ * (role, triggerPath) re-fired with new content gets short-circuited
+ * as already_processed and the agent never re-runs on the change.
+ *
+ * Returns null when the entity row no longer exists (e.g. it was
+ * deleted between trigger time and worker pickup). The agent run
+ * proceeds in that case; the role's prompt handles the missing-file
+ * path. We don't pre-empt here because it's the role's call whether
+ * "entity gone" is a no-op or an explicit cleanup.
+ */
+async function lookupSourceHash(
+  spaceId: string,
+  relativePath: string,
+): Promise<string | null> {
+  const sql = createSql();
+  const rows = (await sql`
+    SELECT source_hash FROM entities
+    WHERE space_id = ${spaceId} AND source_path = ${relativePath}
+    LIMIT 1
+  `) as { source_hash: string }[];
+  return rows.length > 0 ? rows[0].source_hash : null;
+}
+
+/**
  * Start a scheduler for a space. Returns a handle the watcher uses to
  * notify of file events and the daemon uses to stop on shutdown.
  *
@@ -256,12 +282,23 @@ export async function startScheduler(
       }
       const role = buildAgentRole(item.role, config);
 
+      // Pull the entity's current source_hash so the runtime's
+      // idempotency hash reflects content. Two edits to the same
+      // wiki (same triggerPath, same entityId) need to look like
+      // distinct work to runAgent — if meta is null they collapse to
+      // one hash and the second run gets skipped as already_processed.
+      const sourceHash = await lookupSourceHash(
+        opts.space.id,
+        item.trigger_path,
+      );
+
       await runAgent(
         role,
         {
           space: opts.space,
           triggerPath: item.trigger_path,
           triggerEntityId: item.trigger_entity_id ?? undefined,
+          meta: { source_hash: sourceHash },
         },
         tools,
         {},

--- a/packages/arkeon/test/e2e/consolidator-trigger.test.ts
+++ b/packages/arkeon/test/e2e/consolidator-trigger.test.ts
@@ -149,6 +149,10 @@ describe("consolidator trigger — by_role positive attribution + loop safety", 
       expect(fakeConsolidator).toHaveBeenCalledTimes(1);
       expect(fakeConsolidator.mock.calls[0][0].name).toBe("consolidator");
       expect(fakeConsolidator.mock.calls[0][1].triggerPath).toBe(wikiPath);
+      // Scheduler threads the entity's source_hash into input.meta so
+      // the runtime's idempotency hash varies with content. Without
+      // this, a re-edited wiki gets short-circuited as already_processed.
+      expect(fakeConsolidator.mock.calls[0][1].meta?.source_hash).toBeTruthy();
 
       // ── 2. Consolidator's own edit ───────────────────────────────
       // Stamps by_role=consolidator. The consolidator's by_role_not
@@ -195,6 +199,77 @@ describe("consolidator trigger — by_role positive attribution + loop safety", 
         SELECT id FROM agent_queue WHERE space_id = ${space.id}
       `) as { id: number }[];
       expect(queueRows).toHaveLength(0);
+    } finally {
+      await scheduler.stop();
+    }
+  });
+
+  it("re-fires on a fresh ingestor edit with different content (distinct meta hashes)", async () => {
+    // The scheduler change that surfaces source_hash via input.meta is
+    // the load-bearing piece for cascading consolidation: when the
+    // ingestor re-writes a wiki, the consolidator must run again.
+    // Without source_hash in meta, the runtime's idempotency hash
+    // collapses to a single value and the second run gets skipped as
+    // already_processed.
+    const fakeConsolidator = vi.fn(async (_role, _input, _registry) => ({
+      skipped: false,
+      edits: [],
+      text: "ok",
+      steps: 0,
+      usage: undefined,
+    }));
+
+    const scheduler = await startScheduler({
+      space,
+      triggerRoles: ["consolidator"],
+      runAgentFn: fakeConsolidator,
+    });
+
+    try {
+      const wikiPath = "wiki/concept/refire.md";
+
+      // First ingestor edit (CREATE).
+      await applyEdit(
+        space,
+        {
+          kind: "write",
+          path: wikiPath,
+          content: [
+            "---",
+            "label: Refire",
+            "subject_type: concept",
+            "---",
+            "",
+            "Initial body, version one.",
+            "",
+          ].join("\n"),
+        },
+        { role: "ingestor", edit_kind: "create" },
+      );
+      await scheduler.notify(wikiPath);
+      await waitFor(() => fakeConsolidator.mock.calls.length >= 1, 3000);
+
+      const firstHash = fakeConsolidator.mock.calls[0][1].meta?.source_hash;
+      expect(firstHash).toBeTruthy();
+
+      // Second ingestor edit (REPLACE) — by_role stays "ingestor",
+      // entity_id stays the same, but source_hash changes.
+      await applyEdit(
+        space,
+        {
+          kind: "edit",
+          path: wikiPath,
+          search: "Initial body, version one.",
+          replace: "Substantially rewritten body, version two with new content.",
+        },
+        { role: "ingestor", edit_kind: "replace" },
+      );
+      await scheduler.notify(wikiPath);
+      await waitFor(() => fakeConsolidator.mock.calls.length >= 2, 3000);
+
+      const secondHash = fakeConsolidator.mock.calls[1][1].meta?.source_hash;
+      expect(secondHash).toBeTruthy();
+      expect(secondHash).not.toBe(firstHash);
     } finally {
       await scheduler.stop();
     }


### PR DESCRIPTION
**Stacked on #87** (`consolidator-role`). Retarget when the base merges.

## Why

The runtime's default `idempotencyKey` hashes `(triggerPath, triggerEntityId, meta)`. The scheduler wasn't populating `meta` — so two events for the same `(role, triggerPath)` produced identical hashes, and `alreadyProcessed` short-circuited every re-run as `already_processed`. In practice: edit a wiki the ingestor already ran on, the agent never re-fires.

Affects the ingestor too, but the user-visible symptom shows up first with the consolidator: the whole cascade design assumes the consolidator re-runs when the ingestor re-edits a wiki.

## Fix

`scheduler.runOne` now looks up `entities.source_hash` for the trigger path and passes it via `input.meta`. The runtime's hash now varies with content, and re-edits look like distinct work.

```ts
const sourceHash = await lookupSourceHash(opts.space.id, item.trigger_path);
await runAgent(role, {
  ...,
  meta: { source_hash: sourceHash },
}, tools, {});
```

Returns `null` when the entity is gone (deleted between trigger and pickup). The agent run still proceeds in that case — the role's prompt decides what to do with a missing file. Skipping pre-emptively here would be a separate change.

## Test

New e2e case in `consolidator-trigger.test.ts`:
- Ingestor CREATEs a wiki → consolidator fires with `meta.source_hash = A`
- Ingestor REPLACEs the body → consolidator fires again with `meta.source_hash = B`
- Asserts `A !== B`

The first test in the same file also now asserts `meta.source_hash` is populated on the initial fire, so a regression that drops the threading is loud.

## Test plan
- [x] Typecheck clean
- [x] Unit (no new units; existing 204 pass)
- [x] E2E (199/199 — added 1 re-fire test)
- [ ] CI green on this PR
- [ ] Manual smoke run on `smoke-augustine/` once #86 + #87 + this land

🤖 Generated with [Claude Code](https://claude.com/claude-code)