### PR TITLE
feat: keyword search type filter + multi-query batching (closes #100)

### DIFF
--- a/packages/arkeon/src/server/agents/templates/ingestor.yaml
+++ b/packages/arkeon/src/server/agents/templates/ingestor.yaml
@@ -196,8 +196,8 @@ phases:
              aggregate per file, so files matching multiple variants
              rank naturally higher.
            - `type='file'` restricts hits to raw source files (skipping
-             wikis and stubs) — useful when you want to find evidence
-             in the corpus without drowning in your own prior writes.
+             wikis) — useful when you want to find evidence in the
+             corpus without drowning in your own prior writes.
              `type='wiki'` is the inverse.
 
       4. When you've covered every subject worth a wiki, write a short

--- a/packages/arkeon/src/server/agents/templates/ingestor.yaml
+++ b/packages/arkeon/src/server/agents/templates/ingestor.yaml
@@ -187,6 +187,19 @@ phases:
          alone is more useful than "Claude Shannon" because it catches
          "Claude E. Shannon" too.
 
+         When you do reach for keyword search, two switches are worth
+         knowing:
+           - `query` accepts an array of up to 10 patterns OR'd together
+             in one ripgrep pass. Use it for variant batching when names
+             drift: search(query=["Shannon", "Claude Shannon",
+             "information theorist"], mode="keyword"). Match counts
+             aggregate per file, so files matching multiple variants
+             rank naturally higher.
+           - `type='file'` restricts hits to raw source files (skipping
+             wikis and stubs) — useful when you want to find evidence
+             in the corpus without drowning in your own prior writes.
+             `type='wiki'` is the inverse.
+
       4. When you've covered every subject worth a wiki, write a short
          plain-text summary as your final message:
            - one bullet per subject

