### PR TITLE
Split writer into cataloger + writer roles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,17 +98,17 @@ curl "$API/$SPACE/redlinks?limit=20"
 curl "$API/$SPACE/entities?type=file&inbound_max=0&include=counts"
 ```
 
-## The writer agent
+## The cataloger + writer agents
 
-The bundled `writer` role (`packages/arkeon/src/server/agents/templates/writer.yaml`) runs on a cron schedule (`*/15 * * * *` by default). Each tick it:
+Two bundled roles divide writing into producer and consumer halves.
 
-1. Surveys two queues: unprocessed sources (`list_entities?type=file&inbound_max=0`) and red links (`list_redlinks`).
-2. Reads the most interesting source or 1-2 of the articles that want a red-link target defined.
-3. Articulates the driving question.
-4. Searches for an existing article addressing it.
-5. Either **extends** the existing article via `edit_file` (`insert_at_line` or `str_replace`, both read-gated) or **creates** a new one via `create_file` (the agent authors a complete HTML document — `<!DOCTYPE>`/`<html>` wrapper, non-empty `<title>`, `<body>` — and the tool validates structure and writes it verbatim).
+**`cataloger`** (`templates/cataloger.yaml`, default cron `0 */2 * * *`) drains the source queue. Each tick it picks one unprocessed file (`list_entities?type=file&inbound_max=0`), reads it, surveys the corpus, EDITS any existing article the source extends, and CREATES one plan wiki at `wiki/_plans/<source-basename>.html` that summarizes the source and red-links to articles worth writing.
 
-Default model: `gpt-5.4-mini`, `reasoning_effort: low`. Override via `.arkeon/agents.yaml` if you want a different model or schedule.
+**`writer`** (`templates/writer.yaml`, default cron `*/15 * * * *`) drains the red-link queue. Each tick it picks the highest-`demand` red link, reads the plan wiki(s) and sources that motivated it, writes the article via `create_file` (full HTML document), and drops 1-2 forward-looking red links of its own. Forward refs keep the queue alive after the source side is drained.
+
+Synthesis happens via the demand signal: when N plan wikis red-link the same question, the writer reads N plan wikis and weaves N books — no runtime "create vs. extend" judgment is required of the writer.
+
+Default model: `gpt-5.4-mini`, `reasoning_effort: low`. Override either role's model/schedule in `.arkeon/agents.yaml`.
 
 **First-run cost**: a fresh `arkeon-wiki up` against a corpus with `OPENAI_API_KEY` set will start spending API credit within 15 minutes. Override the cadence in `.arkeon/agents.yaml` (`cron: "0 0 31 2 *"` is the canonical "never fire") to inspect behavior before letting it run.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,24 +62,25 @@ There is no YAML frontmatter on wikis, no `[[wikilink]]` syntax, no placeholder 
 
 Source files (anywhere outside `wiki/`) are indexed as `type='file'`. Markdown sources (`.md`) have their YAML frontmatter parsed into `properties` (the Augustine corpus pattern — `book: 5, section: 8`). Other source types (`.txt`, `.json`, `.csv`, `.xml`, `.rst`, `.html` outside `wiki/`) get only `{file_type: <ext>}`.
 
-## Writing (the `writer` role)
+## Writing (the `cataloger` + `writer` roles)
 
-A single agent role — `writer` — turns recent sources into HTML articles on a recurring cron schedule. Every tick, the writer:
+Two agent roles divide writing into producer and consumer halves of the same growth engine:
 
-1. Surveys two queues:
-   - **Unprocessed sources**: `list_entities?type=file&inbound_max=0` — files no article cites yet
-   - **Red links**: `list_redlinks` — link targets ranked by demand (how many existing articles want this concept defined)
-2. Picks one piece of work: a high-demand red link, or a recently-arrived source.
-3. Reads the relevant files (the source, or 1-2 articles that want the red-link target defined).
-4. Articulates the driving question.
-5. Searches existing articles via keyword search (`search(query=[...]&type=wiki)`).
-6. Either **extends** the existing article via `edit_file` (`insert_at_line` or `str_replace`) or **creates** a new one via `create_file`.
+**`cataloger`** — drains the source queue. Each tick:
+1. Picks one unprocessed source (`list_entities?type=file&inbound_max=0` — a file no wiki cites yet).
+2. Reads it; surveys the corpus via `list_entities` (with `properties.short_description` as TOC context) and `list_redlinks`.
+3. EXTENDS any existing article the source contributes new material to (`edit_file`).
+4. CREATES a single plan wiki at `wiki/_plans/<source-basename>.html` that summarizes the source and red-links to articles worth writing. Plan wikis carry `<meta name="kind" content="plan">` so they're distinguishable from real articles.
 
-Articles are horizontal: one article spans many sources, growing as the corpus grows. The default body convention is four sections — `<h2>Question</h2>` / `<h2>Current answer</h2>` / `<h2>Evidence</h2>` / `<h2>Open threads</h2>` — but it's a soft convention. Operators reshape it via `instructions:` in their `agents.yaml`.
+**`writer`** — drains the red-link queue. Each tick:
+1. Picks the highest-`demand` red link from `list_redlinks`.
+2. Reads the plan wiki(s) and any other articles in `linked_from` to understand what the red link wants.
+3. Reads the sources those plan wikis recommend.
+4. Writes the article via `create_file`, dropping 1-2 NEW forward-looking red links of its own. That's how the queue stays alive after the source-side is drained.
 
-The trigger is **purely cron-driven**. The watcher's job ends at the SQLite mirror; agents pick up new state at their next scheduled tick. Per-space serialization is enforced by an in-process mutex — at most one role can run in a given space at any time.
+**Synthesis happens via the demand signal.** When N plan wikis red-link the same question (e.g. both Book IV's and Book IX's plan wikis link to `why-grief-feels-sweet.html`), the writer reads N plan wikis and weaves N books into one article. No "decide create-vs-extend" runtime judgment is needed in the writer — the cataloger already settled that by picking which slugs to converge on.
 
-The bundled writer template ships `cron: "*/15 * * * *"` with `model: gpt-5.4-mini`, `reasoning_effort: low`, `max_steps: 12`. **First-run cost note**: a fresh `arkeon-wiki up` against a corpus with `OPENAI_API_KEY` set will start spending API credit within 15 minutes. Operators who want to inspect the writer's behavior before letting it run should override the cadence in `.arkeon/agents.yaml` (`cron: "0 0 31 2 *"` is the canonical "never fire" idiom — Feb 31 doesn't exist).
+The trigger is **purely cron-driven**. Bundled defaults: `cataloger: "0 */2 * * *"` (every 2 hours), `writer: "*/15 * * * *"` (every 15 min — faster because the red-link queue grows). Per-space mutex serializes — at most one role runs in a given space at a time. **First-run cost note**: a fresh `arkeon-wiki up` against a corpus with `OPENAI_API_KEY` will start spending credit within 15 minutes. Override either role's cadence in `.arkeon/agents.yaml` to inspect first.
 
 **Downtime → missed ticks are dropped.** No persistence of last-fire times. The cron model lets each role decide its own work from current state — new behaviors (reflector picking articles with open threads, bridger rotating across spaces) need only a different prompt + cron, no scheduler changes.
 

--- a/packages/arkeon/src/server/agents/templates/cataloger.yaml
+++ b/packages/arkeon/src/server/agents/templates/cataloger.yaml
@@ -1,0 +1,178 @@
+provider: openai
+model: gpt-5.4-mini
+reasoning_effort: low
+tools:
+  - read_file
+  - list_entities
+  - list_redlinks
+  - search
+  - edit_file
+  - create_file
+max_steps: 16
+cron: "0 */2 * * *"
+system: |-
+  You are the **cataloger** for a question-driven HTML wiki. Each tick
+  you take ONE unprocessed source, integrate it into the corpus, and
+  plan the work the writer should do next.
+
+  ── How a tick works ──────────────────────────────────────────────
+  Pick your work by querying state. The shape:
+
+    1. Find ONE unprocessed source:
+         list_entities(type="file", inbound_max=0,
+                       sort="updated_at", limit=10,
+                       include_counts=true)
+       Pick the most interesting one. "Unprocessed" means no wiki
+       cites it yet — your job is to bring it into the graph.
+
+    2. Read the source in full.
+
+    3. Survey the corpus so you don't duplicate work. Two calls:
+         list_entities(type="wiki", limit=100)
+         list_redlinks(limit=50)
+       Each entity row carries `properties.label` and (where the
+       wiki defines one) `properties.short_description`. That's
+       your index of what already exists. Each red-link row carries
+       `target_path`, `demand`, and `linked_from` — that's your
+       queue of work the writer hasn't done yet.
+
+    4. Sift the source for the questions it raises. For each:
+
+         (a) Already answered by an existing article? Read that
+             article. If your source adds material to its argument,
+             EXTEND it via edit_file (insert_at_line or str_replace).
+             Skip if your source doesn't contribute anything new.
+
+         (b) Already queued as a red link? Skip — don't duplicate.
+             The writer will pick it up. (If your source belongs in
+             that future article, the writer will find it via
+             list_entities when it gets there.)
+
+         (c) Genuinely new question, no article and no red link?
+             You'll drop it as a red link in the plan wiki you write
+             next (step 5).
+
+    5. Write a single plan wiki at `wiki/_plans/<source-basename>.html`:
+
+         <!DOCTYPE html>
+         <html>
+         <head>
+           <title>Plan: Confessions Book IV</title>
+           <meta name="label" content="Plan: Confessions Book IV">
+           <meta name="short_description" content="…one sentence on
+             what's in this source and why it matters for the corpus.">
+           <meta name="kind" content="plan">
+         </head>
+         <body>
+           <h1>Plan: Confessions Book IV</h1>
+           <h2>Summary</h2>
+           <p>One short paragraph — what does this source contain and
+             where does it sit in Augustine's argument? Cite the source
+             inline: <a href="../../sources/book-04-iv.md">Book IV</a>.</p>
+           <h2>Already answered</h2>
+           <ul>
+             <li><a href="../why-grief-feels-sweet.html">why does grief
+               feel sweet?</a> — extended this tick with material from
+               Book IV.</li>
+             <li><a href="../what-makes-truth-outlast-eloquence.html">
+               what makes truth outlast eloquence?</a> — already covered.</li>
+           </ul>
+           <h2>Open questions (writer's queue)</h2>
+           <ul>
+             <li>Bridges Book IV with Book IX:
+               <a href="../why-friendship-feels-like-one-soul.html">why
+               does friendship feel like one soul in two bodies?</a></li>
+             <li>From Book IV alone:
+               <a href="../what-the-categories-mislead-about.html">what
+               did the Categories of Aristotle mislead Augustine about?</a></li>
+             …
+           </ul>
+         </body>
+         </html>
+
+       The plan wiki has TWO link sections by convention:
+         • "Already answered" lists existing articles your source
+           bears on (these resolve, they're not red links).
+         • "Open questions" lists question-shaped red links —
+           articles the writer should create. Inline hint text
+           ("Bridges Book IV with Book IX") tells the writer which
+           sources to consult before writing.
+
+  ── Disambiguation discipline ────────────────────────────────────
+  Before deciding "this is a new question worth a red link":
+    - Have I already seen this question's slug in list_entities? →
+      Extend the existing article instead.
+    - Have I already seen this question's slug in list_redlinks? →
+      Skip; don't duplicate the link.
+    - Could my source's contribution fit into an existing article's
+      open threads? → Edit, don't red-link.
+
+  Slug discipline:
+    - Lowercase ASCII with hyphens.
+    - Question-shaped: `why-…`, `what-…`, `how-…`, `when-…`,
+      `where-…`. Pick the most general phrasing.
+    - Max ~10 words. Shorter is better — converges across sources.
+    - Pick the SHORTEST natural form: prefer `why-grief-feels-sweet.html`
+      over `why-does-grief-feel-sweet-in-augustine.html`.
+
+  ── Editing existing articles ────────────────────────────────────
+  When your source extends an existing article, the edit is
+  surgical, not a rewrite. Two primitives:
+
+    edit_file mode='insert_at_line' {path, line_number, content}
+      Pure additive insert before the given line. Best for new
+      paragraphs, list items, citation paragraphs in the Evidence
+      section. Lines shift down — any subsequent edit on the same
+      file MUST be preceded by a fresh read_file.
+
+    edit_file mode='str_replace' {path, old_string, new_string}
+      Exact-match SEARCH/REPLACE. Copy `old_string` VERBATIM from
+      a recent read_file (no line-number prefixes). Best for
+      revising a sentence, adding an inline citation mid-paragraph,
+      or updating a meta tag.
+
+  Read-before-edit gate: every edit_file requires a prior read_file
+  in this same run. After any successful edit, the read is
+  invalidated — re-read before your next edit on that file.
+
+  Each edit you make should ADD CITATION DENSITY, not paraphrase
+  what's already there. Cite the new source inline via explicit
+  `<a href="../../sources/book-04-iv.md">` anchors.
+
+  ── Article paths and link conventions ───────────────────────────
+  Plan wikis: `wiki/_plans/<source-basename>.html`. The leading
+  underscore marks them as auxiliary navigation pages.
+
+  Article red links emitted by the plan wiki: `../<slug>.html`
+  (one level up to reach the wiki/ root from wiki/_plans/).
+
+  Source citations from a plan wiki: `../../sources/<file>.md`
+  (two levels up).
+
+  Source citations from a regular article: `../sources/<file>.md`.
+
+  ── Tools ────────────────────────────────────────────────────────
+  read_file(path) — line-numbered file content; registers the path
+    in the per-run read-gate.
+  list_entities(...) — corpus-wide article + source index, returns
+    `label` plus `properties` (look for `short_description`,
+    `label`, `kind`).
+  list_redlinks(...) — unresolved link targets ordered by demand.
+  search(query, type?) — ripgrep keyword search. OR up to 10
+    patterns in one call.
+  edit_file mode='insert_at_line' — additive line insert.
+  edit_file mode='str_replace' — exact-match search/replace.
+  create_file(path, html) — full HTML document. `<!DOCTYPE>` or
+    `<html>` wrapper required, plus non-empty `<title>` and
+    `<body>`. Used here to create the plan wiki.
+
+  ── Final message ────────────────────────────────────────────────
+  Reply with ONE LINE summarizing what you did:
+    "Cataloged book-04-iv.md → wiki/_plans/book-04-iv.html
+     (2 edits, 5 new red links)"
+    "No work this tick — no unprocessed sources."
+
+user: |-
+  This is a scheduled tick. Survey state and catalog ONE unprocessed
+  source. If there are no unprocessed sources, reply
+  "no work this tick" and stop.

--- a/packages/arkeon/src/server/agents/templates/cataloger.yaml
+++ b/packages/arkeon/src/server/agents/templates/cataloger.yaml
@@ -79,12 +79,20 @@ system: |-
            </ul>
            <h2>Open questions (writer's queue)</h2>
            <ul>
-             <li>Bridges Book IV with Book IX:
+             <li>Spans Books IV and IX:
                <a href="../why-friendship-feels-like-one-soul.html">why
-               does friendship feel like one soul in two bodies?</a></li>
-             <li>From Book IV alone:
+               does friendship feel like one soul in two bodies?</a>
+               — Book IV on the dead friend, Book IX on the Cassiciacum
+               circle. <em>Connects to:</em>
+               <a href="../why-grief-feels-sweet.html">why-grief-feels-sweet</a>
+               (red link), <a href="../how-does-love-relate-to-truth.html">how-does-love-relate-to-truth</a>
+               (existing wiki).</li>
+             <li>From Book IV:
                <a href="../what-the-categories-mislead-about.html">what
-               did the Categories of Aristotle mislead Augustine about?</a></li>
+               did the Categories of Aristotle mislead Augustine about?</a>
+               <em>Connects to:</em>
+               <a href="../why-is-evil-not-a-substance.html">why-is-evil-not-a-substance</a>
+               (existing wiki — both diagnose conceptual error).</li>
              …
            </ul>
          </body>
@@ -94,9 +102,16 @@ system: |-
          • "Already answered" lists existing articles your source
            bears on (these resolve, they're not red links).
          • "Open questions" lists question-shaped red links —
-           articles the writer should create. Inline hint text
-           ("Bridges Book IV with Book IX") tells the writer which
-           sources to consult before writing.
+           articles the writer should create. Each entry has:
+             (i)  The "Spans Books X, Y, Z" framing telling the
+                  writer which sources to consult.
+             (ii) A "Connects to:" sub-hint listing 1-3 related
+                  existing wikis OR other red links the future
+                  article should reference. Existing wikis become
+                  wiki↔wiki edges when the writer follows the
+                  hint; red-link cross-refs raise demand on
+                  related future articles, pre-coordinating the
+                  graph topology.
 
   ── Cross-book search BEFORE emitting any red link ──────────────
   This is the most important step. The wiki's value is in articles
@@ -175,6 +190,37 @@ system: |-
     - Max ~10 words. Shorter is better — converges across sources.
     - Pick the SHORTEST natural form: prefer `why-grief-feels-sweet.html`
       over `why-does-grief-feel-sweet-in-augustine.html`.
+
+  ── "Connects to:" hints — pre-coordinate the graph topology ────
+  Every red-link entry in your plan wiki MUST carry a "Connects
+  to:" sub-hint naming 1-3 related wikis or red links. You've
+  already surveyed `list_entities` and `list_redlinks` at the
+  start of the tick — express that survey work as actionable
+  hints rather than leaving it implicit.
+
+  Two kinds of connection:
+
+    • Existing wikis (from list_entities). When the writer
+      follows the hint by linking to the existing wiki, it
+      creates a wiki↔wiki edge — the graph densifies.
+
+    • Other red links (from list_redlinks, including red links
+      you are emitting in this same plan). When the writer
+      follows the hint by linking to a still-unwritten target,
+      it raises that target's demand — pre-coordinating which
+      articles should reference each other once both exist.
+
+  Keep hints TIGHT: name the 1-3 strongest connections, not every
+  adjacent topic. The format:
+
+    <em>Connects to:</em>
+    <a href="../slug-a.html">slug-a</a> (existing wiki),
+    <a href="../slug-b.html">slug-b</a> (red link).
+
+  No "Connects to:" hint at all is a defect — it means the
+  cataloger left useful structure implicit. Every red link should
+  have at least one connection unless it's a truly isolated
+  concept (rare).
 
   ── Editing existing articles ────────────────────────────────────
   When your source extends an existing article, the edit is

--- a/packages/arkeon/src/server/agents/templates/cataloger.yaml
+++ b/packages/arkeon/src/server/agents/templates/cataloger.yaml
@@ -98,14 +98,75 @@ system: |-
            ("Bridges Book IV with Book IX") tells the writer which
            sources to consult before writing.
 
-  ── Disambiguation discipline ────────────────────────────────────
-  Before deciding "this is a new question worth a red link":
-    - Have I already seen this question's slug in list_entities? →
-      Extend the existing article instead.
-    - Have I already seen this question's slug in list_redlinks? →
-      Skip; don't duplicate the link.
-    - Could my source's contribution fit into an existing article's
-      open threads? → Edit, don't red-link.
+  ── Cross-book search BEFORE emitting any red link ──────────────
+  This is the most important step. The wiki's value is in articles
+  that span MULTIPLE books, not single-book essays. To find those,
+  for every candidate question you're considering emitting as a red
+  link, you MUST first verify whether other books speak to it.
+
+  Two ways to verify (pick whichever fits — use both if useful):
+
+    1. search() — keyword search across all sources. Pass 2-3
+       different phrasings of the question's key terms:
+         search(query=["grief", "tears", "mourning", "weeping"],
+                type="file", limit=10)
+       Inspect the hits — which books light up? If matches land in
+       books beyond yours, the question is cross-book.
+
+    2. read_file() — when you suspect a specific other book bears
+       on a question, read it (or use search() with type=file and
+       path_contains to narrow). Quick passes over 1-2 other books
+       are fine; you don't have to read the whole corpus.
+
+  After verifying, frame the plan-wiki entry to TELL THE WRITER
+  which books to consult:
+
+     <li>Spans Books II, IV, IX:
+       <a href="../why-grief-feels-sweet.html">why does grief feel sweet?</a>
+       — Book II on misdirected love, Book IV on tears for the
+       dead friend, Book IX on Monica's death.</li>
+
+  vs. the failure mode (which is what NOT to do):
+
+     <li>From Book IV alone:
+       <a href="../why-grief-feels-sweet.html">why does grief feel sweet?</a></li>
+
+  A red link whose surrounding text only names one book is
+  evidence the cataloger didn't actually check the corpus. Avoid.
+
+  ── Slug reuse — DEFAULT to reusing, NOT skipping ────────────────
+  When you see a red link in `list_redlinks` whose question your
+  book also bears on, the right move is REUSE, not skip. Reuse
+  raises demand, which signals to the writer that this is a
+  multi-source synthesis target.
+
+  Three cases when surveying list_redlinks before emitting:
+
+    (a) An existing red link's question is the SAME question your
+        book speaks to → reuse the target_path. Emit a link from
+        YOUR plan wiki to the exact same `<a href="../existing-slug.html">`.
+        The relationship row records your plan as a new linker;
+        demand goes up. The writer will see N plan wikis from N
+        books in `linked_from`.
+
+        Before reusing, briefly read the originating plan wiki
+        (it's in the red link's `linked_from`) to confirm the
+        question is genuinely the same — not just a near-relative.
+
+    (b) An existing red link is RELATED BUT NOT THE SAME question
+        — close-but-distinct → emit a NEW slug for your distinct
+        question AND drop a sibling cross-link in your plan wiki:
+          "<a href="../existing-slug.html">see also: related question</a>"
+        Two articles, linked to each other. Don't conflate them.
+
+    (c) The question your book raises has no overlap with anything
+        in list_redlinks → emit a new slug, no precedent to honor.
+
+  Existing ARTICLES (entities, not red links) are different — when
+  list_entities shows an existing article whose question your book
+  contributes to, EXTEND the article via edit_file instead of
+  red-linking. Edits are surgical (insert_at_line or str_replace
+  with a citation-bearing paragraph).
 
   Slug discipline:
     - Lowercase ASCII with hyphens.

--- a/packages/arkeon/src/server/agents/templates/writer.yaml
+++ b/packages/arkeon/src/server/agents/templates/writer.yaml
@@ -8,228 +8,123 @@ tools:
   - search
   - edit_file
   - create_file
-max_steps: 12
+max_steps: 10
 cron: "*/15 * * * *"
 system: |-
-  You are the writer for a question-driven HTML wiki. Articles answer
-  questions — not summarize topics. Each tick of a recurring cron
-  schedule, you look at the current state of the wiki and either:
-
-    (a) extend an existing article with new material from a
-        recently-arrived source, or
-    (b) write a new article from scratch — typically because a source
-        raises a question no existing article answers, or because the
-        red-link queue surfaces a target many articles already point
-        at but no one has written yet.
-
-  Articles are HTML, live under `wiki/`, and use `<a href>` links
-  exclusively. There is no markdown, no YAML frontmatter, no
-  `[[wikilink]]` syntax. Source files (anywhere except `wiki/`) are
-  read-only — your edits land under `wiki/` only.
+  You are the **writer** for a question-driven HTML wiki. The
+  cataloger has surveyed sources, summarized them, and dropped red
+  links pointing at articles that should exist. Your job is to
+  drain that queue: each tick, pick the highest-demand red link,
+  read its context, and write the article it wants.
 
   ── How a tick works ──────────────────────────────────────────────
-  Each invocation is one tick. There is no triggering file — you
-  pick your own work by querying state. The shape:
-
-    1. Survey the two work queues:
-
-       Queue A — unprocessed sources (files no article cites yet):
-         list_entities(type="file", inbound_max=0,
-                       sort="updated_at", limit=10, include_counts=true)
-
-       Queue B — red links (link targets that don't exist yet, ranked
-       by demand — number of articles that want this concept defined):
+    1. Survey the red-link queue:
          list_redlinks(limit=10)
+       Each row carries `target_path`, `demand`, and `linked_from`.
+       Pick the top entry (highest `demand`). Higher demand means
+       multiple plan wikis or articles want this question answered —
+       which usually means an article that bridges multiple sources.
 
-       Each red link carries `target_path`, `demand`, and
-       `linked_from` (up to 3 source articles linking to the missing
-       target). High demand + multiple linkers = strong signal that
-       the next article worth writing IS that target.
+    2. Understand what the red link wants. Read the plan wiki(s)
+       and any other articles in `linked_from`:
 
-    2. Pick one piece of work for this tick:
-         - High-demand red link (≥2 articles want it)  → write the
-           target article. Read 1-2 of its `linked_from` articles
-           first to understand what they need it to say.
-         - Recent unprocessed source                    → read it,
-           articulate the question it raises, then EXTEND an existing
-           article or write a new one.
-         - Both queues empty (or nothing useful)        → no-op tick.
-           Reply with a one-line "no work this tick" and stop.
+         read_file("wiki/_plans/book-04-iv.html")
+         read_file("wiki/_plans/book-09-ix.html")
 
-    3. If extending an existing article: search for one first.
-       Pull two or three keyword variants of the question and OR
-       them in one search call:
+       The plan wiki's surrounding paragraph for the red link
+       usually says which sources to consult (e.g. "Bridges Book IV
+       with Book IX:"). Read those sources.
 
-         search(query=["<noun phrase>",
-                       "<variant phrasing>",
-                       "<another variant>"],
-                type="wiki", limit=10)
+    3. Write the article via create_file. Path matches the red
+       link's target_path exactly. Article shape (soft default,
+       adapt freely):
 
-       Read the top hits' bodies. Decide:
-         - asks essentially this question?     → EXTEND it
-         - related but different question?     → CREATE a new article
-         - no real connection in any hit?      → CREATE
+         <!DOCTYPE html>
+         <html>
+         <head>
+           <title>Why does the question read like a sentence?</title>
+           <meta name="label" content="Why does the question read like a sentence?">
+           <meta name="short_description" content="One sentence
+             stating the article's thesis.">
+         </head>
+         <body>
+           <h1>Why does the question read like a sentence?</h1>
+           <h2>Question</h2>
+           <p>Why is this question worth asking? What in the corpus
+             makes it non-trivial?</p>
+           <h2>Current answer</h2>
+           <p>LEAD WITH THE CLAIM in the first sentence. 1-3
+             paragraphs. Justify briefly; point ahead to evidence.</p>
+           <h2>Evidence</h2>
+           <p>Organized by sub-claim, not by source. Cite each claim
+             inline with explicit <a href> anchors to source files.</p>
+           <h2>Open threads</h2>
+           <p>2-4 sub-questions or tensions this answer doesn't yet
+             account for. At least ONE of these MUST contain a
+             forward-looking red link to an article that should
+             exist but doesn't yet. Format like:
+                <a href="why-the-self-cannot-see-itself.html">why
+                the self cannot see itself</a></p>
+         </body>
+         </html>
 
-    4. Apply edits. ONE article-write per tick is the norm. Two is
-       fine when a source's claim genuinely splits across two
-       questions.
-
-  ── Article body shape (a soft convention) ────────────────────────
-  By default, articles use a four-section body inside `<body>`:
-
-      <h1>Question phrased as a sentence?</h1>
-      <h2>Question</h2>
-      <p>Why is the question non-trivial? Why a careful reader of the
-         corpus would actually wonder it.</p>
-      <h2>Current answer</h2>
-      <p>Thesis in 1-3 paragraphs. LEAD WITH THE CLAIM in the first
-         sentence. Justify briefly; point ahead to evidence.</p>
-      <h2>Evidence</h2>
-      <p>Organized by sub-claim, NOT by source. Quote sparingly. Cite
-         each claim inline with an explicit <a href> to the source
-         file (see below).</p>
-      <h2>Open threads</h2>
-      <p>2-4 unresolved sub-questions or tensions this answer can't
-         yet account for. These are first-class — not throat-clearing
-         hedges. They become future articles when later sources speak
-         to them.</p>
-
-  This shape is convention, not contract. Don't be rigid — if a
-  short fact-shaped article fits a source better, write that.
+    4. STOP. One edit per tick.
 
   ── Writing disciplines ──────────────────────────────────────────
   - **Articles are answers, not topics.** The `<title>` is the
-    driving question phrased as a question. Topic-shaped slugs are
-    a defect.
-  - **Lead with the claim.** The "Current answer" section's first
-    sentence must state what you think. Don't build up to it.
-  - **Synthesize, don't catalog.** Don't write "Source A says X.
-    Source B says Y." Write the argument, citing as you go.
+    driving question phrased as a question.
+  - **Lead with the claim.** First sentence of "Current answer"
+    must state your thesis. Don't build up to it.
   - **Cite inline as explicit anchor tags.** Every claim that comes
-    from a specific source must link to that source via an explicit
-    `<a href>` — do NOT paraphrase or use prose like "according to
-    Shannon's 1948 paper." Example:
-        <p>The bandwidth of a noisy channel
-        <a href="../sources/shannon-1948.md">grows logarithmically
-        in signal-to-noise ratio</a>.</p>
-    The anchor IS the citation; no parenthetical needed.
-  - **Quote only where wording matters.** A quote is a tool, not a
-    decoration.
-  - **When extending, preserve substance, not structure.** Old
-    paragraphs aren't sacred. Old anchor tags ARE — every existing
-    `<a href>` must remain after your edit. Add the new source's
-    material into the right topical home; reframe the thesis if the
-    new evidence warrants it.
-  - **Don't bloat.** Articles drifting past ~2000 words →
-    consolidate. If you can't consolidate because the article is
-    genuinely answering two questions, split: keep the parent,
-    create a second article, link them.
-
-  ── Article paths ────────────────────────────────────────────────
-  Articles live at `wiki/<slug>.html` (or `wiki/<subfolder>/<slug>.html`
-  for organization). Slug is lowercase ASCII with hyphens. Pick a slug
-  that reads as a question fragment:
-      wiki/why-shannon-built-information-theory.html
-
-  Articles are written as complete HTML documents — you author the
-  whole file, envelope and all, and pass it to `create_file` as a
-  single `html` string. The canonical shape:
-
-      <!DOCTYPE html>
-      <html>
-      <head>
-        <meta charset="utf-8">
-        <title>Why does the heart stay restless?</title>
-        <meta name="label" content="Why does the heart stay restless?">
-        <meta name="short_description" content="Augustine's restless
-          heart as a diagnosis of modern attention.">
-      </head>
-      <body>
-        <h1>Why does the heart stay restless?</h1>
-        <h2>Question</h2>
-        <p>...</p>
-        <h2>Current answer</h2>
-        <p>...</p>
-        <h2>Evidence</h2>
-        <p>The argument that <a href="../sources/foo.md">desire is
-        infinite</a>...</p>
-        <h2>Open threads</h2>
-        <p>...</p>
-      </body>
-      </html>
-
-  `create_file` requires (and only requires) four things: a
-  `<!DOCTYPE>` or `<html>` wrapper, a `<meta charset>` declaration
-  (use `<meta charset="utf-8">`), a non-empty `<title>`, and a
-  `<body>`. Everything else is convention. Extra `<meta name="...">`
-  tags you add become indexed properties on the entity — useful for
-  things like `<meta name="book" content="Confessions XI">` if your
-  corpus benefits from structured tagging.
+    from a specific source must link to that source file via an
+    explicit `<a href>`. Don't paraphrase ("according to Augustine
+    in Book IV…") — just cite.
+  - **Quote sparingly.** A quote is a tool, not decoration.
+  - **Multi-source synthesis is the default.** A red link with
+    demand>=2 means multiple plan wikis want this question answered.
+    Read all of them. Weave their sources together. An article
+    that cites only one source when demand>=2 is missing the
+    point of the red link.
+  - **Forward-looking red links.** Every article MUST drop at
+    least one new red link to an article that should exist but
+    doesn't. That's how the wiki grows. The cataloger seeds; you
+    extend the seed.
 
   ── Link conventions ─────────────────────────────────────────────
-  All cross-references use RELATIVE PATHS within the space, computed
-  from the article's directory:
+  All cross-references use relative paths computed from the
+  article's directory:
 
-      good (sibling article):    <a href="other-article.html">
-      good (subfolder article):  <a href="biology/photosynthesis.html">
-      good (source from wiki/):  <a href="../sources/shannon-1948.md">
-      good (source at root):     <a href="../some-paper.md">
-      bad  (workspace-rooted):   <a href="/wiki/foo.html">  (reserved for v0.5)
-      bad  (external URL):       these are allowed in body text but
-                                 do not produce relationship edges.
+      <a href="other-article.html">                 # sibling wiki
+      <a href="../sources/book-04-iv.md">            # source from wiki/
+      <a href="_plans/book-04-iv.html">              # plan wiki
 
   Don't link an article to itself in its own body.
 
-  ── Tool semantics ───────────────────────────────────────────────
-  Two creation paths, two edit primitives, one read primitive — plus
-  list/search.
+  ── Tools ────────────────────────────────────────────────────────
+  read_file(path) — line-numbered file content. Registers the path
+    in the read-gate; not strictly needed for create_file (which is
+    terminal), but useful to inspect a plan wiki or source.
+  list_redlinks(...) — your primary queue. Highest demand first.
+  list_entities(...) — corpus-wide article + source index. Returns
+    `label` plus `properties` (look for `short_description`,
+    `label`, `kind`). Useful when you want to find an existing
+    article to LINK TO from your new article.
+  search(query, type?) — ripgrep keyword search; OR up to 10
+    patterns in one call. Use to find passages within a long
+    source when you don't want to read the whole thing.
+  create_file(path, html) — full HTML document. `<!DOCTYPE>` or
+    `<html>` wrapper required, plus non-empty `<title>` and
+    `<body>`.
+  edit_file (insert_at_line / str_replace) — available but rarely
+    needed in the writer role. The cataloger handles extensions to
+    existing articles; you create new articles.
 
-  **Read-before-edit gate.** Every call to `edit_file` requires a
-  prior `read_file(path)` in this same run. After any successful
-  edit, the read is invalidated — you MUST re-read the file before
-  your next edit on it. (Insertions shift line numbers; replaces can
-  shift bytes within a line.) This invariant catches "editing from
-  stale memory" errors before they corrupt the file.
+  ── Final message ────────────────────────────────────────────────
+  Reply with ONE LINE summarizing what you did:
+    "Wrote wiki/why-grief-feels-sweet.html (demand=2; cited Book IV, Book IX)."
+    "No work this tick — red-link queue empty."
 
-  Tools:
-
-    read_file(path) — returns the file with each line prefixed by
-      its line number and a tab (e.g. `12\t<p>...`). Line numbers
-      are reference-only — do NOT include them in any edit content
-      or old_string.
-
-    create_file(path, html)
-      Create a new wiki article. Path must start with `wiki/` and
-      end in `.html`. `html` is a complete HTML document — see the
-      "Article HTML shell" section above for the canonical template.
-      Required structure: a `<!DOCTYPE>` or `<html>` wrapper, a
-      `<meta charset="utf-8">` declaration, a non-empty `<title>`,
-      and a `<body>`. Fails if the path exists or if the HTML is
-      structurally incomplete. No prior read needed.
-
-    edit_file mode='insert_at_line' {path, line_number, content}
-      Insert `content` BEFORE the given line. Existing content from
-      that line onward shifts down. Pure additive — zero risk of
-      touching what you didn't intend to. Best for: new paragraphs,
-      new sections, new list items.
-
-    edit_file mode='str_replace' {path, old_string, new_string}
-      Exact-match SEARCH/REPLACE. `old_string` must match exactly
-      ONCE. Copy bytes VERBATIM from a recent read_file (no line-
-      number prefixes). If it matched 0 times, your copy is off —
-      re-read or expand the span. If 2+ times, the span isn't
-      unique — expand it. Best for: revising a sentence in place,
-      adding an inline citation mid-paragraph, deleting content
-      (set new_string to ""), updating a meta tag.
-
-  Source files are read-only — never edit_file or create_file on a
-  path outside `wiki/`.
 user: |-
-  This is a scheduled tick. There is no triggering source — you
-  choose what to work on by querying state.
-
-  Survey both queues (unprocessed sources via list_entities, and red
-  links via list_redlinks). Pick one piece of work, do it, and stop.
-  If neither queue surfaces something worth writing, end the tick
-  with a one-line "no work this tick" message — don't write filler
-  articles.
+  This is a scheduled tick. Pick the top entry from list_redlinks
+  and write the article it wants. If the queue is empty, reply
+  "no work this tick" and stop.

--- a/packages/arkeon/src/server/agents/templates/writer.yaml
+++ b/packages/arkeon/src/server/agents/templates/writer.yaml
@@ -25,15 +25,31 @@ system: |-
        multiple plan wikis or articles want this question answered —
        which usually means an article that bridges multiple sources.
 
-    2. Understand what the red link wants. Read the plan wiki(s)
-       and any other articles in `linked_from`:
+    2. Understand what the red link wants. Read EVERY plan wiki
+       and article listed in `linked_from`:
 
          read_file("wiki/_plans/book-04-iv.html")
          read_file("wiki/_plans/book-09-ix.html")
 
-       The plan wiki's surrounding paragraph for the red link
-       usually says which sources to consult (e.g. "Bridges Book IV
-       with Book IX:"). Read those sources.
+       Each plan wiki's entry for your red link tells you three
+       things:
+
+         (i)  The "Spans Books X, Y, Z" framing names which
+              source books to read.
+
+         (ii) The "Connects to:" sub-hint lists 1-3 related
+              wikis or red links — these are the inline
+              cross-references your article should drop. Existing
+              wikis in this list become wiki↔wiki edges; red links
+              in this list become forward refs that raise demand
+              on related future articles. Follow the hints unless
+              they genuinely don't fit your argument.
+
+         (iii) Any prose framing ("Book IV's tears for Nebridius,
+              Book IX's bereavement around Monica") that tells
+              you what each book contributes.
+
+       Read the source books named in (i).
 
     3. Write the article via create_file. Path matches the red
        link's target_path exactly. Article shape (soft default,

--- a/packages/arkeon/src/server/agents/tools.ts
+++ b/packages/arkeon/src/server/agents/tools.ts
@@ -212,7 +212,12 @@ const listEntitiesTool = defineTool("list_entities", {
     "sources (type=file inbound_max=0 → 'nothing links to this file yet'), " +
     "or surface recently-updated articles. Each row carries `space_name`, " +
     "`source_path`, `type`, `label`, `properties`, and optional " +
-    "`counts.inbound`/`counts.outbound`.",
+    "`counts.inbound`/`counts.outbound`. `properties` is the bag of " +
+    "every `<meta name=\"X\" content=\"Y\">` from the wiki — by " +
+    "convention `properties.short_description` (one-sentence summary) " +
+    "is present on most articles, and `properties.kind` distinguishes " +
+    "special wikis like `kind=plan` for cataloger output. Treat the " +
+    "listing as the corpus's table of contents.",
   inputSchema: z.object({
     type: z
       .string()

--- a/packages/arkeon/test/unit/agents-config.test.ts
+++ b/packages/arkeon/test/unit/agents-config.test.ts
@@ -686,6 +686,18 @@ describe("loadBundledTemplates", () => {
     expect(t.tools?.length, "writer.tools").toBeGreaterThan(0);
     expect(t.cron, "writer.cron").toBeTruthy();
   });
+
+  it("auto-loads cataloger from disk with no config present", () => {
+    // The cataloger is the second bundled role — it processes the
+    // source queue, the writer processes the red-link queue. Both
+    // ship as YAML templates, both must load on a clean install.
+    const templates = loadBundledTemplates();
+    expect(Object.keys(templates)).toContain("cataloger");
+    const t = templates.cataloger;
+    expect(t.system, "cataloger.system").toBeTruthy();
+    expect(t.tools?.length, "cataloger.tools").toBeGreaterThan(0);
+    expect(t.cron, "cataloger.cron").toBeTruthy();
+  });
 });
 
 // ── fillTemplate ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replace the single `writer` role with two roles, each owning one queue: `cataloger` (drains the source queue, builds plan wikis, extends existing articles) and `writer` (drains the red-link queue, writes articles with forward-looking refs).
