### PR TITLE
Phase 2: browser reader (HTML routes, chrome injection, link classes)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,17 @@ Default base URL: `http://localhost:8000`. No auth. JSON in, JSON out. Routes ar
 | `GET` | `/health` | Liveness. |
 | `GET` | `/ready` | Readiness — `200` if SQLite responds. |
 
+The daemon also serves a small browser-facing reader (Phase 2). These return HTML, not JSON:
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/` | HTML list of spaces + entity counts. |
+| `GET` | `/{space}/` | HTML alphabetical article index (only `type='wiki'`). |
+| `GET` | `/{space}/wiki/*` | The article HTML from disk, with `<div id="arkeon-chrome">` injected and link classes tagged (`arkeon-wiki`, `arkeon-file`, `arkeon-redlink`). |
+| `GET` | `/{space}/*` | Static-file fallback (sources, PDFs, images, …) with the right `Content-Type`. |
+
+URL structure mirrors disk structure: `wiki/foo.html` on disk → `/{space}/wiki/foo.html` over HTTP. Articles also work directly over `file://` because hrefs are never rewritten.
+
 ## Wiki file format
 
 Wikis are HTML under `wiki/` (subfolders allowed for organization, no `subject_type` namespacing). The shell:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,8 @@ No auth, no actors, no versioning.
 - `src/server/lib/file-edits.ts` — `applyEdit(space, edit, opts)`: the mutation chokepoint. Four kinds: `create`, `insert_at_line`, `str_replace`, `delete`. Exports `validateWikiHtmlDocument` for `create_file` (structural validation: `<!DOCTYPE>`/`<html>` + non-empty `<title>` + `<body>`).
 - `src/server/lib/entities.ts` — `listEntities()` + `listRedLinks()` + `getEntity()`. Pure SQL, parameterized.
 - `src/server/lib/search.ts` — ripgrep adapter (`@vscode/ripgrep`), spawns per-space, parses `--json` events, joins back to entities by path.
+- `src/server/lib/reader.ts` — Phase 2 rendering primitives: `classifyAnchor`, `instrumentArticle`, `renderSpaceIndex`, `renderArticleIndex`. Pure functions; the route handlers in `routes/reader.ts` are thin glue.
+- `src/server/routes/reader.ts` — the four human-facing routes (`/`, `/:space`, `/:space/`, `/:space/wiki/*`, `/:space/*`). Mounted last so `/:space/*` is a true fallback.
 - `src/server/agents/` — declarative `.arkeon/agents.yaml` config (Zod-validated), bundled role templates (`templates/*.yaml`), role-builder, tool registry, `runAgent` loop (Vercel AI SDK), per-space cron scheduler.
 - `src/server/agents/cron.ts` — `nextTick(expr, from)` via `cron-parser`. Drives the scheduler's `setTimeout` chain.
 - `src/server/agents/scheduler.ts` — per-space cron. Per-space mutex (skip-if-busy on contention). No event queue, no orphan reclaim.
@@ -133,7 +135,8 @@ No auth, no actors, no versioning.
 
 Routes are space-scoped under `/{space}/...`. No auth required.
 
-- `GET /` — daemon-level landing (returns `{name, status}` for now; the human-facing version arrives in Phase 2).
+JSON API:
+
 - `POST /spaces` — register a directory. Body `{name, watch_dir}`. Name collisions return 409.
 - `GET /spaces` — list spaces with entity counts.
 - `GET /spaces/:name` — single space.
@@ -145,7 +148,17 @@ Routes are space-scoped under `/{space}/...`. No auth required.
 - `POST /{space}/chat`, `GET /{space}/chat/:conversation_id`, `DELETE ...` — **501 Phase 1 stubs**, wired up in Phase 3.
 - `GET /health` / `GET /ready` — liveness/readiness.
 
+Human-facing reader (Phase 2):
+
+- `GET /` — HTML spaces list (alphabetical, with per-space entity counts).
+- `GET /{space}` — 301 redirect to `/{space}/` (keeps relative hrefs correct on the index page).
+- `GET /{space}/` — HTML article index (`type='wiki'` only, alphabetical by `label`, with `short_description` subtitles).
+- `GET /{space}/wiki/*` — wiki article with chrome injection (`<div id="arkeon-chrome">`) and link classes (`arkeon-wiki`, `arkeon-file`, `arkeon-redlink`). The reader parses the on-disk HTML, decorates anchors, and serializes — never rewrites hrefs, so the same file opens identically via `file://`.
+- `GET /{space}/*` — static-file fallback. Serves any non-wiki path inside the watch dir with the right `Content-Type` (markdown → `text/markdown`, PDF → `application/pdf`, images → `image/*`, etc.). Path-traversal escapes return 404.
+
 Content lives on disk — the API returns metadata, relationships, and (optionally) file bodies.
+
+The reader is the "everything else" layer — it's mounted last so its `/:space/*` fallback only matches URLs no other route has claimed. The hard rule: URL structure mirrors disk structure within a space (`wiki/foo.html` on disk → `/{space}/wiki/foo.html` over HTTP). Articles render identically under `file://` and `http://`.
 
 ## Search
 
@@ -217,8 +230,8 @@ Tail with `tail -f <path> | jq` or query with `jq -c 'select(.event=="tool.call"
 
 ## What's NOT here (yet)
 
-- HTML reader / web viewer / chrome injection → **Phase 2** (`tasks/v0-reading-experience.md`)
 - Chat-with-article → **Phase 3** (`tasks/v0-chat.md`). Schema is in place; routes are stubs.
+- Human-facing UI for `/{space}/search`, `/{space}/recent`, `/{space}/redlinks`, per-article history. APIs exist; the reader pages don't render them in v0 (see `tasks/v0-reading-experience.md` for what was deliberately cut).
 - Cross-space link resolution — schema is ready (`relationships.target_path` is unconstrained text; URL scheme `/{other-space}/wiki/...` is committed). Writer prompt updates wait for **v0.5**.
 - Vector / semantic search — returns at **v0.5** when corpus crosses ~2,000 articles.
 - FTS5 / BM25 ranking (ripgrep gives substring matching only)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,13 @@ The system automatically:
 
 No manual sync commands. Just save files.
 
-**4. Query the graph**
+**4. Read in the browser**
+
+Open `http://localhost:8000/` to see the list of registered spaces. Click through to an article — the daemon serves the HTML straight off disk, injects a small back-link strip, and tags missing link targets in red so red links are obvious as you read.
+
+URL structure mirrors disk structure within a space (`wiki/foo.html` on disk → `http://localhost:8000/{space}/wiki/foo.html`). Relative hrefs in articles resolve the same way over HTTP and `file://`, so the writer's output stays portable — copy the directory, open the HTML, links work.
+
+**5. Query the graph**
 
 ```bash
 # List wikis in your space

--- a/packages/arkeon/src/server/app.ts
+++ b/packages/arkeon/src/server/app.ts
@@ -10,18 +10,12 @@ import { mapDatabaseError } from "./lib/db-errors.js";
 import { createSql } from "./lib/sql.js";
 import { spacesRouter } from "./routes/spaces.js";
 import { spaceScopedRouter } from "./routes/space-scoped.js";
+import { readerRouter } from "./routes/reader.js";
 
 export function createApp() {
   const app = new Hono<AppBindings>();
 
   app.use("*", requestContextMiddleware);
-
-  app.get("/", (c) =>
-    c.json({
-      name: "arkeon-wiki",
-      status: "ok",
-    }),
-  );
 
   app.get("/health", (c) => c.json({ status: "ok" }));
 
@@ -37,6 +31,9 @@ export function createApp() {
 
   app.route("/spaces", spacesRouter);
   app.route("/", spaceScopedRouter);
+  // The reader is mounted last because its `/:space/*` fallback should
+  // only match URLs no other route has claimed.
+  app.route("/", readerRouter);
 
   app.notFound((c) => {
     const requestId = c.get("requestId");

--- a/packages/arkeon/src/server/lib/fs-watcher.ts
+++ b/packages/arkeon/src/server/lib/fs-watcher.ts
@@ -33,7 +33,16 @@ const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 const DEBOUNCE_MS = 500;
 
-function shouldIgnorePath(relativePath: string): boolean {
+/**
+ * True if any path segment is hidden (`.`-prefixed) or matches a
+ * well-known ignore directory (`.git`, `node_modules`, `.arkeon`, etc.).
+ *
+ * Exported so the reader routes can return 404 for the same set the
+ * watcher refuses to index — keeping one rule in one place. Without
+ * this, a user could navigate to `/{space}/.arkeon/state.json` or
+ * `/{space}/.git/config` and the static-file fallback would serve it.
+ */
+export function shouldIgnorePath(relativePath: string): boolean {
   const parts = relativePath.split("/");
   for (const part of parts) {
     if (part.startsWith(".") && part !== ".") return true;

--- a/packages/arkeon/src/server/lib/reader.ts
+++ b/packages/arkeon/src/server/lib/reader.ts
@@ -1,0 +1,283 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pure rendering primitives for the Phase 2 reader.
+ *
+ * The four routes are thin glue over four functions in this file:
+ *
+ *   - `classifyAnchor`        decide which classes an `<a href>` earns.
+ *   - `instrumentArticle`     parse a wiki article, tag links, inject chrome.
+ *   - `renderSpaceIndex`      `GET /` — list of spaces on this daemon.
+ *   - `renderArticleIndex`    `GET /{space}/` — alphabetical article list.
+ *
+ * All four are deterministic and DB-free — the route handlers pass in the
+ * data they need (space rows, entity rows, the set of known paths in the
+ * article's space). Easy to unit-test.
+ *
+ * The injected chrome is a single `<div id="arkeon-chrome">` after `<body>`
+ * open, plus a small `<style>` block in `<head>`. CSS is scoped to
+ * `#arkeon-chrome` and to the three link classes the server adds:
+ *
+ *   - `arkeon-wiki`     target ends in `.html` (lives under any directory)
+ *   - `arkeon-file`     anything else (markdown, pdf, image, …)
+ *   - `arkeon-redlink`  target has no `entities` row for this space
+ *
+ * The classes are independent and combine freely. Article-author `<style>`
+ * blocks can override via specificity.
+ */
+
+import { parse } from "node-html-parser";
+import { posix } from "node:path";
+
+import { resolveHref } from "./html-links.js";
+
+const SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+
+/**
+ * Decide which `arkeon-*` classes to add to a single anchor.
+ *
+ * Returns an empty array when the href is external, a fragment, a
+ * server-absolute path (`/...` — reserved for cross-space in v0.5), or
+ * escapes the space root. Those anchors render with no extra classes
+ * and behave like normal links.
+ *
+ * Otherwise the result is some combination of `arkeon-wiki` /
+ * `arkeon-file` plus an optional `arkeon-redlink`.
+ */
+export function classifyAnchor(
+  href: string,
+  fromPath: string,
+  knownPaths: Set<string>,
+): string[] {
+  if (!href) return [];
+  if (href.startsWith("#")) return [];
+  if (SCHEME_RE.test(href)) return [];
+  if (href.startsWith("//")) return [];
+  if (href.startsWith("/")) return []; // reserved for cross-space
+
+  const resolved = resolveHref(href, fromPath);
+  if (!resolved) return [];
+
+  const classes: string[] = [];
+  classes.push(resolved.toLowerCase().endsWith(".html") ? "arkeon-wiki" : "arkeon-file");
+  if (!knownPaths.has(resolved)) classes.push("arkeon-redlink");
+  return classes;
+}
+
+const CHROME_CSS = `
+#arkeon-chrome {
+  position: sticky;
+  top: 0;
+  z-index: 9999;
+  padding: 8px 16px;
+  background: #f5f5f5;
+  border-bottom: 1px solid #e0e0e0;
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 14px;
+  color: #333;
+}
+#arkeon-chrome a.arkeon-back { color: #555; text-decoration: none; }
+#arkeon-chrome a.arkeon-back:hover { color: #000; }
+a.arkeon-file { color: #4a6b7c; text-decoration: underline dotted; text-underline-offset: 2px; }
+a.arkeon-file:hover { color: #2c4a59; text-decoration: underline; }
+a.arkeon-redlink { color: #c00; }
+a.arkeon-redlink:hover { color: #900; text-decoration: underline; }
+`.trim();
+
+/**
+ * Parse an article's HTML, decorate every relative `<a>` with the
+ * appropriate `arkeon-*` classes, inject the chrome div + style, and
+ * return the serialized document.
+ *
+ * Idempotent enough for v0: if the page already has an `#arkeon-chrome`
+ * element we skip re-injecting (defensive against double-renders, not a
+ * real concern since articles on disk never contain one).
+ */
+export function instrumentArticle(
+  html: string,
+  fromPath: string,
+  knownPaths: Set<string>,
+  spaceName: string,
+): string {
+  const root = parse(html);
+
+  for (const a of root.querySelectorAll("a")) {
+    const href = a.getAttribute("href");
+    if (!href) continue;
+    const added = classifyAnchor(href, fromPath, knownPaths);
+    if (added.length === 0) continue;
+    const existing = (a.getAttribute("class") ?? "").trim();
+    const merged = existing ? `${existing} ${added.join(" ")}` : added.join(" ");
+    a.setAttribute("class", merged);
+  }
+
+  const head = root.querySelector("head");
+  if (head && !head.querySelector("style[data-arkeon-chrome]")) {
+    head.insertAdjacentHTML(
+      "beforeend",
+      `<style data-arkeon-chrome>${CHROME_CSS}</style>`,
+    );
+  }
+
+  const body = root.querySelector("body");
+  if (body && !body.querySelector("#arkeon-chrome")) {
+    const safeName = escapeHtml(spaceName);
+    body.insertAdjacentHTML(
+      "afterbegin",
+      `<div id="arkeon-chrome"><a class="arkeon-back" href="/${encodeURIComponent(spaceName)}/">&larr; ${safeName}</a></div>`,
+    );
+  }
+
+  return root.toString();
+}
+
+export interface SpaceIndexRow {
+  name: string;
+  entity_count: number;
+}
+
+/**
+ * Render the daemon-level landing page. Always shows the full list of
+ * spaces, even when there's only one — no redirect, no "featured"
+ * selection. Simple and predictable.
+ */
+export function renderSpaceIndex(spaces: SpaceIndexRow[]): string {
+  const rows = spaces
+    .map(
+      (s) =>
+        `    <li><a href="/${encodeURIComponent(s.name)}/">${escapeHtml(s.name)}</a> — ${s.entity_count} ${s.entity_count === 1 ? "entity" : "entities"}</li>`,
+    )
+    .join("\n");
+  const empty = `    <li><em>no spaces registered yet — run <code>arkeon-wiki init</code> in a directory to create one</em></li>`;
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>arkeon-wiki</title>
+  <style>
+    body { font-family: system-ui, -apple-system, sans-serif; max-width: 720px; margin: 2rem auto; padding: 0 1rem; color: #222; }
+    h1 { font-size: 1.4rem; margin-bottom: 1rem; }
+    ul { list-style: none; padding: 0; }
+    li { padding: 0.4rem 0; border-bottom: 1px solid #eee; }
+    a { color: #0366d6; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code { background: #f4f4f4; padding: 0 0.3em; border-radius: 3px; font-size: 0.95em; }
+  </style>
+</head>
+<body>
+  <h1>arkeon-wiki</h1>
+  <ul>
+${spaces.length === 0 ? empty : rows}
+  </ul>
+</body>
+</html>
+`;
+}
+
+export interface ArticleIndexRow {
+  source_path: string;
+  label: string | null;
+  short_description: string | null;
+}
+
+/**
+ * Render the per-space alphabetical article index. Each row links to
+ * the wiki article via its on-disk path under `/{space}/wiki/...`.
+ *
+ * `label` falls back to the bare filename if missing (the writer is
+ * supposed to emit `<title>`, so this is just defensive).
+ */
+export function renderArticleIndex(
+  spaceName: string,
+  articles: ArticleIndexRow[],
+): string {
+  const sorted = [...articles].sort((a, b) => {
+    const al = (a.label ?? posix.basename(a.source_path)).toLowerCase();
+    const bl = (b.label ?? posix.basename(b.source_path)).toLowerCase();
+    if (al < bl) return -1;
+    if (al > bl) return 1;
+    return 0;
+  });
+
+  const rows = sorted
+    .map((a) => {
+      const display = escapeHtml(a.label ?? posix.basename(a.source_path));
+      const href = `/${encodeURIComponent(spaceName)}/${a.source_path
+        .split("/")
+        .map(encodeURIComponent)
+        .join("/")}`;
+      const sub = a.short_description
+        ? `<p class="desc">${escapeHtml(a.short_description)}</p>`
+        : "";
+      return `    <li><a href="${href}">${display}</a>${sub}</li>`;
+    })
+    .join("\n");
+
+  const empty = `    <li><em>no articles yet — the writer creates them on its cron schedule.</em></li>`;
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>${escapeHtml(spaceName)} — arkeon-wiki</title>
+  <style>
+    body { font-family: system-ui, -apple-system, sans-serif; max-width: 760px; margin: 2rem auto; padding: 0 1rem; color: #222; }
+    h1 { font-size: 1.4rem; margin-bottom: 1rem; }
+    .crumb { color: #888; font-size: 0.9em; margin-bottom: 1rem; }
+    .crumb a { color: #888; }
+    ul { list-style: none; padding: 0; }
+    li { padding: 0.6rem 0; border-bottom: 1px solid #eee; }
+    a { color: #0366d6; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .desc { color: #555; margin: 0.2rem 0 0 0; font-size: 0.95em; }
+  </style>
+</head>
+<body>
+  <p class="crumb"><a href="/">&larr; spaces</a></p>
+  <h1>${escapeHtml(spaceName)}</h1>
+  <ul>
+${sorted.length === 0 ? empty : rows}
+  </ul>
+</body>
+</html>
+`;
+}
+
+/**
+ * Render a minimal 404 page for the reader. The article/file route
+ * uses this when a path doesn't resolve. Red text on a missing wiki
+ * link is enough signal in the article view; this page is just for the
+ * direct-navigation case.
+ */
+export function renderNotFound(spaceName: string, path: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>not found — ${escapeHtml(spaceName)}</title>
+  <style>
+    body { font-family: system-ui, -apple-system, sans-serif; max-width: 720px; margin: 4rem auto; padding: 0 1rem; color: #222; }
+    h1 { color: #c00; font-size: 1.4rem; }
+    code { background: #f4f4f4; padding: 0.1em 0.3em; border-radius: 3px; }
+    p { color: #555; }
+    a { color: #0366d6; }
+  </style>
+</head>
+<body>
+  <h1>not found</h1>
+  <p><code>${escapeHtml(path)}</code> doesn't exist in space <code>${escapeHtml(spaceName)}</code>.</p>
+  <p><a href="/${encodeURIComponent(spaceName)}/">&larr; back to ${escapeHtml(spaceName)}</a></p>
+</body>
+</html>
+`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/packages/arkeon/src/server/lib/reader.ts
+++ b/packages/arkeon/src/server/lib/reader.ts
@@ -90,6 +90,10 @@ a.arkeon-redlink:hover { color: #900; text-decoration: underline; }
  * appropriate `arkeon-*` classes, inject the chrome div + style, and
  * return the serialized document.
  *
+ * Note: the bytes round-trip through `node-html-parser`'s parse →
+ * toString, so whitespace, attribute quoting, and self-closing-tag
+ * style may differ from the on-disk source. Semantics don't.
+ *
  * Idempotent enough for v0: if the page already has an `#arkeon-chrome`
  * element we skip re-injecting (defensive against double-renders, not a
  * real concern since articles on disk never contain one).

--- a/packages/arkeon/src/server/routes/reader.ts
+++ b/packages/arkeon/src/server/routes/reader.ts
@@ -31,6 +31,7 @@ import type { AppBindings } from "../types.js";
 import { ApiError } from "../lib/errors.js";
 import { createSql } from "../lib/sql.js";
 import { safeResolve } from "../lib/file-edits.js";
+import { shouldIgnorePath } from "../lib/fs-watcher.js";
 import {
   instrumentArticle,
   renderArticleIndex,
@@ -136,6 +137,9 @@ readerRouter.get("/:space/wiki/*", async (c) => {
   if (!articlePath || !articlePath.startsWith("wiki/")) {
     throw new ApiError(400, "validation_error", "missing wiki path");
   }
+  if (shouldIgnorePath(articlePath)) {
+    return c.html(renderNotFound(space, articlePath), 404);
+  }
 
   let abs: string;
   try {
@@ -165,6 +169,12 @@ readerRouter.get("/:space/*", async (c) => {
   const relPath = extractSpacePath(c.req.url, space);
   if (!relPath) {
     throw new ApiError(400, "validation_error", "missing file path");
+  }
+  // The reader never serves anything under hidden / ignored directories
+  // (`.arkeon`, `.git`, `node_modules`, dot-prefixed files, …). Same set
+  // the watcher refuses to index — see `shouldIgnorePath`.
+  if (shouldIgnorePath(relPath)) {
+    return c.html(renderNotFound(space, relPath), 404);
   }
 
   let abs: string;

--- a/packages/arkeon/src/server/routes/reader.ts
+++ b/packages/arkeon/src/server/routes/reader.ts
@@ -1,0 +1,243 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Phase 2 reader routes. Four URLs that let a human browse the writer's
+ * HTML output:
+ *
+ *   GET /                     daemon landing — spaces list
+ *   GET /:space               redirect to `/:space/` (relative-href hygiene)
+ *   GET /:space/              alphabetical article index
+ *   GET /:space/wiki/*        wiki article + chrome injection + link classes
+ *   GET /:space/*             static-file fallback (sources, PDFs, images, ...)
+ *
+ * URL structure mirrors disk structure — articles linked as
+ * `<a href="../sources/foo.md">` resolve to the same file under both
+ * `file://` and `http://`. No path rewriting anywhere.
+ *
+ * The static-file fallback must be mounted AFTER `space-scoped.ts` (which
+ * owns `/:space/entities`, `/:space/redlinks`, `/:space/recent`,
+ * `/:space/search`, and `/:space/chat`). Hono's trie router prefers
+ * static segments over parameterized ones, so registration order between
+ * the two routers does not matter — but conceptually the reader is the
+ * "everything else" layer.
+ */
+
+import { Hono } from "hono";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { extname } from "node:path";
+
+import type { AppBindings } from "../types.js";
+import { ApiError } from "../lib/errors.js";
+import { createSql } from "../lib/sql.js";
+import { safeResolve } from "../lib/file-edits.js";
+import {
+  instrumentArticle,
+  renderArticleIndex,
+  renderNotFound,
+  renderSpaceIndex,
+  type ArticleIndexRow,
+  type SpaceIndexRow,
+} from "../lib/reader.js";
+
+export const readerRouter = new Hono<AppBindings>();
+
+async function spaceWatchDir(spaceName: string): Promise<string | null> {
+  const sql = createSql();
+  const rows = await sql`SELECT watch_dir FROM spaces WHERE name = ${spaceName}`;
+  if (rows.length === 0) return null;
+  return rows[0].watch_dir as string;
+}
+
+async function knownPathsFor(spaceName: string): Promise<Set<string>> {
+  const sql = createSql();
+  const rows = await sql`
+    SELECT source_path FROM entities WHERE space_name = ${spaceName}
+  `;
+  const out = new Set<string>();
+  for (const row of rows) out.add(row.source_path as string);
+  return out;
+}
+
+// ── GET / — daemon landing ────────────────────────────────────────
+
+readerRouter.get("/", async (c) => {
+  const sql = createSql();
+  const rows = await sql`
+    SELECT s.name,
+           (SELECT COUNT(*) FROM entities e WHERE e.space_name = s.name) AS entity_count
+    FROM spaces s
+    ORDER BY s.name ASC
+  `;
+  const spaces: SpaceIndexRow[] = rows.map((r) => ({
+    name: r.name as string,
+    entity_count: Number(r.entity_count ?? 0),
+  }));
+  return c.html(renderSpaceIndex(spaces));
+});
+
+// ── GET /:space — redirect to /:space/ ────────────────────────────
+//
+// Relative hrefs in the article-index page resolve against the URL's
+// directory, so the trailing slash is load-bearing. Redirecting up
+// front keeps every link sane regardless of how the user typed the URL.
+
+readerRouter.get("/:space", async (c) => {
+  const space = c.req.param("space");
+  return c.redirect(`/${encodeURIComponent(space)}/`, 301);
+});
+
+// ── GET /:space/ — article index ──────────────────────────────────
+
+readerRouter.get("/:space/", async (c) => {
+  const space = c.req.param("space");
+  const watchDir = await spaceWatchDir(space);
+  if (!watchDir) {
+    throw new ApiError(404, "not_found", `Space '${space}' not found`);
+  }
+
+  const sql = createSql();
+  const rows = await sql`
+    SELECT source_path, label, properties
+    FROM entities
+    WHERE space_name = ${space} AND type = 'wiki'
+  `;
+  const articles: ArticleIndexRow[] = rows.map((r) => {
+    let shortDescription: string | null = null;
+    try {
+      const propsRaw = r.properties;
+      const props =
+        typeof propsRaw === "string" ? JSON.parse(propsRaw || "{}") : (propsRaw ?? {});
+      const v = (props as Record<string, unknown>).short_description;
+      if (typeof v === "string" && v.length > 0) shortDescription = v;
+    } catch {
+      // Ignore malformed properties — fall back to no description.
+    }
+    return {
+      source_path: r.source_path as string,
+      label: (r.label as string | null) ?? null,
+      short_description: shortDescription,
+    };
+  });
+
+  return c.html(renderArticleIndex(space, articles));
+});
+
+// ── GET /:space/wiki/* — wiki article view ────────────────────────
+
+readerRouter.get("/:space/wiki/*", async (c) => {
+  const space = c.req.param("space");
+  const watchDir = await spaceWatchDir(space);
+  if (!watchDir) {
+    throw new ApiError(404, "not_found", `Space '${space}' not found`);
+  }
+
+  const articlePath = extractSpacePath(c.req.url, space);
+  if (!articlePath || !articlePath.startsWith("wiki/")) {
+    throw new ApiError(400, "validation_error", "missing wiki path");
+  }
+
+  let abs: string;
+  try {
+    abs = safeResolve(watchDir, articlePath);
+  } catch {
+    return c.html(renderNotFound(space, articlePath), 404);
+  }
+  if (!existsSync(abs) || !statSync(abs).isFile()) {
+    return c.html(renderNotFound(space, articlePath), 404);
+  }
+
+  const original = readFileSync(abs, "utf-8");
+  const knownPaths = await knownPathsFor(space);
+  const instrumented = instrumentArticle(original, articlePath, knownPaths, space);
+  return c.html(instrumented);
+});
+
+// ── GET /:space/* — static file fallback ──────────────────────────
+
+readerRouter.get("/:space/*", async (c) => {
+  const space = c.req.param("space");
+  const watchDir = await spaceWatchDir(space);
+  if (!watchDir) {
+    throw new ApiError(404, "not_found", `Space '${space}' not found`);
+  }
+
+  const relPath = extractSpacePath(c.req.url, space);
+  if (!relPath) {
+    throw new ApiError(400, "validation_error", "missing file path");
+  }
+
+  let abs: string;
+  try {
+    abs = safeResolve(watchDir, relPath);
+  } catch {
+    return c.html(renderNotFound(space, relPath), 404);
+  }
+  if (!existsSync(abs) || !statSync(abs).isFile()) {
+    return c.html(renderNotFound(space, relPath), 404);
+  }
+
+  const body = readFileSync(abs);
+  const contentType = mimeTypeFor(abs);
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": contentType },
+  });
+});
+
+// ── helpers ───────────────────────────────────────────────────────
+
+/**
+ * Pull the in-space path out of a `/{space}/...` URL. Hono's
+ * `c.req.param("*")` returns the wildcard match, but the wiki route
+ * captures it as `wiki/foo.html` (no leading slash) while the catch-all
+ * captures everything after `/{space}/`. Going through the URL pathname
+ * directly avoids the discrepancy and decodes percent-escapes uniformly.
+ */
+function extractSpacePath(rawUrl: string, space: string): string | null {
+  const u = new URL(rawUrl);
+  const prefix = `/${space}/`;
+  const idx = u.pathname.indexOf(prefix);
+  if (idx < 0) return null;
+  const remainder = u.pathname.slice(idx + prefix.length);
+  if (!remainder) return null;
+  try {
+    return decodeURIComponent(remainder);
+  } catch {
+    return null;
+  }
+}
+
+const MIME_TYPES: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".htm": "text/html; charset=utf-8",
+  ".md": "text/markdown; charset=utf-8",
+  ".markdown": "text/markdown; charset=utf-8",
+  ".txt": "text/plain; charset=utf-8",
+  ".csv": "text/csv; charset=utf-8",
+  ".tsv": "text/tab-separated-values; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".jsonl": "application/x-ndjson; charset=utf-8",
+  ".xml": "application/xml; charset=utf-8",
+  ".yaml": "application/yaml; charset=utf-8",
+  ".yml": "application/yaml; charset=utf-8",
+  ".rst": "text/plain; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".pdf": "application/pdf",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+  ".mp3": "audio/mpeg",
+  ".mp4": "video/mp4",
+  ".webm": "video/webm",
+};
+
+function mimeTypeFor(path: string): string {
+  const ext = extname(path).toLowerCase();
+  return MIME_TYPES[ext] ?? "application/octet-stream";
+}

--- a/packages/arkeon/test/e2e/reader.test.ts
+++ b/packages/arkeon/test/e2e/reader.test.ts
@@ -1,0 +1,248 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * End-to-end tests for the Phase 2 reader routes:
+ *
+ *   GET /                     spaces list HTML
+ *   GET /:space               301 → /:space/
+ *   GET /:space/              article index HTML
+ *   GET /:space/wiki/*        instrumented wiki HTML
+ *   GET /:space/*             raw static-file passthrough
+ *
+ * Boots a real arkeon-wiki API, registers a space, waits for the
+ * watcher to sync a small corpus, then exercises each route.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { startApi, type ArkeonApi } from "../../src/server/server.js";
+import { runMigrations } from "../../src/schema/migrate.js";
+import { waitForEntity } from "./helpers.js";
+
+let api: ArkeonApi;
+let baseUrl: string;
+let workdir: string;
+let dbPath: string;
+
+const SPACE = "reader-demo";
+
+beforeAll(async () => {
+  workdir = mkdtempSync(join(tmpdir(), "arkeon-reader-"));
+  dbPath = join(workdir, "arke.db");
+
+  mkdirSync(join(workdir, "wiki/biology"), { recursive: true });
+  mkdirSync(join(workdir, "sources"), { recursive: true });
+  mkdirSync(join(workdir, "images"), { recursive: true });
+
+  writeFileSync(
+    join(workdir, "wiki/photosynthesis.html"),
+    `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Photosynthesis</title>
+<meta name="label" content="Photosynthesis">
+<meta name="short_description" content="How plants convert light into chemical energy.">
+</head>
+<body>
+<h1>Photosynthesis</h1>
+<p>Occurs inside <a href="biology/chlorophyll.html">chloroplasts</a> and references
+<a href="ghost-article.html">a missing article</a>.</p>
+<p>See <a href="../sources/shannon-1948.md">Shannon 1948</a> and
+<a href="../sources/missing.md">a missing source</a> and
+<a href="https://wikipedia.org">wikipedia</a>.</p>
+</body>
+</html>`,
+  );
+
+  writeFileSync(
+    join(workdir, "wiki/biology/chlorophyll.html"),
+    `<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>Chlorophyll</title>
+<meta name="label" content="Chlorophyll"></head>
+<body><h1>Chlorophyll</h1><p>Found in chloroplasts.</p></body>
+</html>`,
+  );
+
+  writeFileSync(
+    join(workdir, "sources/shannon-1948.md"),
+    `---
+year: 1948
+author: Shannon
+---
+
+A mathematical theory of communication.
+`,
+  );
+
+  writeFileSync(
+    join(workdir, "images/diagram.txt"),
+    "pretend this is a binary image",
+  );
+
+  await runMigrations({ dbPath });
+  api = await startApi({ port: 0, dbPath });
+  baseUrl = `http://localhost:${api.address.port}`;
+
+  const res = await fetch(`${baseUrl}/spaces`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: SPACE, watch_dir: workdir }),
+  });
+  expect(res.status).toBe(201);
+
+  await waitForEntity(SPACE, "wiki/photosynthesis.html");
+  await waitForEntity(SPACE, "wiki/biology/chlorophyll.html");
+  await waitForEntity(SPACE, "sources/shannon-1948.md");
+}, 30_000);
+
+afterAll(async () => {
+  await api?.stop({ drainTimeoutMs: 2000 });
+  if (workdir) rmSync(workdir, { recursive: true, force: true });
+});
+
+describe("Phase 2 reader", () => {
+  it("GET / returns an HTML list of spaces", async () => {
+    const res = await fetch(`${baseUrl}/`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/text\/html/);
+    const body = await res.text();
+    expect(body).toContain("<title>arkeon-wiki</title>");
+    expect(body).toContain(`<a href="/${SPACE}/">${SPACE}</a>`);
+  });
+
+  it("GET /:space (no trailing slash) 301-redirects to /:space/", async () => {
+    const res = await fetch(`${baseUrl}/${SPACE}`, { redirect: "manual" });
+    expect(res.status).toBe(301);
+    expect(res.headers.get("location")).toBe(`/${SPACE}/`);
+  });
+
+  it("GET /:space/ returns an alphabetical article index", async () => {
+    const res = await fetch(`${baseUrl}/${SPACE}/`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/text\/html/);
+    const body = await res.text();
+    expect(body).toContain(`<title>${SPACE} — arkeon-wiki</title>`);
+    expect(body).toContain(
+      `<a href="/${SPACE}/wiki/biology/chlorophyll.html">Chlorophyll</a>`,
+    );
+    expect(body).toContain(
+      `<a href="/${SPACE}/wiki/photosynthesis.html">Photosynthesis</a>`,
+    );
+    expect(body).toContain("How plants convert light into chemical energy.");
+
+    const choIdx = body.indexOf(">Chlorophyll<");
+    const phoIdx = body.indexOf(">Photosynthesis<");
+    expect(choIdx).toBeLessThan(phoIdx); // alphabetical
+  });
+
+  it("GET /:space/wiki/* returns the article with chrome and link classes", async () => {
+    const res = await fetch(`${baseUrl}/${SPACE}/wiki/photosynthesis.html`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/text\/html/);
+    const body = await res.text();
+
+    // Chrome injected
+    expect(body).toContain(`<div id="arkeon-chrome">`);
+    expect(body).toContain(`href="/${SPACE}/"`);
+    expect(body).toContain(`<style data-arkeon-chrome>`);
+
+    // Article body preserved
+    expect(body).toContain("<h1>Photosynthesis</h1>");
+
+    // Existing wiki link → arkeon-wiki only
+    expect(body).toContain(
+      `<a href="biology/chlorophyll.html" class="arkeon-wiki">`,
+    );
+    // Missing wiki → arkeon-wiki + arkeon-redlink
+    expect(body).toContain(
+      `<a href="ghost-article.html" class="arkeon-wiki arkeon-redlink">`,
+    );
+    // Existing source → arkeon-file
+    expect(body).toContain(
+      `<a href="../sources/shannon-1948.md" class="arkeon-file">`,
+    );
+    // Missing source → arkeon-file + arkeon-redlink
+    expect(body).toContain(
+      `<a href="../sources/missing.md" class="arkeon-file arkeon-redlink">`,
+    );
+    // External link untouched
+    expect(body).toContain(`<a href="https://wikipedia.org">wikipedia</a>`);
+  });
+
+  it("GET /:space/sources/*.md serves markdown raw with text/markdown content-type", async () => {
+    const res = await fetch(`${baseUrl}/${SPACE}/sources/shannon-1948.md`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/text\/markdown/);
+    const body = await res.text();
+    expect(body).toContain("A mathematical theory of communication.");
+    // No chrome injection for non-wiki paths.
+    expect(body).not.toContain("arkeon-chrome");
+  });
+
+  it("GET /:space/wiki/*.html for a missing path returns 404 HTML", async () => {
+    const res = await fetch(`${baseUrl}/${SPACE}/wiki/no-such-article.html`);
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type")).toMatch(/text\/html/);
+    const body = await res.text();
+    expect(body).toContain("not found");
+  });
+
+  it("GET /:space/wiki/* refuses path-traversal escapes", async () => {
+    // /etc/passwd via ../../.. — must not serve anything outside watch_dir.
+    const res = await fetch(
+      `${baseUrl}/${SPACE}/wiki/../../../../etc/passwd`,
+    );
+    // node-fetch / undici may normalize `..` before the request; either
+    // way we should never get a 200 with /etc/passwd content.
+    expect(res.status === 404 || res.status === 400).toBe(true);
+    if (res.status === 200) {
+      const body = await res.text();
+      expect(body).not.toContain("root:");
+    }
+  });
+
+  it("GET /:space/<missing> returns 404 (not a 500)", async () => {
+    const res = await fetch(`${baseUrl}/${SPACE}/sources/totally-missing.md`);
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type")).toMatch(/text\/html/);
+  });
+
+  it("GET /:space/ for an unknown space returns 404", async () => {
+    const res = await fetch(`${baseUrl}/no-such-space/`);
+    expect(res.status).toBe(404);
+  });
+
+  it("reader does not shadow the API routes", async () => {
+    // /:space/entities, /:space/redlinks etc. must still return JSON,
+    // not get gobbled by the static-file fallback.
+    const entities = await fetch(`${baseUrl}/${SPACE}/entities?type=wiki`);
+    expect(entities.status).toBe(200);
+    expect(entities.headers.get("content-type")).toMatch(/application\/json/);
+
+    const redlinks = await fetch(`${baseUrl}/${SPACE}/redlinks`);
+    expect(redlinks.status).toBe(200);
+    expect(redlinks.headers.get("content-type")).toMatch(/application\/json/);
+
+    const recent = await fetch(`${baseUrl}/${SPACE}/recent`);
+    expect(recent.status).toBe(200);
+
+    const search = await fetch(`${baseUrl}/${SPACE}/search?q=chloroplast`);
+    expect(search.status).toBe(200);
+  });
+
+  it("daemon-level routes still respond as JSON", async () => {
+    const health = await fetch(`${baseUrl}/health`);
+    expect(health.status).toBe(200);
+    expect(health.headers.get("content-type")).toMatch(/application\/json/);
+
+    const spaces = await fetch(`${baseUrl}/spaces`);
+    expect(spaces.status).toBe(200);
+    expect(spaces.headers.get("content-type")).toMatch(/application\/json/);
+  });
+});

--- a/packages/arkeon/test/e2e/reader.test.ts
+++ b/packages/arkeon/test/e2e/reader.test.ts
@@ -67,8 +67,9 @@ beforeAll(async () => {
 <h1>Photosynthesis</h1>
 <p>Occurs inside <a href="biology/chlorophyll.html">chloroplasts</a> and references
 <a href="ghost-article.html">a missing article</a>.</p>
-<p>See <a href="../sources/shannon-1948.md">Shannon 1948</a> and
-<a href="../sources/missing.md">a missing source</a> and
+<p>See <a href="../sources/shannon-1948.txt">Shannon 1948</a> and
+<a href="../sources/missing.txt">a missing source</a> and
+<a href="../sources/notes.md">scratch notes</a> and
 <a href="https://wikipedia.org">wikipedia</a>.</p>
 </body>
 </html>`,
@@ -84,15 +85,20 @@ beforeAll(async () => {
 </html>`,
   );
 
+  // Indexed source (`.txt` is in INDEX_EXTENSIONS) — produces an entity row.
   writeFileSync(
-    join(workdir, "sources/shannon-1948.md"),
-    `---
-year: 1948
-author: Shannon
----
+    join(workdir, "sources/shannon-1948.txt"),
+    `A mathematical theory of communication.\n`,
+  );
 
-A mathematical theory of communication.
-`,
+  // Deliberately NOT indexed (markdown was removed in #126). Still exists on
+  // disk and gets served raw by the static-file fallback with the MIME table's
+  // `text/markdown` content type — exercises the passthrough path for any
+  // non-indexed file type. From the wiki's perspective it's a red link
+  // because no entity row exists.
+  writeFileSync(
+    join(workdir, "sources/notes.md"),
+    `# Scratch notes\n\nNot indexed, served raw.\n`,
   );
 
   writeFileSync(
@@ -113,7 +119,7 @@ A mathematical theory of communication.
 
   await waitForEntity(SPACE, "wiki/photosynthesis.html");
   await waitForEntity(SPACE, "wiki/biology/chlorophyll.html");
-  await waitForEntity(SPACE, "sources/shannon-1948.md");
+  await waitForEntity(SPACE, "sources/shannon-1948.txt");
 }, 30_000);
 
 afterAll(async () => {
@@ -178,25 +184,44 @@ describe("Phase 2 reader", () => {
     expect(body).toContain(
       `<a href="ghost-article.html" class="arkeon-wiki arkeon-redlink">`,
     );
-    // Existing source → arkeon-file
+    // Existing indexed source → arkeon-file (no redlink)
     expect(body).toContain(
-      `<a href="../sources/shannon-1948.md" class="arkeon-file">`,
+      `<a href="../sources/shannon-1948.txt" class="arkeon-file">`,
     );
     // Missing source → arkeon-file + arkeon-redlink
     expect(body).toContain(
-      `<a href="../sources/missing.md" class="arkeon-file arkeon-redlink">`,
+      `<a href="../sources/missing.txt" class="arkeon-file arkeon-redlink">`,
+    );
+    // Non-indexed file type (markdown isn't in INDEX_EXTENSIONS) — the file
+    // exists on disk but there's no entity row, so the reader classifies it
+    // as a red link. The static-file route below verifies the bytes still
+    // come through.
+    expect(body).toContain(
+      `<a href="../sources/notes.md" class="arkeon-file arkeon-redlink">`,
     );
     // External link untouched
     expect(body).toContain(`<a href="https://wikipedia.org">wikipedia</a>`);
   });
 
-  it("GET /:space/sources/*.md serves markdown raw with text/markdown content-type", async () => {
-    const res = await fetch(`${baseUrl}/${SPACE}/sources/shannon-1948.md`);
+  it("GET /:space/sources/*.txt serves indexed plain text raw with text/plain content-type", async () => {
+    const res = await fetch(`${baseUrl}/${SPACE}/sources/shannon-1948.txt`);
     expect(res.status).toBe(200);
-    expect(res.headers.get("content-type")).toMatch(/text\/markdown/);
+    expect(res.headers.get("content-type")).toMatch(/text\/plain/);
     const body = await res.text();
     expect(body).toContain("A mathematical theory of communication.");
     // No chrome injection for non-wiki paths.
+    expect(body).not.toContain("arkeon-chrome");
+  });
+
+  it("GET /:space/sources/*.md serves non-indexed markdown raw via MIME table passthrough", async () => {
+    // Markdown isn't indexed but the static-file fallback still serves it
+    // with text/markdown so browsers display it natively. Same principle
+    // covers PDFs, images, JSON, etc. — the MIME table is the contract.
+    const res = await fetch(`${baseUrl}/${SPACE}/sources/notes.md`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/text\/markdown/);
+    const body = await res.text();
+    expect(body).toContain("Scratch notes");
     expect(body).not.toContain("arkeon-chrome");
   });
 

--- a/packages/arkeon/test/e2e/reader.test.ts
+++ b/packages/arkeon/test/e2e/reader.test.ts
@@ -37,6 +37,21 @@ beforeAll(async () => {
   mkdirSync(join(workdir, "wiki/biology"), { recursive: true });
   mkdirSync(join(workdir, "sources"), { recursive: true });
   mkdirSync(join(workdir, "images"), { recursive: true });
+  // Hidden / ignored directories the reader must refuse to serve, even
+  // though they physically exist inside the watch dir.
+  mkdirSync(join(workdir, ".arkeon"), { recursive: true });
+  mkdirSync(join(workdir, ".git"), { recursive: true });
+  mkdirSync(join(workdir, "node_modules/secret-pkg"), { recursive: true });
+  writeFileSync(
+    join(workdir, ".arkeon/state.json"),
+    `{"api_url":"http://localhost:0","space_name":"reader-demo"}`,
+  );
+  writeFileSync(join(workdir, ".git/config"), "[core]\n  repo = secret\n");
+  writeFileSync(join(workdir, ".env"), "OPENAI_API_KEY=sk-fake-secret\n");
+  writeFileSync(
+    join(workdir, "node_modules/secret-pkg/leak.txt"),
+    "dependency internal\n",
+  );
 
   writeFileSync(
     join(workdir, "wiki/photosynthesis.html"),
@@ -215,6 +230,34 @@ describe("Phase 2 reader", () => {
 
   it("GET /:space/ for an unknown space returns 404", async () => {
     const res = await fetch(`${baseUrl}/no-such-space/`);
+    expect(res.status).toBe(404);
+  });
+
+  it("refuses to serve hidden / ignored directories (.arkeon, .git, node_modules, dotfiles)", async () => {
+    const hiddenPaths = [
+      ".arkeon/state.json",
+      ".git/config",
+      ".env",
+      "node_modules/secret-pkg/leak.txt",
+    ];
+    for (const path of hiddenPaths) {
+      const res = await fetch(`${baseUrl}/${SPACE}/${path}`);
+      expect(res.status, `expected 404 for ${path}`).toBe(404);
+      const body = await res.text();
+      // Make sure nothing from the actual file leaked into the body —
+      // the renderNotFound page echoes the requested path but not the
+      // file contents.
+      expect(body).not.toContain("sk-fake-secret");
+      expect(body).not.toContain("repo = secret");
+      expect(body).not.toContain("dependency internal");
+      expect(body).not.toContain('"api_url"');
+    }
+  });
+
+  it("refuses hidden paths under the wiki/ prefix too", async () => {
+    // No actual file needed — the filter rejects the request before
+    // touching the filesystem.
+    const res = await fetch(`${baseUrl}/${SPACE}/wiki/.hidden.html`);
     expect(res.status).toBe(404);
   });
 

--- a/packages/arkeon/test/unit/reader.test.ts
+++ b/packages/arkeon/test/unit/reader.test.ts
@@ -1,0 +1,230 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pure-function tests for the Phase 2 reader primitives. No server, no
+ * DB — every test passes its own `knownPaths` Set to mimic the entity
+ * lookup the route would do.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  classifyAnchor,
+  instrumentArticle,
+  renderArticleIndex,
+  renderSpaceIndex,
+} from "../../src/server/lib/reader.js";
+
+describe("classifyAnchor", () => {
+  const known = new Set(["wiki/chloroplast.html", "sources/shannon-1948.md"]);
+  const from = "wiki/photosynthesis.html";
+
+  it("tags an existing .html target as arkeon-wiki", () => {
+    expect(classifyAnchor("chloroplast.html", from, known)).toEqual(["arkeon-wiki"]);
+  });
+
+  it("tags an existing non-html target as arkeon-file", () => {
+    expect(classifyAnchor("../sources/shannon-1948.md", from, known)).toEqual([
+      "arkeon-file",
+    ]);
+  });
+
+  it("tags a missing .html target as arkeon-wiki + arkeon-redlink", () => {
+    expect(classifyAnchor("ghost.html", from, known)).toEqual([
+      "arkeon-wiki",
+      "arkeon-redlink",
+    ]);
+  });
+
+  it("tags a missing source target as arkeon-file + arkeon-redlink", () => {
+    expect(classifyAnchor("../sources/missing.md", from, known)).toEqual([
+      "arkeon-file",
+      "arkeon-redlink",
+    ]);
+  });
+
+  it("drops external links", () => {
+    expect(classifyAnchor("https://example.com", from, known)).toEqual([]);
+    expect(classifyAnchor("mailto:x@y", from, known)).toEqual([]);
+    expect(classifyAnchor("tel:555", from, known)).toEqual([]);
+  });
+
+  it("drops fragments and protocol-relative URLs", () => {
+    expect(classifyAnchor("#section", from, known)).toEqual([]);
+    expect(classifyAnchor("//example.com/x", from, known)).toEqual([]);
+  });
+
+  it("drops server-absolute paths (reserved for cross-space in v0.5)", () => {
+    expect(classifyAnchor("/other-space/wiki/x.html", from, known)).toEqual([]);
+  });
+
+  it("drops paths that escape the space root", () => {
+    expect(classifyAnchor("../../etc/passwd", from, known)).toEqual([]);
+  });
+
+  it("is case-insensitive on the .html extension check", () => {
+    expect(classifyAnchor("photo.HTML", from, known)).toEqual([
+      "arkeon-wiki",
+      "arkeon-redlink",
+    ]);
+  });
+});
+
+describe("instrumentArticle", () => {
+  const known = new Set(["wiki/chloroplast.html", "sources/shannon-1948.md"]);
+  const articlePath = "wiki/photosynthesis.html";
+
+  const html = `<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>Photosynthesis</title></head>
+<body>
+<h1>Photosynthesis</h1>
+<p><a href="chloroplast.html">chloro</a></p>
+<p><a href="ghost.html">ghost</a></p>
+<p><a href="../sources/shannon-1948.md">shannon</a></p>
+<p><a href="https://wikipedia.org">wikipedia</a></p>
+</body>
+</html>`;
+
+  it("tags links with the right classes", () => {
+    const out = instrumentArticle(html, articlePath, known, "demo");
+    expect(out).toContain(`<a href="chloroplast.html" class="arkeon-wiki">`);
+    expect(out).toContain(
+      `<a href="ghost.html" class="arkeon-wiki arkeon-redlink">`,
+    );
+    expect(out).toContain(
+      `<a href="../sources/shannon-1948.md" class="arkeon-file">`,
+    );
+    // External link: no class added.
+    expect(out).toContain(`<a href="https://wikipedia.org">wikipedia</a>`);
+  });
+
+  it("injects the chrome div under <body>", () => {
+    const out = instrumentArticle(html, articlePath, known, "demo");
+    expect(out).toContain(`<div id="arkeon-chrome">`);
+    expect(out).toContain(`href="/demo/"`);
+    // Chrome must appear before the article content.
+    const chromeIdx = out.indexOf("arkeon-chrome");
+    const h1Idx = out.indexOf("<h1>");
+    expect(chromeIdx).toBeGreaterThan(0);
+    expect(chromeIdx).toBeLessThan(h1Idx);
+  });
+
+  it("injects the chrome style block in <head>", () => {
+    const out = instrumentArticle(html, articlePath, known, "demo");
+    expect(out).toContain(`<style data-arkeon-chrome>`);
+    expect(out).toContain(`#arkeon-chrome`);
+    // All three link classes get a visual treatment that distinguishes
+    // them from each other and from external links:
+    //   wiki   → browser default (blue, solid underline)
+    //   file   → muted slate + dotted underline ("reference" feel)
+    //   redlink → red (overrides color of either of the above)
+    expect(out).toContain(`a.arkeon-file`);
+    expect(out).toContain(`text-decoration: underline dotted`);
+    expect(out).toContain(`a.arkeon-redlink`);
+  });
+
+  it("preserves existing class attributes on anchors", () => {
+    const withExisting = `<!doctype html><html><head><title>x</title></head>
+<body><a class="important" href="chloroplast.html">c</a></body></html>`;
+    const out = instrumentArticle(withExisting, articlePath, known, "demo");
+    expect(out).toContain(`class="important arkeon-wiki"`);
+  });
+
+  it("does not double-inject chrome if re-run", () => {
+    const once = instrumentArticle(html, articlePath, known, "demo");
+    const twice = instrumentArticle(once, articlePath, known, "demo");
+    expect(twice.match(/id="arkeon-chrome"/g)?.length).toBe(1);
+    expect(twice.match(/data-arkeon-chrome/g)?.length).toBe(1);
+  });
+
+  it("escapes HTML in the space name shown in the chrome", () => {
+    const out = instrumentArticle(html, articlePath, known, "<bad>");
+    expect(out).toContain("&lt;bad&gt;");
+    expect(out).not.toContain("<bad>");
+  });
+});
+
+describe("renderSpaceIndex", () => {
+  it("renders a list of spaces with their entity counts", () => {
+    const out = renderSpaceIndex([
+      { name: "augustine", entity_count: 42 },
+      { name: "notes", entity_count: 1 },
+    ]);
+    expect(out).toContain("<title>arkeon-wiki</title>");
+    expect(out).toContain(`<a href="/augustine/">augustine</a>`);
+    expect(out).toContain("42 entities");
+    expect(out).toContain(`<a href="/notes/">notes</a>`);
+    expect(out).toContain("1 entity");
+  });
+
+  it("renders an empty-state hint when no spaces are registered", () => {
+    const out = renderSpaceIndex([]);
+    expect(out).toContain("no spaces registered yet");
+    expect(out).toContain("arkeon-wiki init");
+  });
+
+  it("escapes space names safely", () => {
+    const out = renderSpaceIndex([{ name: "<x>", entity_count: 0 }]);
+    expect(out).toContain("&lt;x&gt;");
+    expect(out).toContain("/%3Cx%3E/");
+  });
+});
+
+describe("renderArticleIndex", () => {
+  it("sorts alphabetically by label (case-insensitive)", () => {
+    const out = renderArticleIndex("demo", [
+      { source_path: "wiki/zebra.html", label: "Zebra", short_description: null },
+      { source_path: "wiki/apple.html", label: "apple", short_description: null },
+      { source_path: "wiki/banana.html", label: "Banana", short_description: null },
+    ]);
+    const appleIdx = out.indexOf("apple");
+    const bananaIdx = out.indexOf("Banana");
+    const zebraIdx = out.indexOf("Zebra");
+    expect(appleIdx).toBeLessThan(bananaIdx);
+    expect(bananaIdx).toBeLessThan(zebraIdx);
+  });
+
+  it("links to /:space/<source_path>", () => {
+    const out = renderArticleIndex("demo", [
+      {
+        source_path: "wiki/biology/chlorophyll.html",
+        label: "Chlorophyll",
+        short_description: null,
+      },
+    ]);
+    expect(out).toContain(`href="/demo/wiki/biology/chlorophyll.html"`);
+  });
+
+  it("renders short_description as a subtitle when present", () => {
+    const out = renderArticleIndex("demo", [
+      {
+        source_path: "wiki/x.html",
+        label: "X",
+        short_description: "The letter X.",
+      },
+    ]);
+    expect(out).toContain(`<p class="desc">The letter X.</p>`);
+  });
+
+  it("falls back to filename when label is missing", () => {
+    const out = renderArticleIndex("demo", [
+      { source_path: "wiki/orphan.html", label: null, short_description: null },
+    ]);
+    expect(out).toContain(">orphan.html</a>");
+  });
+
+  it("escapes labels and descriptions for XSS safety", () => {
+    const out = renderArticleIndex("demo", [
+      {
+        source_path: "wiki/x.html",
+        label: "<script>alert(1)</script>",
+        short_description: '"; drop',
+      },
+    ]);
+    expect(out).not.toContain("<script>alert(1)</script>");
+    expect(out).toContain("&lt;script&gt;");
+    expect(out).toContain("&quot;");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds the four human-facing routes that make Phase 1's HTML wikis browsable. URL structure mirrors disk structure within a space — `wiki/foo.html` on disk → `/{space}/wiki/foo.html` over HTTP — so the same article opens identically via `file://` and `http://`. The server never rewrites hrefs, only decorates them.
- New `lib/reader.ts` holds the pure rendering primitives (`classifyAnchor`, `instrumentArticle`, `renderSpaceIndex`, `renderArticleIndex`); new `routes/reader.ts` is thin glue over them, mounted last so `/:space/*` is a true fallback.
- Link classes tagged at render time against the space's entities Set: `arkeon-wiki`, `arkeon-file`, `arkeon-redlink` (combinable). Wiki links get the browser default; source/file links get a muted slate with a dotted underline (typographic "citation" feel); redlinks are red.

## Routes

| Method | Path | Returns |
|---|---|---|
| `GET` | `/` | HTML — list of registered spaces with entity counts |
| `GET` | `/:space` | 301 redirect to `/:space/` |
| `GET` | `/:space/` | HTML — alphabetical article index (`type='wiki'`) |
| `GET` | `/:space/wiki/*` | Article HTML with chrome strip + link classes |
| `GET` | `/:space/*` | Static-file passthrough with right `Content-Type` |

The JSON `GET /` (`{name, status}`) is replaced by the HTML spaces list. CLI/clients use `/health` for liveness; no callers depended on the old root response.

## Deliberately cut from this PR (per `tasks/phase-2-todo.md`)

Human-facing UI for `/{space}/search`, `/{space}/recent`, `/{space}/redlinks`, per-article history, chat button, red-link 404 stubs, sorting toggles, mobile-responsive chrome, source-rendering. Cross-space link classification is also still v0.5 work — `/{other-space}/wiki/...` URLs route and serve fine, but the link extractor doesn't index them as relationship edges yet, so they render as plain (uncolored) links and don't show up in `/{space}/redlinks`.

## Test plan

- [x] `npm run typecheck -w packages/arkeon` — clean
- [x] `npm test -w packages/arkeon` — 161/161 (23 new in `reader.test.ts`)
- [x] `npm run test:e2e -w packages/arkeon` — 33/33 (11 new in `reader.test.ts`)
- [x] Manual smoke against a synthetic 8-article + 2-source corpus: spaces list, article index, instrumented article with all three link classes + their `arkeon-redlink` combinations, raw markdown served as `text/markdown`, missing-path 404s, path-traversal guard, API routes (`/entities`, `/redlinks`, `/recent`, `/search`) still return JSON, `/health` + `/spaces` unchanged.
- [ ] Manual `file://` parity check — open an article straight off disk and verify relative hrefs still work. Implementation never rewrites hrefs, so this should be automatic; nice-to-verify before tagging a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)