--- a/packages/arkeon/src/server/agents/tools.ts
+++ b/packages/arkeon/src/server/agents/tools.ts
@@ -152,11 +152,11 @@ const searchTool = defineTool("search", {
     "or `mode=vector` to scope to one. Vector results carry similarity " +
     "scores in [-1, 1] (higher = more similar); keyword hits are " +
     "ranked by match count with line snippets.\n" +
-    "Pass `type` (comma-separated: 'wiki', 'file', 'stub') to restrict " +
-    "keyword hits to a subset of entity types — e.g. `type='file'` to " +
-    "focus on raw sources without drowning in wiki hits, or `type='wiki'` " +
-    "to skip your own prior writes. Vector hits are always wikis (the " +
-    "filter is a no-op for them).\n" +
+    "Pass `type` (comma-separated: 'wiki', 'file') to restrict keyword " +
+    "hits to a subset of entity types — e.g. `type='file'` to focus on " +
+    "raw sources without drowning in wiki hits, or `type='wiki'` to " +
+    "skip raw sources. Vector hits are always wikis (the filter is a " +
+    "no-op for them).\n" +
     "Multi-space roles can pass `space` to scope to one space, or omit " +
     "it to search every allowed space (each hit carries `space_id` and " +
     "`space` so you can tell them apart).",
@@ -176,9 +176,9 @@ const searchTool = defineTool("search", {
       .string()
       .optional()
       .describe(
-        "Comma-separated entity types: any of 'wiki', 'file', 'stub'. " +
-          "Omit for all types. Affects keyword hits only — vector " +
-          "results are always wikis.",
+        "Comma-separated entity types: any of 'wiki', 'file'. Omit for " +
+          "all types. Affects keyword hits only — vector results are " +
+          "always wikis.",
       ),
     mode: z
       .enum(["keyword", "vector", "both"])

--- a/packages/arkeon/src/server/agents/tools.ts
+++ b/packages/arkeon/src/server/agents/tools.ts
@@ -134,23 +134,48 @@ const searchTool = defineTool("search", {
   description:
     "Search the role's allowed spaces. Two strategies, no fusion:\n" +
     "  - keyword (ripgrep): exact substring (or regex) over file contents. " +
-    "Best for proper nouns, code identifiers, ULIDs, exact phrases.\n" +
+    "Best for proper nouns, code identifiers, ULIDs, exact phrases. " +
+    "Pass `query` as an array (up to 10) to OR several patterns in a " +
+    "single ripgrep pass — useful for variant batching " +
+    "(['Shannon', 'Claude Shannon', 'information theorist']). Match " +
+    "counts aggregate per file, so files matching multiple variants " +
+    "naturally rank higher.\n" +
     "  - vector (sqlite-vec): semantic similarity. Returns a ranked list " +
     "of WIKIS — each hit is a complete wiki with its full body and " +
     "frontmatter, deduplicated from chunk-level matches under the hood. " +
     "Best for finding related or possibly-duplicate wikis you don't have " +
     "a literal name for. The body is right there in the response, so " +
-    "there's no need to read_file the wiki separately to inspect it.\n" +
+    "there's no need to read_file the wiki separately to inspect it. " +
+    "Vector mode uses the FIRST query when an array is passed.\n" +
     "Default `mode=both` runs both in parallel and returns each result " +
     "set in its own namespace ({keyword, vector}). Pass `mode=keyword` " +
     "or `mode=vector` to scope to one. Vector results carry similarity " +
     "scores in [-1, 1] (higher = more similar); keyword hits are " +
     "ranked by match count with line snippets.\n" +
+    "Pass `type` (comma-separated: 'wiki', 'file', 'stub') to restrict " +
+    "keyword hits to a subset of entity types — e.g. `type='file'` to " +
+    "focus on raw sources without drowning in wiki hits, or `type='wiki'` " +
+    "to skip your own prior writes. Vector hits are always wikis (the " +
+    "filter is a no-op for them).\n" +
     "Multi-space roles can pass `space` to scope to one space, or omit " +
     "it to search every allowed space (each hit carries `space_id` and " +
     "`space` so you can tell them apart).",
   inputSchema: z.object({
-    query: z.string().describe("The query string."),
+    query: z
+      .union([z.string(), z.array(z.string()).min(1).max(10)])
+      .describe(
+        "A single query string, or an array of up to 10 patterns OR'd " +
+          "together in one ripgrep invocation. For vector mode, only " +
+          "the first pattern is embedded.",
+      ),
+    type: z
+      .string()
+      .optional()
+      .describe(
+        "Comma-separated entity types: any of 'wiki', 'file', 'stub'. " +
+          "Omit for all types. Affects keyword hits only — vector " +
+          "results are always wikis.",
+      ),
     mode: z
       .enum(["keyword", "vector", "both"])
       .optional()
@@ -182,16 +207,35 @@ const searchTool = defineTool("search", {
     space: z.string().optional().describe(SPACE_PARAM_DESC),
   }),
   call: async (
-    { query, mode, regex, limit, max_snippets_per_file, space },
+    { query, type, mode, regex, limit, max_snippets_per_file, space },
     ctx,
   ) => {
     const m = mode ?? "both";
     const wantKeyword = m === "keyword" || m === "both";
     const wantVector = m === "vector" || m === "both";
 
+    let types: EntityType[] | undefined;
+    try {
+      types = parseEntityTypes(type);
+    } catch (err) {
+      // parseEntityTypes throws an ApiError with a route-friendly
+      // message; rewrap with a tool-prefix so the agent sees a clean
+      // error body in the tool result rather than a 400-shaped object.
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`search: ${msg}`);
+    }
+
     const targets = resolveToolScope(ctx, space);
     const targetIds = targets.map((s) => s.id);
     const indexById = new Map(targets.map((s) => [s.id, s.name]));
+
+    // Vector search embeds a single query. When the agent passes an
+    // array of patterns it's expressing a keyword-side variant union
+    // (different surface forms of the same subject); embedding the
+    // first one is the most useful default — they all describe the
+    // same target, so we pick a representative rather than running
+    // multiple embeddings or refusing the call.
+    const vectorQuery = Array.isArray(query) ? query[0]! : query;
 
     // Run requested strategies in parallel, fail-soft per strategy:
     // if vector throws (e.g. embedder still warming up), the agent
@@ -202,13 +246,14 @@ const searchTool = defineTool("search", {
         ? searchKeyword({
             query,
             spaceIds: targetIds,
+            types,
             regex,
             limit,
             maxSnippetsPerFile: max_snippets_per_file,
           })
         : Promise.resolve(null),
       wantVector
-        ? searchVector({ query, spaceIds: targetIds, limit })
+        ? searchVector({ query: vectorQuery, spaceIds: targetIds, limit })
         : Promise.resolve(null),
     ]);
 

--- a/packages/arkeon/src/server/agents/tools.ts
+++ b/packages/arkeon/src/server/agents/tools.ts
@@ -18,7 +18,7 @@ import { z } from "zod";
 
 import { safeResolve } from "../lib/file-edits.js";
 import { parseFrontmatter } from "../lib/frontmatter.js";
-import { searchKeyword, searchVector } from "../lib/search.js";
+import { MAX_QUERY_PATTERNS, searchKeyword, searchVector } from "../lib/search.js";
 import { listEntities, parseEntityTypes, type EntityType } from "../lib/entities.js";
 
 import { defineTool, type ToolFactory } from "./define-tool.js";
@@ -165,8 +165,12 @@ const searchTool = defineTool("search", {
       .union([z.string(), z.array(z.string()).min(1).max(10)])
       .describe(
         "A single query string, or an array of up to 10 patterns OR'd " +
-          "together in one ripgrep invocation. For vector mode, only " +
-          "the first pattern is embedded.",
+          "together in one ripgrep invocation. All variants share " +
+          "ripgrep's --smart-case mode: a single uppercase letter " +
+          "anywhere in the array makes the WHOLE batch case-sensitive, " +
+          "so prefer all-lowercase variants unless you need case " +
+          "discrimination. For vector mode, only the first pattern is " +
+          "embedded — pass the most representative form first.",
       ),
     type: z
       .string()
@@ -223,6 +227,18 @@ const searchTool = defineTool("search", {
       // error body in the tool result rather than a 400-shaped object.
       const msg = err instanceof Error ? err.message : String(err);
       throw new Error(`search: ${msg}`);
+    }
+
+    // Defense-in-depth: the Zod schema caps array length at 10, but
+    // direct callers (tests, future internal code) bypass Zod. The
+    // lib's defensive throw IS reached — but it lands inside the
+    // Promise.allSettled below and gets silently coerced to empty
+    // hits. The worst kind of failure for an LLM. Throw here so the
+    // tool result carries a real error message.
+    if (Array.isArray(query) && query.length > MAX_QUERY_PATTERNS) {
+      throw new Error(
+        `search: too many query patterns (${query.length}); max is ${MAX_QUERY_PATTERNS}`,
+      );
     }
 
     const targets = resolveToolScope(ctx, space);
@@ -282,6 +298,12 @@ const searchTool = defineTool("search", {
           : { hits: [], total: 0, model: "unavailable" };
       out.vector = {
         ...raw,
+        // Surface the single pattern that was actually embedded so
+        // the caller can see — at a glance — which form drove the
+        // semantic ranking when an array was passed. Always present
+        // (even for single-string queries) so consumers don't have
+        // to branch on the top-level `query` shape.
+        query_used: vectorQuery,
         hits: raw.hits.map((h) => ({
           ...h,
           space: indexById.get(h.space_id) ?? "",

--- a/packages/arkeon/src/server/lib/search.ts
+++ b/packages/arkeon/src/server/lib/search.ts
@@ -55,12 +55,13 @@ export interface KeywordSearchOptions {
    *  Empty/undefined = every registered space. Used by the agent
    *  runtime to fan out across a role's allowed-space scope. */
   spaceIds?: string[];
-  /** Restrict hits to entities of the given type(s). Omit/empty = no
-   *  filter (every type). Filters at SQL-join time — ripgrep still
-   *  scans every indexed file; the entity rows that aren't of an
-   *  allowed type just don't make it into the response. Cheap path
-   *  for `type=file` (raw sources only) or `type=wiki` (skip stubs
-   *  and sources). */
+  /** Restrict hits to entities of the given type(s). Any combination
+   *  of `wiki`, `file`, `stub`. Omit/empty = no filter. Ripgrep still
+   *  scans every indexed file; the filter applies post-fetch on the
+   *  entity-join rows so the `unmatched_files` diagnostic counter
+   *  retains its "no entity at all" meaning instead of conflating
+   *  with "filtered out by type". Useful for source-only sweeps
+   *  (`['file']`) or wiki-only sweeps (`['wiki']`). */
   types?: EntityType[];
   limit?: number;
   maxSnippetsPerFile?: number;

--- a/packages/arkeon/src/server/lib/search.ts
+++ b/packages/arkeon/src/server/lib/search.ts
@@ -28,6 +28,7 @@ import { rgPath } from "@vscode/ripgrep";
 import { createSql } from "./sql.js";
 import type { EntityType } from "./entities.js";
 import { getEmbedder } from "./embedder/index.js";
+import type { EntityType } from "./entities.js";
 import { parseFrontmatter } from "./frontmatter.js";
 
 const SNIPPET_MAX_LEN = 240;
@@ -35,9 +36,18 @@ const DEFAULT_LIMIT = 20;
 const VECTOR_DEFAULT_LIMIT = 8;
 const MAX_LIMIT = 200;
 const DEFAULT_SNIPPETS_PER_FILE = 3;
+/** Maximum number of patterns accepted in a single multi-query call.
+ *  Defensive cap so a runaway caller can't fan out a thousand-pattern
+ *  search; the tool layer enforces the same limit at the Zod schema. */
+export const MAX_QUERY_PATTERNS = 10;
 
 export interface KeywordSearchOptions {
-  query: string;
+  /** Single substring/regex pattern, or up to MAX_QUERY_PATTERNS
+   *  patterns run together as one ripgrep invocation (`-e p1 -e p2`).
+   *  Match counts aggregate per file, so multi-pattern hits naturally
+   *  rank higher — this is the right behaviour for variant batching
+   *  ("Shannon", "Claude Shannon", "information theorist"). */
+  query: string | string[];
   /** Single-space convenience filter. Equivalent to passing
    *  `spaceIds: [spaceId]`. If both are set, `spaceIds` wins. */
   spaceId?: string;
@@ -45,6 +55,13 @@ export interface KeywordSearchOptions {
    *  Empty/undefined = every registered space. Used by the agent
    *  runtime to fan out across a role's allowed-space scope. */
   spaceIds?: string[];
+  /** Restrict hits to entities of the given type(s). Omit/empty = no
+   *  filter (every type). Filters at SQL-join time — ripgrep still
+   *  scans every indexed file; the entity rows that aren't of an
+   *  allowed type just don't make it into the response. Cheap path
+   *  for `type=file` (raw sources only) or `type=wiki` (skip stubs
+   *  and sources). */
+  types?: EntityType[];
   limit?: number;
   maxSnippetsPerFile?: number;
   regex?: boolean;
@@ -212,12 +229,15 @@ function truncateSnippet(text: string): string {
 }
 
 /**
- * Spawn ripgrep against `cwd` with the given query and return parsed file
- * results. Exit codes: 0 = matches found, 1 = no matches, 2+ = error.
+ * Spawn ripgrep against `cwd` with one or more query patterns and return
+ * parsed file results. Multiple patterns are passed as repeated `-e`
+ * arguments — ripgrep ORs them in a single pass, so an entity that
+ * matches several variants of a name accumulates a higher match count
+ * naturally. Exit codes: 0 = matches found, 1 = no matches, 2+ = error.
  */
 export function runRipgrep(opts: {
   cwd: string;
-  query: string;
+  queries: string[];
   regex: boolean;
   maxSnippetsPerFile: number;
 }): Promise<FileResult[]> {
@@ -233,7 +253,10 @@ export function runRipgrep(opts: {
     // Restrict to the file types we index.
     args.push("--type-add", "arkeon:*.{md,txt,json,csv,xml,html,rst}");
     args.push("--type", "arkeon");
-    args.push("--", opts.query, ".");
+    for (const q of opts.queries) {
+      args.push("-e", q);
+    }
+    args.push("--", ".");
 
     const child = spawn(rgPath, args, {
       cwd: opts.cwd,
@@ -265,9 +288,22 @@ export function runRipgrep(opts: {
 export async function searchKeyword(
   opts: KeywordSearchOptions,
 ): Promise<KeywordSearchResult> {
-  const query = opts.query;
+  // Normalise to a non-empty pattern array. Empty / oversized inputs
+  // are caller bugs — surface them rather than silently swallowing the
+  // call (e.g. a 0-pattern array would otherwise tell ripgrep to match
+  // everything, which is almost certainly not what was meant).
+  const queries = Array.isArray(opts.query) ? opts.query : [opts.query];
+  if (queries.length === 0) {
+    throw new Error("searchKeyword: query must not be empty");
+  }
+  if (queries.length > MAX_QUERY_PATTERNS) {
+    throw new Error(
+      `searchKeyword: too many query patterns (${queries.length}); max is ${MAX_QUERY_PATTERNS}`,
+    );
+  }
   const limit = Math.min(opts.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
   const maxSnippets = Math.max(0, opts.maxSnippetsPerFile ?? DEFAULT_SNIPPETS_PER_FILE);
+  const types = opts.types && opts.types.length > 0 ? opts.types : null;
 
   const sql = createSql();
   const requestedIds =
@@ -303,7 +339,7 @@ export async function searchKeyword(
 
     const fileResults = await runRipgrep({
       cwd: watchDir,
-      query,
+      queries,
       regex: !!opts.regex,
       maxSnippetsPerFile: maxSnippets,
     });
@@ -325,6 +361,13 @@ export async function searchKeyword(
       const entity = entityByPath.get(fileResult.path);
       if (!entity) {
         unmatched++;
+        continue;
+      }
+      // Type filter: drop entities whose type isn't in the allowed set.
+      // We filter post-fetch (instead of pushing into SQL) so the
+      // `unmatched_files` diagnostic keeps its meaning — files filtered
+      // out by `types` are not "unmatched", they're explicitly excluded.
+      if (types && !types.includes(entity.type as EntityType)) {
         continue;
       }
       hits.push({

--- a/packages/arkeon/src/server/lib/search.ts
+++ b/packages/arkeon/src/server/lib/search.ts
@@ -26,7 +26,6 @@ import { join } from "node:path";
 import { rgPath } from "@vscode/ripgrep";
 
 import { createSql } from "./sql.js";
-import type { EntityType } from "./entities.js";
 import { getEmbedder } from "./embedder/index.js";
 import type { EntityType } from "./entities.js";
 import { parseFrontmatter } from "./frontmatter.js";
@@ -56,12 +55,15 @@ export interface KeywordSearchOptions {
    *  runtime to fan out across a role's allowed-space scope. */
   spaceIds?: string[];
   /** Restrict hits to entities of the given type(s). Any combination
-   *  of `wiki`, `file`, `stub`. Omit/empty = no filter. Ripgrep still
-   *  scans every indexed file; the filter applies post-fetch on the
+   *  of `wiki`, `file`. Omit/empty = no filter. Ripgrep still scans
+   *  every indexed file; the filter applies post-fetch on the
    *  entity-join rows so the `unmatched_files` diagnostic counter
    *  retains its "no entity at all" meaning instead of conflating
    *  with "filtered out by type". Useful for source-only sweeps
-   *  (`['file']`) or wiki-only sweeps (`['wiki']`). */
+   *  (`['file']`) or wiki-only sweeps (`['wiki']`). Placeholder wikis
+   *  (`type='wiki'` with `source_hash IS NULL`, post-#104) are not
+   *  separable here — use `/entities?unresolved=true` if you want
+   *  those filtered specifically. */
   types?: EntityType[];
   limit?: number;
   maxSnippetsPerFile?: number;

--- a/packages/arkeon/src/server/routes/search.ts
+++ b/packages/arkeon/src/server/routes/search.ts
@@ -5,7 +5,9 @@ import { Hono } from "hono";
 
 import type { AppBindings } from "../types.js";
 import { ApiError } from "../lib/errors.js";
+import { parseEntityTypes } from "../lib/entities.js";
 import {
+  MAX_QUERY_PATTERNS,
   searchKeyword,
   searchVector,
   type KeywordSearchResult,
@@ -17,16 +19,19 @@ export const searchRouter = new Hono<AppBindings>();
 type Mode = "keyword" | "vector" | "both";
 
 interface SearchResponse {
-  query: string;
+  /** Echoes the requested query/queries — single string when one `q`
+   *  was passed, array when several were OR'd together. */
+  query: string | string[];
   mode: Mode;
   keyword?: KeywordSearchResult;
   vector?: VectorSearchResult;
 }
 
-// GET /search?q=...&mode=keyword|vector|both&space_id=...&limit=20&snippets=3&regex=false
+// GET /search?q=...&mode=keyword|vector|both&space_id=...&type=...&limit=20&snippets=3&regex=false
 //
-// Issue #47. Two strategies, no fusion. Each mode's results are returned
-// in their own namespace. Caller decides how (or whether) to combine.
+// Issue #47, extended in #100. Two strategies, no fusion. Each mode's
+// results are returned in their own namespace. Caller decides how (or
+// whether) to combine.
 //
 //   mode=keyword           {keyword: {hits, total, unmatched_files}}
 //   mode=vector            {vector: {hits, total, model}}
@@ -39,11 +44,31 @@ interface SearchResponse {
 //
 // `space_id` filters both strategies. `limit` is per-strategy — each
 // gets up to `limit` results. `snippets` and `regex` only affect keyword.
+//
+// `q` may be repeated (`?q=foo&q=bar`) up to MAX_QUERY_PATTERNS times
+// to OR several patterns in one ripgrep pass. Vector mode embeds the
+// first `q` only.
+//
+// `type` is a comma-separated list of entity types to keep in keyword
+// hits — any of `wiki`, `file`, `stub`. Omit for no filter. Vector
+// hits are always wikis.
 searchRouter.get("/", async (c) => {
-  const query = c.req.query("q");
-  if (!query) {
+  const queries = c.req.queries("q");
+  if (!queries || queries.length === 0) {
     throw new ApiError(400, "validation_error", "q is required");
   }
+  if (queries.length > MAX_QUERY_PATTERNS) {
+    throw new ApiError(
+      400,
+      "validation_error",
+      `too many q parameters (${queries.length}); max is ${MAX_QUERY_PATTERNS}`,
+    );
+  }
+  // Single-q calls keep their classic shape (`query: "foo"`); only
+  // collapse to an array when the caller actually passed several.
+  const queryForKeyword = queries.length === 1 ? queries[0]! : queries;
+  const queryForVector = queries[0]!;
+  const queryEcho = queries.length === 1 ? queries[0]! : queries;
 
   const modeParam = c.req.query("mode") ?? "both";
   if (modeParam !== "keyword" && modeParam !== "vector" && modeParam !== "both") {
@@ -54,6 +79,9 @@ searchRouter.get("/", async (c) => {
     );
   }
   const mode: Mode = modeParam;
+
+  // parseEntityTypes throws ApiError on invalid values; let it bubble.
+  const types = parseEntityTypes(c.req.query("type"));
 
   const spaceId = c.req.query("space_id");
   const limitParam = c.req.query("limit");
@@ -81,19 +109,20 @@ searchRouter.get("/", async (c) => {
   const [keywordSettled, vectorSettled] = await Promise.allSettled([
     wantKeyword
       ? searchKeyword({
-          query,
+          query: queryForKeyword,
           spaceId,
+          types,
           limit,
           maxSnippetsPerFile,
           regex,
         })
       : Promise.resolve(null),
     wantVector
-      ? searchVector({ query, spaceId, limit })
+      ? searchVector({ query: queryForVector, spaceId, limit })
       : Promise.resolve(null),
   ]);
 
-  const response: SearchResponse = { query, mode };
+  const response: SearchResponse = { query: queryEcho, mode };
 
   if (wantKeyword) {
     if (keywordSettled.status === "fulfilled" && keywordSettled.value) {

--- a/packages/arkeon/src/server/routes/search.ts
+++ b/packages/arkeon/src/server/routes/search.ts
@@ -56,8 +56,9 @@ interface SearchResponse {
 // in any `q` makes the whole batch case-sensitive.
 //
 // `type` is a comma-separated list of entity types to keep in keyword
-// hits — any of `wiki`, `file`, `stub`. Omit for no filter. Vector
-// hits are always wikis.
+// hits — any of `wiki`, `file`. Omit for no filter. Vector hits are
+// always wikis. Placeholder wikis (post-#104, no file on disk yet) are
+// `type='wiki'`; filter them via `/entities?unresolved=true`.
 searchRouter.get("/", async (c) => {
   const queries = c.req.queries("q");
   if (!queries || queries.length === 0) {

--- a/packages/arkeon/src/server/routes/search.ts
+++ b/packages/arkeon/src/server/routes/search.ts
@@ -24,7 +24,11 @@ interface SearchResponse {
   query: string | string[];
   mode: Mode;
   keyword?: KeywordSearchResult;
-  vector?: VectorSearchResult;
+  /** Vector results carry an extra `query_used` because vector mode
+   *  always embeds a single string — when `q` is repeated only the
+   *  first one drives the embedding. Surfacing it next to the hits
+   *  makes the asymmetry explicit. */
+  vector?: VectorSearchResult & { query_used: string };
 }
 
 // GET /search?q=...&mode=keyword|vector|both&space_id=...&type=...&limit=20&snippets=3&regex=false
@@ -34,7 +38,7 @@ interface SearchResponse {
 // whether) to combine.
 //
 //   mode=keyword           {keyword: {hits, total, unmatched_files}}
-//   mode=vector            {vector: {hits, total, model}}
+//   mode=vector            {vector: {hits, total, model, query_used}}
 //   mode=both (default)    {keyword: ..., vector: ...}
 //
 // `keyword` hits are entity-level, ranked by ripgrep match_count, with
@@ -46,8 +50,10 @@ interface SearchResponse {
 // gets up to `limit` results. `snippets` and `regex` only affect keyword.
 //
 // `q` may be repeated (`?q=foo&q=bar`) up to MAX_QUERY_PATTERNS times
-// to OR several patterns in one ripgrep pass. Vector mode embeds the
-// first `q` only.
+// to OR several patterns in one ripgrep pass. Vector mode embeds only
+// the first `q` and surfaces it on `vector.query_used`. All patterns
+// share ripgrep's --smart-case semantics — a single uppercase letter
+// in any `q` makes the whole batch case-sensitive.
 //
 // `type` is a comma-separated list of entity types to keep in keyword
 // hits — any of `wiki`, `file`, `stub`. Omit for no filter. Vector
@@ -135,10 +141,15 @@ searchRouter.get("/", async (c) => {
 
   if (wantVector) {
     if (vectorSettled.status === "fulfilled" && vectorSettled.value) {
-      response.vector = vectorSettled.value;
+      response.vector = { ...vectorSettled.value, query_used: queryForVector };
     } else if (vectorSettled.status === "rejected") {
       console.error(`[search] vector strategy failed: ${vectorSettled.reason}`);
-      response.vector = { hits: [], total: 0, model: "unavailable" };
+      response.vector = {
+        hits: [],
+        total: 0,
+        model: "unavailable",
+        query_used: queryForVector,
+      };
     }
   }
 

--- a/packages/arkeon/test/e2e/agent-tools.test.ts
+++ b/packages/arkeon/test/e2e/agent-tools.test.ts
@@ -562,6 +562,78 @@ describe("search edge cases", () => {
     expect(result.vector).toBeDefined();
     expect(result.keyword).toBeUndefined();
   });
+
+  // Issue #100 — multi-query batching + type filter.
+  it("accepts an array of patterns and ORs them in one keyword pass", async () => {
+    // Both patterns lowercase so smart-case stays case-insensitive
+    // across both — mixing cases would force case-sensitive matching
+    // in ripgrep and skew this test.
+    const result = (await tool("search").execute({
+      query: ["electron", "redox"],
+      mode: "keyword",
+    })) as {
+      keyword: { hits: Array<{ source_path: string; match_count: number }> };
+    };
+    const paths = result.keyword.hits.map((h) => h.source_path).sort();
+    expect(paths).toContain("wiki/concept/redox.md");
+    expect(paths).toContain("wiki/concept/oxidation.md");
+    // redox.md matches "electron" in its body line AND "redox" in its
+    // frontmatter `label: Redox Reactions` — two distinct matched
+    // lines. oxidation.md only matches "electron" on its body line.
+    // Match counts aggregate per file, so redox.md ranks higher.
+    const redox = result.keyword.hits.find(
+      (h) => h.source_path === "wiki/concept/redox.md",
+    )!;
+    const oxid = result.keyword.hits.find(
+      (h) => h.source_path === "wiki/concept/oxidation.md",
+    )!;
+    expect(redox.match_count).toBeGreaterThan(oxid.match_count);
+  });
+
+  it("type='file' filters keyword hits to source files only", async () => {
+    // Seed a source file. Watcher indexes it as type='file'; without
+    // the filter both wikis and sources can match, with type='file'
+    // only the source survives.
+    writeFileSync(
+      join(testDir, "type-filter-source.txt"),
+      "type-filter-source mentions electron in passing.",
+    );
+    const sql = createSql();
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      const rows =
+        await sql`SELECT id FROM entities WHERE space_id = ${space.id} AND source_path = ${"type-filter-source.txt"}`;
+      if (rows.length === 1) break;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+
+    const result = (await tool("search").execute({
+      query: "electron",
+      type: "file",
+      mode: "keyword",
+    })) as {
+      keyword: { hits: Array<{ type: string; source_path: string }> };
+    };
+    expect(result.keyword.hits.length).toBeGreaterThan(0);
+    for (const hit of result.keyword.hits) {
+      expect(hit.type).toBe("file");
+    }
+    expect(
+      result.keyword.hits.some(
+        (h) => h.source_path === "type-filter-source.txt",
+      ),
+    ).toBe(true);
+  });
+
+  it("type='bogus' surfaces a tool-prefixed error", async () => {
+    await expect(
+      tool("search").execute({
+        query: "electron",
+        type: "bogus",
+        mode: "keyword",
+      }),
+    ).rejects.toThrow(/search:.*bogus/);
+  });
 });
 
 // ── list_entities ─────────────────────────────────────────────────

--- a/packages/arkeon/test/e2e/agent-tools.test.ts
+++ b/packages/arkeon/test/e2e/agent-tools.test.ts
@@ -634,6 +634,36 @@ describe("search edge cases", () => {
       }),
     ).rejects.toThrow(/search:.*bogus/);
   });
+
+  it("rejects an oversized query array with a clear error (not silent empty hits)", async () => {
+    // The Zod schema caps at 10, but direct callers bypass Zod. The
+    // tool layer enforces the cap explicitly so the failure surfaces
+    // as a real error rather than getting swallowed by the inner
+    // Promise.allSettled into an empty-hits response.
+    const queries = Array.from({ length: 11 }, (_, i) => `pattern${i}`);
+    await expect(
+      tool("search").execute({ query: queries, mode: "keyword" }),
+    ).rejects.toThrow(/search: too many query patterns \(11\); max is 10/);
+  });
+
+  it("vector namespace echoes the embedded query via query_used", async () => {
+    // Multi-pattern keyword search runs ripgrep with all patterns,
+    // but vector embeds only the first one. The tool layer surfaces
+    // that as `vector.query_used` so a consumer can see — at a
+    // glance — which form drove the semantic ranking.
+    const result = (await tool("search").execute({
+      query: ["redox", "electron"],
+    })) as { vector?: { query_used?: string } };
+    expect(result.vector?.query_used).toBe("redox");
+
+    // Single-string queries also include query_used so consumers
+    // don't have to branch on shape.
+    const single = (await tool("search").execute({
+      query: "electron",
+      mode: "vector",
+    })) as { vector?: { query_used?: string } };
+    expect(single.vector?.query_used).toBe("electron");
+  });
 });
 
 // ── list_entities ─────────────────────────────────────────────────

--- a/packages/arkeon/test/e2e/search.test.ts
+++ b/packages/arkeon/test/e2e/search.test.ts
@@ -752,6 +752,20 @@ describe("GET /search?mode=keyword — type filter (#100)", () => {
     expect(data.error?.code).toBe("validation_error");
   });
 
+  it("rejects type=stub with the #104 migration message", async () => {
+    // PR #104 collapsed the `stub` type into placeholder wikis
+    // (type='wiki', source_hash IS NULL) surfaced via `?unresolved=true`.
+    // Callers that still pass type=stub get a 400 with a message
+    // pointing at the new mechanism, not a generic "invalid type".
+    // Pin the migration shape so a regression in the error doesn't
+    // strand future callers (LLM agents included).
+    const data = await api(
+      `/search?space_id=${spaceId}&q=Turing&mode=keyword&type=stub`,
+    );
+    expect(data.error?.code).toBe("validation_error");
+    expect(data.error?.message).toMatch(/unresolved/i);
+  });
+
   it("type filter does not inflate unmatched_files diagnostic", async () => {
     // Files filtered out by `type` are explicitly excluded — they're
     // not the "ripgrep matched but no entity row" condition the

--- a/packages/arkeon/test/e2e/search.test.ts
+++ b/packages/arkeon/test/e2e/search.test.ts
@@ -604,3 +604,152 @@ describe("GET /search — cross-space scoping", () => {
     expect(data.keyword.hits).toEqual([]);
   });
 });
+
+// ────────────────────────────────────────────────────────────────────
+// Issue #100: type filter + multi-query batching for keyword search.
+// ────────────────────────────────────────────────────────────────────
+
+describe("GET /search?mode=keyword — multi-query batching (#100)", () => {
+  it("ORs multiple ?q= patterns in a single call", async () => {
+    // Two patterns that match disjoint wikis. Without multi-query a
+    // caller would have to issue two requests; with multi-query the
+    // single response carries hits from both.
+    const data = await api(
+      `/search?space_id=${spaceId}&mode=keyword&q=Turing&q=Shannon`,
+    );
+    const labels = data.keyword.hits.map((h: any) => h.label);
+    expect(labels).toContain("Alan Turing");
+    expect(labels).toContain("Claude Shannon");
+    // The route echoes the array form back so callers can confirm
+    // they got the multi-pattern semantics.
+    expect(data.query).toEqual(["Turing", "Shannon"]);
+  });
+
+  it("aggregates match counts across patterns so multi-pattern matches rank higher", async () => {
+    // alan-turing.md mentions "Turing" twice and "mathematician" once.
+    // claude-shannon.md mentions "mathematician" once but not "Turing".
+    // Single-pattern ?q=mathematician → both wikis tie at 1.
+    // Multi-pattern ?q=Turing&q=mathematician → turing.md sums to 3,
+    // shannon.md stays at 1. Same in computability.md (mentions Turing).
+    const data = await api(
+      `/search?space_id=${spaceId}&mode=keyword&q=Turing&q=mathematician`,
+    );
+    const turing = data.keyword.hits.find((h: any) => h.label === "Alan Turing");
+    const shannon = data.keyword.hits.find(
+      (h: any) => h.label === "Claude Shannon",
+    );
+    expect(turing).toBeDefined();
+    expect(shannon).toBeDefined();
+    expect(turing.match_count).toBeGreaterThan(shannon.match_count);
+    expect(data.keyword.hits[0].label).toBe("Alan Turing");
+  });
+
+  it("preserves single-string echo when only one ?q= is passed", async () => {
+    const data = await api(`/search?space_id=${spaceId}&mode=keyword&q=Turing`);
+    expect(data.query).toBe("Turing");
+  });
+
+  it("rejects more than 10 patterns with 400", async () => {
+    const params = Array.from({ length: 11 }, (_, i) => `q=p${i}`).join("&");
+    const data = await api(
+      `/search?space_id=${spaceId}&mode=keyword&${params}`,
+    );
+    expect(data.error?.code).toBe("validation_error");
+  });
+});
+
+describe("GET /search?mode=keyword — type filter (#100)", () => {
+  // Add a source file alongside the wikis so we have type=file rows
+  // to filter on. The notes.txt added by the keyword edge-case suite
+  // would also work but lives behind a different describe block —
+  // duplicate the seed locally so test ordering doesn't bind us.
+  beforeAll(async () => {
+    writeFileSync(
+      join(testDir, "source-doc.txt"),
+      "source-doc covers ZZTYPEPROBE and other notes about Turing.",
+    );
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      const r = await api(
+        `/search?space_id=${spaceId}&q=ZZTYPEPROBE&mode=keyword`,
+      );
+      if (r.keyword.hits.some((h: any) => h.source_path === "source-doc.txt")) {
+        return;
+      }
+      await new Promise((res) => setTimeout(res, 200));
+    }
+    throw new Error("source-doc.txt never appeared in keyword search");
+  }, 15_000);
+
+  it("type=file restricts hits to source files (no wikis)", async () => {
+    const data = await api(
+      `/search?space_id=${spaceId}&q=Turing&mode=keyword&type=file`,
+    );
+    expect(data.keyword.hits.length).toBeGreaterThan(0);
+    for (const hit of data.keyword.hits) {
+      expect(hit.type).toBe("file");
+    }
+    expect(
+      data.keyword.hits.some((h: any) => h.source_path === "source-doc.txt"),
+    ).toBe(true);
+    // Wikis under wiki/ must not appear when type=file.
+    expect(
+      data.keyword.hits.some((h: any) => h.source_path.startsWith("wiki/")),
+    ).toBe(false);
+  });
+
+  it("type=wiki restricts hits to wikis (no source files)", async () => {
+    const data = await api(
+      `/search?space_id=${spaceId}&q=Turing&mode=keyword&type=wiki`,
+    );
+    expect(data.keyword.hits.length).toBeGreaterThan(0);
+    for (const hit of data.keyword.hits) {
+      expect(hit.type).toBe("wiki");
+    }
+    expect(
+      data.keyword.hits.some((h: any) => h.source_path === "source-doc.txt"),
+    ).toBe(false);
+  });
+
+  it("type=wiki,file accepts both", async () => {
+    const data = await api(
+      `/search?space_id=${spaceId}&q=Turing&mode=keyword&type=wiki,file`,
+    );
+    const types = new Set(data.keyword.hits.map((h: any) => h.type));
+    expect(types.has("wiki")).toBe(true);
+    expect(types.has("file")).toBe(true);
+  });
+
+  it("omitted type returns hits of every type", async () => {
+    const data = await api(
+      `/search?space_id=${spaceId}&q=Turing&mode=keyword`,
+    );
+    const types = new Set(data.keyword.hits.map((h: any) => h.type));
+    // Both wiki and file rows match the query when no filter is set.
+    expect(types.has("wiki")).toBe(true);
+    expect(types.has("file")).toBe(true);
+  });
+
+  it("rejects an invalid type with 400", async () => {
+    const data = await api(
+      `/search?space_id=${spaceId}&q=Turing&mode=keyword&type=bogus`,
+    );
+    expect(data.error?.code).toBe("validation_error");
+  });
+
+  it("type filter does not inflate unmatched_files diagnostic", async () => {
+    // Files filtered out by `type` are explicitly excluded — they're
+    // not the "ripgrep matched but no entity row" condition the
+    // unmatched_files counter is for. Verify by comparing a no-filter
+    // call (where wiki/file paths both have entities, so unmatched=0)
+    // to a type=file call (which drops wiki rows in JS, not as
+    // unmatched). Both calls should report the same unmatched count.
+    const all = await api(
+      `/search?space_id=${spaceId}&q=Turing&mode=keyword`,
+    );
+    const filtered = await api(
+      `/search?space_id=${spaceId}&q=Turing&mode=keyword&type=file`,
+    );
+    expect(filtered.keyword.unmatched_files).toBe(all.keyword.unmatched_files);
+  });
+});

--- a/packages/arkeon/test/e2e/search.test.ts
+++ b/packages/arkeon/test/e2e/search.test.ts
@@ -656,6 +656,21 @@ describe("GET /search?mode=keyword — multi-query batching (#100)", () => {
     );
     expect(data.error?.code).toBe("validation_error");
   });
+
+  it("vector response surfaces the embedded query via query_used", async () => {
+    // Vector mode embeds only the first ?q=. Without explicit echo
+    // a consumer sees `query: ["A","B","C"]` next to vector hits
+    // derived purely from "A" — surprising. `vector.query_used`
+    // makes the asymmetry explicit. Always present (even for
+    // single-q calls) so consumers don't have to branch on shape.
+    const multi = await api(
+      `/search?space_id=${spaceId}&q=Turing&q=Shannon&mode=vector`,
+    );
+    expect(multi.vector.query_used).toBe("Turing");
+
+    const single = await api(`/search?space_id=${spaceId}&q=Shannon&mode=vector`);
+    expect(single.vector.query_used).toBe("Shannon");
+  });
 });
 
 describe("GET /search?mode=keyword — type filter (#100)", () => {

--- a/packages/arkeon/test/unit/search.test.ts
+++ b/packages/arkeon/test/unit/search.test.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from "vitest";
-import { parseRipgrepJson } from "../../src/server/lib/search.js";
+import {
+  MAX_QUERY_PATTERNS,
+  parseRipgrepJson,
+  searchKeyword,
+} from "../../src/server/lib/search.js";
 
 const beginEvent = (path: string) =>
   JSON.stringify({ type: "begin", data: { path: { text: path } } });
@@ -130,5 +134,24 @@ describe("parseRipgrepJson", () => {
     const result = parseRipgrepJson(stdout, 3);
     expect(result[0]!.snippets[0]!.text.length).toBeLessThanOrEqual(241);
     expect(result[0]!.snippets[0]!.text.endsWith("…")).toBe(true);
+  });
+});
+
+// Defensive cap on multi-query inputs (#100). The route rejects
+// oversized arrays at the boundary; this test pins the lib's own
+// safety net for any future internal caller that bypasses the route.
+describe("searchKeyword — input validation", () => {
+  it("throws when query is an empty array", async () => {
+    await expect(searchKeyword({ query: [] })).rejects.toThrow(/empty/i);
+  });
+
+  it(`throws when query has more than ${MAX_QUERY_PATTERNS} patterns`, async () => {
+    const queries = Array.from(
+      { length: MAX_QUERY_PATTERNS + 1 },
+      (_, i) => `p${i}`,
+    );
+    await expect(searchKeyword({ query: queries })).rejects.toThrow(
+      /too many query patterns/i,
+    );
   });
 });


### PR DESCRIPTION
## Summary

Adds two ergonomics features to the keyword search path so an ingestor or planner can do real corpus work without drowning in noise.

- **Multi-query batching** — `searchKeyword.query` now accepts `string | string[]` (capped at 10). `runRipgrep` emits `-e <q>` per pattern so all variants OR in a single ripgrep pass; match counts aggregate per file, so a wiki matching multiple variants ranks naturally higher.
- **Type filter** — new optional `types?: EntityType[]` on `searchKeyword`, surfaced as `type` (comma-separated, mirrors `list_entities`) on the agent tool and `/search` route. Filters entity rows post-fetch in JS rather than at SQL so the `unmatched_files` diagnostic counter keeps its meaning ("no entity at all", not "filtered out by type").

## Surfaces

| Layer | Change |
|---|---|
| Lib (`search.ts`) | `query` union, `types` filter, `MAX_QUERY_PATTERNS=10`, defensive throws on empty/oversized arrays |
| Tool (`tools.ts`) | Zod accepts array (min 1, max 10); new `type` arg; vector mode embeds first pattern when an array is passed |
| Route (`routes/search.ts`) | Repeated `?q=` (Hono `c.req.queries`); `?type=` parsed via `parseEntityTypes`; 400 on >10 patterns or invalid type |
| Prompt (`ingestor.yaml`) | New paragraph on array form for variant batching and `type='file'` for source-only sweeps |

## Design choices worth flagging

- **Type filter lives in JS, not SQL.** Pushing into SQL (`AND type IN ...`) would conflate `unmatched_files` ("ripgrep matched but no entity row") with "filtered out by type". Cheap path keeps the diagnostic honest.
- **Vector mode embeds first pattern** when an array is passed — variants of a subject have one semantic target; running multiple embeddings would be wasteful and refusing the call hostile.
- **`tool().execute()` bypasses Zod.** AI SDK only validates Zod at the LLM-call boundary; combined with the tool's `Promise.allSettled` fail-soft pattern, an oversized array silently yields empty hits at the tool layer. Cap is enforced at the route (boundary) and the lib (defensive).
- **`--smart-case` is global across patterns.** Mixing `electron` and `Oxidation` flips both to case-sensitive in ripgrep. Tests use consistently-cased patterns; documented in test comments.

## Out of scope (per issue)

- Vector search over source files (`entity_chunks` is wiki-only by design)
- Server-side keyword/vector fusion
- Regex-union inside a single pattern (multi-pattern is cleaner)

## Test plan

- [x] `npm run typecheck -w packages/arkeon` clean
- [x] `npm test -w packages/arkeon` — 252/252 (added 2 lib defensive-cap tests)
- [x] `npm run test:e2e -w packages/arkeon` — 254/254 (added 12 search route tests, 3 agent-tool tests)
- [x] Manual review of `ingestor.yaml` for prompt coherence

🤖 Generated with [Claude Code](https://claude.com/claude-code)