### PR TITLE
Make agent tool filters .nullable().optional() to defeat strict-mode default fills

### DIFF
--- a/packages/arkeon/src/server/agents/tools.ts
+++ b/packages/arkeon/src/server/agents/tools.ts
@@ -49,9 +49,9 @@ import type { Space } from "../lib/sync.js";
  */
 function resolveToolScope(
   ctx: AgentContext,
-  spaceArg: string | undefined,
+  spaceArg: string | null | undefined,
 ): Space[] {
-  if (spaceArg !== undefined && spaceArg !== "") {
+  if (spaceArg != null && spaceArg !== "") {
     if (ctx.allowedSpaces.length <= 1) return [ctx.space];
     return [resolveSpaceArg(spaceArg, ctx.allowedSpaces)];
   }
@@ -88,13 +88,13 @@ const readFileTool = defineTool("read_file", {
     "You MUST read a file before editing it; edit_file refuses unread paths.",
   inputSchema: z.object({
     path: z.string().describe("Relative path inside the space's watch_dir."),
-    space: z.string().optional().describe(SPACE_PARAM_DESC),
+    space: z.string().nullable().optional().describe(SPACE_PARAM_DESC),
   }),
   call: ({ path, space }, ctx) => {
     let target: Space;
     if (ctx.allowedSpaces.length <= 1) {
       target = ctx.space;
-    } else if (space !== undefined && space !== "") {
+    } else if (space != null && space !== "") {
       target = resolveSpaceArg(space, ctx.allowedSpaces);
     } else {
       throw new Error(
@@ -145,17 +145,33 @@ const searchTool = defineTool("search", {
       ),
     type: z
       .string()
+      .nullable()
       .optional()
-      .describe("Comma-separated: 'wiki', 'file'. Omit for all types."),
-    regex: z.boolean().optional().describe("Treat query as a regex."),
-    limit: z.number().int().positive().optional().describe("Max hits. Default 20."),
+      .describe(
+        "Comma-separated: 'wiki', 'file'. Pass null (or omit) for all types.",
+      ),
+    regex: z
+      .boolean()
+      .nullable()
+      .optional()
+      .describe("Treat query as a regex. Pass null (or omit) for substring."),
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .nullable()
+      .optional()
+      .describe("Max hits. Pass null (or omit) for the default of 20."),
     max_snippets_per_file: z
       .number()
       .int()
       .min(0)
+      .nullable()
       .optional()
-      .describe("Max line snippets per hit (default 3)."),
-    space: z.string().optional().describe(SPACE_PARAM_DESC),
+      .describe(
+        "Max line snippets per hit. Pass null (or omit) for the default of 3.",
+      ),
+    space: z.string().nullable().optional().describe(SPACE_PARAM_DESC),
   }),
   call: async (
     { query, type, regex, limit, max_snippets_per_file, space },
@@ -216,46 +232,98 @@ const listEntitiesTool = defineTool("list_entities", {
   inputSchema: z.object({
     type: z
       .string()
+      .nullable()
       .optional()
-      .describe("Comma-separated entity types: 'wiki' or 'file'. Omit for both."),
+      .describe(
+        "Comma-separated entity types: 'wiki' or 'file'. Pass null (or omit) for both.",
+      ),
     label_contains: z
       .string()
+      .nullable()
       .optional()
       .describe(
         "Case-insensitive substring match on the entity's label. Useful " +
-          "for checking whether a subject already exists under some variant.",
+          "for checking whether a subject already exists under some variant. " +
+          "Pass null (or omit) to skip the filter.",
       ),
     path_contains: z
       .string()
+      .nullable()
       .optional()
       .describe(
         "Case-insensitive substring match on `source_path`. Useful for " +
-          "filtering to a subdirectory (e.g. 'biology' to narrow articles).",
+          "filtering to a subdirectory (e.g. 'biology' to narrow articles). " +
+          "Pass null (or omit) to skip the filter.",
       ),
-    inbound_min: z.number().int().min(0).optional(),
+    inbound_min: z
+      .number()
+      .int()
+      .min(0)
+      .nullable()
+      .optional()
+      .describe("Pass null (or omit) to skip the filter."),
     inbound_max: z
       .number()
       .int()
       .min(0)
+      .nullable()
       .optional()
       .describe(
-        "Combine with type='file' inbound_max=0 to find sources nothing has cited yet.",
+        "Combine with type='file' inbound_max=0 to find sources nothing has cited yet. " +
+          "Pass null (or omit) for no upper bound.",
       ),
-    outbound_min: z.number().int().min(0).optional(),
-    outbound_max: z.number().int().min(0).optional(),
-    updated_since: z.string().optional().describe("ISO timestamp."),
+    outbound_min: z
+      .number()
+      .int()
+      .min(0)
+      .nullable()
+      .optional()
+      .describe("Pass null (or omit) to skip the filter."),
+    outbound_max: z
+      .number()
+      .int()
+      .min(0)
+      .nullable()
+      .optional()
+      .describe("Pass null (or omit) for no upper bound."),
+    updated_since: z
+      .string()
+      .nullable()
+      .optional()
+      .describe("ISO timestamp. Pass null (or omit) to skip the filter."),
     edited_by_role: z
       .string()
+      .nullable()
       .optional()
-      .describe("Filter on the most recent edit's by_role ('writer', 'human', etc.)."),
+      .describe(
+        "Filter on the most recent edit's by_role ('writer', 'human', etc.). " +
+          "Pass null (or omit) to skip the filter.",
+      ),
     sort: z
       .enum(["updated_at", "label", "inbound", "outbound"])
+      .nullable()
       .optional()
-      .describe("Default 'updated_at' (newest first)."),
-    include_counts: z.boolean().optional(),
-    limit: z.number().int().positive().optional().describe("Default 100, max 10000."),
-    offset: z.number().int().min(0).optional(),
-    space: z.string().optional().describe(SPACE_PARAM_DESC),
+      .describe("Default 'updated_at' (newest first). Pass null (or omit) for default."),
+    include_counts: z
+      .boolean()
+      .nullable()
+      .optional()
+      .describe("Pass null (or omit) to skip counts."),
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .nullable()
+      .optional()
+      .describe("Default 100, max 10000. Pass null (or omit) for default."),
+    offset: z
+      .number()
+      .int()
+      .min(0)
+      .nullable()
+      .optional()
+      .describe("Pass null (or omit) for 0."),
+    space: z.string().nullable().optional().describe(SPACE_PARAM_DESC),
   }),
   call: async (input, ctx) => {
     let types: EntityType[] | undefined;
@@ -314,9 +382,21 @@ const listRedLinksTool = defineTool("list_redlinks", {
     "articles want this concept defined. `linked_from` shows the last 3 " +
     "source articles that pointed at the missing target.",
   inputSchema: z.object({
-    limit: z.number().int().positive().optional().describe("Default 100."),
-    offset: z.number().int().min(0).optional(),
-    space: z.string().optional().describe(SPACE_PARAM_DESC),
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .nullable()
+      .optional()
+      .describe("Default 100. Pass null (or omit) for default."),
+    offset: z
+      .number()
+      .int()
+      .min(0)
+      .nullable()
+      .optional()
+      .describe("Pass null (or omit) for 0."),
+    space: z.string().nullable().optional().describe(SPACE_PARAM_DESC),
   }),
   call: async ({ limit, offset, space }, ctx) => {
     const targets = resolveToolScope(ctx, space);
@@ -359,26 +439,37 @@ const editFileTool = defineTool("edit_file", {
       .number()
       .int()
       .positive()
+      .nullable()
       .optional()
-      .describe("REQUIRED when mode='insert_at_line'. 1-indexed."),
+      .describe(
+        "REQUIRED when mode='insert_at_line'. 1-indexed. Pass null (or omit) for str_replace mode.",
+      ),
     content: z
       .string()
+      .nullable()
       .optional()
       .describe(
         "REQUIRED when mode='insert_at_line'. One or more lines to insert " +
-          "BEFORE `line_number`. Use \\n for line breaks.",
+          "BEFORE `line_number`. Use \\n for line breaks. " +
+          "Pass null (or omit) for str_replace mode.",
       ),
     old_string: z
       .string()
+      .nullable()
       .optional()
       .describe(
         "REQUIRED when mode='str_replace'. The exact span to substitute. " +
-          "Must match exactly once. Do NOT include line-number prefixes from read_file output.",
+          "Must match exactly once. Do NOT include line-number prefixes from read_file output. " +
+          "Pass null (or omit) for insert_at_line mode.",
       ),
     new_string: z
       .string()
+      .nullable()
       .optional()
-      .describe("REQUIRED when mode='str_replace'. The substitute content."),
+      .describe(
+        "REQUIRED when mode='str_replace'. The substitute content. " +
+          "Pass null (or omit) for insert_at_line mode.",
+      ),
   }),
   call: async (input, ctx) => {
     const key = readGateKey(ctx.space.name, input.path);

--- a/packages/arkeon/src/server/lib/entities.ts
+++ b/packages/arkeon/src/server/lib/entities.ts
@@ -23,27 +23,31 @@ import { createSql } from "./sql.js";
 export type EntityType = "wiki" | "file";
 export type EntitySort = "updated_at" | "label" | "inbound" | "outbound";
 
+// All optional filters accept `null` as well as `undefined` — the AI SDK /
+// OpenAI strict-mode pipeline materialises every schema field in the
+// model's tool call, and `.nullable().optional()` zod fields surface as
+// `null` for "absent". Internal checks use `!= null` to treat both alike.
 export interface ListEntitiesOptions {
   /** Restrict to a single space by name. */
-  space_name?: string;
+  space_name?: string | null;
   /** Restrict to one or more entity types. */
-  types?: EntityType[];
+  types?: EntityType[] | null;
   /** Case-insensitive substring match on `label`. */
-  label_contains?: string;
+  label_contains?: string | null;
   /** Case-insensitive substring match on `source_path`. */
-  path_contains?: string;
-  inbound_min?: number;
-  inbound_max?: number;
-  outbound_min?: number;
-  outbound_max?: number;
+  path_contains?: string | null;
+  inbound_min?: number | null;
+  inbound_max?: number | null;
+  outbound_min?: number | null;
+  outbound_max?: number | null;
   /** ISO timestamp; only entities with `updated_at >= this`. */
-  updated_since?: string;
+  updated_since?: string | null;
   /** Filter on the entity's most recent edit's `by_role`. */
-  edited_by_role?: string;
-  sort?: string;
-  include_counts?: boolean;
-  limit?: number;
-  offset?: number;
+  edited_by_role?: string | null;
+  sort?: string | null;
+  include_counts?: boolean | null;
+  limit?: number | null;
+  offset?: number | null;
 }
 
 export interface EntityCounts {
@@ -142,19 +146,19 @@ export async function listEntities(
   const outerConditions: string[] = [];
   const outerParams: unknown[] = [];
 
-  if (opts.inbound_min !== undefined) {
+  if (opts.inbound_min != null) {
     outerConditions.push("inbound >= ?");
     outerParams.push(opts.inbound_min);
   }
-  if (opts.inbound_max !== undefined) {
+  if (opts.inbound_max != null) {
     outerConditions.push("inbound <= ?");
     outerParams.push(opts.inbound_max);
   }
-  if (opts.outbound_min !== undefined) {
+  if (opts.outbound_min != null) {
     outerConditions.push("outbound >= ?");
     outerParams.push(opts.outbound_min);
   }
-  if (opts.outbound_max !== undefined) {
+  if (opts.outbound_max != null) {
     outerConditions.push("outbound <= ?");
     outerParams.push(opts.outbound_max);
   }
@@ -243,8 +247,8 @@ export async function listEntities(
 export interface ListRedLinksOptions {
   space_name: string;
   /** Default 100. */
-  limit?: number;
-  offset?: number;
+  limit?: number | null;
+  offset?: number | null;
 }
 
 export interface RedLinkRow {
@@ -350,7 +354,7 @@ export async function listRedLinks(
  * Parse a comma-separated list of entity types, validating each one.
  * Used by route handlers to coerce `?type=wiki,file` into the typed array.
  */
-export function parseEntityTypes(raw: string | undefined): EntityType[] | undefined {
+export function parseEntityTypes(raw: string | null | undefined): EntityType[] | undefined {
   if (!raw) return undefined;
   const out: EntityType[] = [];
   for (const part of raw.split(",")) {

--- a/packages/arkeon/src/server/lib/search.ts
+++ b/packages/arkeon/src/server/lib/search.ts
@@ -26,21 +26,25 @@ const DEFAULT_SNIPPETS_PER_FILE = 3;
  *  search; the tool layer enforces the same limit at the Zod schema. */
 export const MAX_QUERY_PATTERNS = 10;
 
+// Optional filters accept `null` as well as `undefined` — the AI SDK /
+// OpenAI strict-mode pipeline materialises every schema field in tool
+// calls, and `.nullable().optional()` zod fields surface as `null` for
+// "absent". Internals use `??` / `!!` / `length > 0` which treat both alike.
 export interface KeywordSearchOptions {
   /** Single substring/regex pattern, or up to MAX_QUERY_PATTERNS
    *  patterns run together as one ripgrep invocation (`-e p1 -e p2`).
    *  Match counts aggregate per file. */
   query: string | string[];
   /** Single-space convenience filter (equivalent to spaceNames: [spaceName]). */
-  spaceName?: string;
+  spaceName?: string | null;
   /** Restrict the search to a specific set of registered spaces by name.
-   *  Empty/undefined = every registered space. */
-  spaceNames?: string[];
+   *  Empty/undefined/null = every registered space. */
+  spaceNames?: string[] | null;
   /** Restrict hits to entities of the given type(s). */
-  types?: EntityType[];
-  limit?: number;
-  maxSnippetsPerFile?: number;
-  regex?: boolean;
+  types?: EntityType[] | null;
+  limit?: number | null;
+  maxSnippetsPerFile?: number | null;
+  regex?: boolean | null;
 }
 
 export interface SearchSnippet {


### PR DESCRIPTION
## Summary

- Every `.optional()` filter on the AI-SDK tool schemas (`list_entities`, `list_redlinks`, `search`, `read_file`'s `space`, `edit_file`'s mode-conditional fields) becomes `.nullable().optional()`.
- `entities.ts` / `search.ts` option types accept `T | null`. The four count-filter checks switch from `!== undefined` to `!= null`. `parseEntityTypes` accepts null.
- HTTP routes are untouched — `c.req.query()` naturally returns `undefined`, and falsy / `??` paths already absorb both.

## Why

OpenAI's strict-output JSON Schema mode (which the AI SDK turns on by default for `@ai-sdk/openai`) requires every property in the schema to be present in the model's tool call. Plain `.optional()` fields get serialised to type defaults — numbers as `0`, strings as `""`, booleans as `false`. The model can't truly omit; that's a serialization-layer decision, not a model decision, so `.describe("OMIT entirely")` has zero effect.

Bigger models pattern-match their way to sentinels (gpt-5.4-mini was caught passing `inbound_max: 9007199254740991` to mean "no upper bound"); mini variants don't, and silently apply garbage filters like `inbound_max: 0` when the user just wanted "everything." `.nullable().optional()` renders fields as `{ "type": [..., "null"] }` in JSON Schema, letting the model express absence via `null`.

## Verification

- `npm run typecheck -w packages/arkeon` — clean.
- `npm test -w packages/arkeon` — 127/127 passing.
- gpt-5-mini probe with `reasoning_effort: low`:
  - "list every entity, no filtering" → `{type: null, inbound_min: null, inbound_max: null, ...all fields null}`. Pre-fix would have shown `inbound_max: 0`, `label_contains: ""`, etc.
  - "find unprocessed sources" → `{type: "file", inbound_max: 0, ...rest null}`. Here `0` is the actual semantic filter requested, not a default-fill.

## Test plan

- [x] Typecheck clean
- [x] Unit tests pass
- [x] gpt-5-mini probe confirms `null`-for-absent behaviour end-to-end
- [ ] Real cataloger/editor agent (writer role) flow on a seeded corpus

🤖 Generated with [Claude Code](https://claude.com/claude-code)