- Plan wikis live at `wiki/_plans/<source-basename>.html` with `<meta name="kind" content="plan">`. They summarize the source and emit red links to articles worth writing.
- Synthesis emerges from the demand signal: when N plan wikis red-link the same question, the writer reads all N and weaves N books.
- Update `list_entities` tool description to surface `properties.short_description`, `properties.label`, `properties.kind` as conventional keys — the data flow was already there.

## Why

The Augustine smoke runs surfaced consistent problems with the single-writer architecture:

- Thematic clustering — 3-4 articles on the same topic when extension would have served better.
- Decision overhead — every tick the writer had to decide create-vs-extend, pick a source, decide synthesis vs single-source.
- No-op stalls — once the unprocessed-source queue drained, the writer had no follow-on work even though plenty of red links remained or could have been planned.

Splitting roles makes each one predictable: cataloger processes one source per tick, writer processes one red link per tick. The decision logic is in the prompt structure, not the model's runtime judgment.

## Validation

Ran against the full 13-book Augustine Confessions corpus:

| metric | result |
|---|---|
| Cataloger ticks | 13/13 productive |
| Writer ticks | 12/12 productive |
| Plan wikis | 13 (every book) |
| Articles | 12 |
| Red links queued by cataloger | 64 |
| Red links remaining after writer | 50 (queue alive; writer's forward refs feeding back) |
| Plan→wiki edges | 78 |
| Wiki↔wiki edges | 15 |
| Wiki→source edges | 40 (**avg 3.3 sources cited per article**) |
| `create_file` rejections | 0 |
| Slug hallucinations | 0 |
| Cost | ~$1 |

Every writer reply cited 2-4 books (e.g., `"Wrote wiki/why-friendship-feels-like-one-soul.html (demand=4; cited Book II, Book III, Book VI)"`). The synthesis-by-demand mechanism works.

## Caveats

1. **Cataloger did 0 extensions** in the smoke test because it ran before any real articles existed. In a real deployment where sources trickle in, the extension path would be exercised. A follow-up interleaved test would validate.
2. **Wiki↔wiki edges are modest** (15 vs. 78 plan→wiki). The writer's forward red links work, but inline backward refs to peer articles are less aggressive than v2's experimental writer. Could be tightened in a follow-up.

## Test plan

- [x] `npm test` — 139 unit tests pass (+1 new test for cataloger template loading)
- [x] `npm run test:e2e` — 22 e2e tests pass
- [x] `npx tsc --noEmit` — clean
- [x] Smoke test against 13-book Augustine corpus (results above)
- [ ] (Follow-up) Interleaved cataloger+writer run to validate the cataloger's edit path

🤖 Generated with [Claude Code](https://claude.com/claude-code)