### PR TITLE
Agent-applied tags on entities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ The writer's tool surface, validated by a 75-trial bake-off (see `tasks/v0-agent
 - `edit_file mode='str_replace' {path, old_string, new_string}` — exact-match SEARCH/REPLACE. `old_string` must match exactly once.
 - `create_file(path, html)` — new wiki from a complete HTML document. Path must start with `wiki/` and end in `.html`. `html` must begin with `<!DOCTYPE>` or `<html>` and contain a non-empty `<title>` plus a `<body>`. The agent authors the whole document, envelope and all — symmetric with how a human writes a wiki. Recommended (not enforced): `<meta name="label">` and `<meta name="short_description">`. Any other `<meta name="...">` tags land in `entities.properties`. Each validation failure returns the canonical template inline so the model can retry in one shot.
 - `delete_wiki(path, reason)` — guarded full-file deletion (only `wiki/**`, required reason). Not in the writer's whitelist; available for operator scripts or future curator roles.
+- `tag_entity(path, key, value)` — set or clear an agent-applied tag on any entity (wiki or source). Writes to `entities.tags`, a JSON bag distinct from `properties` (see "Properties vs tags" below). Pass an empty string as `value` to delete a key. Idempotent. No read-gate interaction — tags aren't file content.
 
 **The read-gate.** `edit_file` refuses to mutate a path the agent hasn't `read_file`-ed in this run. Successful edits invalidate the path — the agent must re-read before its next edit on the same file. This catches "editing from stale memory" errors before they corrupt a file. It lives on `AgentContext.readPaths` in `runtime.ts`.
 
@@ -107,13 +108,22 @@ The read-gate is orthogonal to `edit-context.ts`, which exists for **attribution
 Six tables in SQLite, fresh `001-foundation.sql`:
 
 - `spaces (name PK, watch_dir UNIQUE, created_at)`
-- `entities (space_name, source_path)` composite PK, `type` CHECK (`'wiki'|'file'`), `label`, `source_hash`, `properties` JSON, timestamps
+- `entities (space_name, source_path)` composite PK, `type` CHECK (`'wiki'|'file'`), `label`, `source_hash`, `properties` JSON (file-derived), `tags` JSON (agent-applied), timestamps
 - `relationships (space_name, source_path, target_path)` composite PK, `link_text` — no FK on `target_path` (red links!)
 - `entity_edits (space_name, entity_path, at)` composite PK — `at` carries millisecond precision via `strftime('%f')` so same-second writes don't collide. Not FK'd; history survives entity deletion.
 - `conversations (id PK ULID, space_name, article_path NULLABLE, title)` — the **one** v0 table with an explicit ID, because conversations have no on-disk file to derive identity from. Phase 1 lays the schema; Phase 3 wires the routes.
 - `conversation_messages (conversation_id, seq)` composite PK, `role`, `content` JSON
 
 No auth, no actors, no versioning.
+
+### Properties vs tags
+
+The `entities` table carries two JSON bags, divided by origin:
+
+- `properties` — **file-derived**. Wikis fill it from `<meta name="X" content="Y">` tags; sources get an auto-generated `file_type`. `syncFile()` rebuilds this column on every reconcile, so its contents always reflect what's on disk.
+- `tags` — **agent-applied bookkeeping**. Written exclusively via the `tag_entity` tool (or `setEntityTag`/`deleteEntityTag` helpers). The sync UPDATE clauses are explicit-column and never touch `tags`, so it survives content edits — cleared only when the entity row itself is deleted (file removed) or the DB is wiped.
+
+Tags exist so multi-agent pipelines can track "has role X processed entity Y" without conflating it with `inbound_max=0`-style structural queries. Convention: dotted-namespace keys (`editor.processed_hash`, `proposer.processed_hash`) — values are strings (encode timestamps, hashes, or status flags as needed). Liberal at this stage: any agent can write any key. `list_entities` exposes `has_tag` / `not_has_tag` / `tag_equals` filters that hit these via `json_each`, which handles dotted keys verbatim (a `json_extract('$.editor.processed')` path would otherwise be misread as a nested lookup).
 
 ## Key modules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ The writer's tool surface, validated by a 75-trial bake-off (see `tasks/v0-agent
 - `edit_file mode='str_replace' {path, old_string, new_string}` — exact-match SEARCH/REPLACE. `old_string` must match exactly once.
 - `create_file(path, html)` — new wiki from a complete HTML document. Path must start with `wiki/` and end in `.html`. `html` must begin with `<!DOCTYPE>` or `<html>` and contain a non-empty `<title>` plus a `<body>`. The agent authors the whole document, envelope and all — symmetric with how a human writes a wiki. Recommended (not enforced): `<meta name="label">` and `<meta name="short_description">`. Any other `<meta name="...">` tags land in `entities.properties`. Each validation failure returns the canonical template inline so the model can retry in one shot.
 - `delete_wiki(path, reason)` — guarded full-file deletion (only `wiki/**`, required reason). Not in the writer's whitelist; available for operator scripts or future curator roles.
-- `tag_entity(path, key, value)` — set or clear an agent-applied tag on any entity (wiki or source). Writes to `entities.tags`, a JSON bag distinct from `properties` (see "Properties vs tags" below). Pass an empty string as `value` to delete a key. Idempotent. No read-gate interaction — tags aren't file content.
+- `tag_entity(path, key, value)` — set or clear an agent-applied tag on any entity (wiki or source). Writes to `entities.tags`, a JSON bag distinct from `properties` (see "Properties vs tags" below). Pass `null` as `value` to delete the key (empty string is a legitimate value and is stored verbatim). Idempotent. No read-gate interaction — tags aren't file content.
 
 **The read-gate.** `edit_file` refuses to mutate a path the agent hasn't `read_file`-ed in this run. Successful edits invalidate the path — the agent must re-read before its next edit on the same file. This catches "editing from stale memory" errors before they corrupt a file. It lives on `AgentContext.readPaths` in `runtime.ts`.
 
@@ -234,9 +234,11 @@ Tail with `tail -f <path> | jq` or query with `jq -c 'select(.event=="tool.call"
 
 ## Schema migrations
 
-`src/schema/001-foundation.sql` is the v0 reset point — six tables, no migration history. The runner (`src/schema/migrate.ts`) tracks applied files in `schema_migrations` so future non-idempotent migrations only run once.
+`src/schema/001-foundation.sql` is the v0 reset point — six tables. Subsequent files (`002-entity-tags.sql`, ...) are additive migrations applied in lexicographic order and recorded in `schema_migrations` (`src/schema/migrate.ts`), so they run exactly once.
 
-**Phase 1 migration story is destructive**: `rm ~/.arkeon-wiki/data/arke.db && arkeon-wiki up`. The database is a pure index — the only state that doesn't live on disk is `entity_edits`, and nobody is in production with audit history they care about.
+Use `ALTER TABLE ... ADD COLUMN` with `NOT NULL DEFAULT` for new columns — SQLite rewrites the table-defining schema entry rather than the row data, so even large tables migrate in milliseconds. The DB is a pure index of filesystem state (the only column that doesn't have an on-disk counterpart is `entity_edits` history), so a `rm ~/.arkeon-wiki/data/arke.db && arkeon-wiki up` reset is always available as a fallback for development.
+
+`json_patch` / `json_object` / `json_each` (used by the tag helpers and filters) require SQLite 3.38+. better-sqlite3 bundles SQLite, so this is satisfied at the application level; portability to a system sqlite3 isn't a goal.
 
 ## What's NOT here (yet)
 

--- a/packages/arkeon/src/schema/002-entity-tags.sql
+++ b/packages/arkeon/src/schema/002-entity-tags.sql
@@ -1,0 +1,12 @@
+-- Copyright (c) 2026 Arkeon Technologies, Inc.
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Agent-applied tags on entities.
+--
+-- `properties` is file-derived (rebuilt by syncFile() from <meta> tags).
+-- `tags` is agent-applied bookkeeping — a separate JSON bag the sync
+-- path never touches, so an editor agent's `editor.processed_hash`
+-- survives file re-syncs and is cleared only when the entity itself
+-- is deleted (or the DB is wiped).
+
+ALTER TABLE entities ADD COLUMN tags TEXT NOT NULL DEFAULT '{}';

--- a/packages/arkeon/src/server/agents/tools.ts
+++ b/packages/arkeon/src/server/agents/tools.ts
@@ -763,8 +763,9 @@ const tagEntityTool = defineTool("tag_entity", {
     "`properties` — they persist across content edits and are used for " +
     "processing bookkeeping (e.g. 'editor.processed_hash' set to the " +
     "source_hash that was processed). Idempotent — calling twice with " +
-    "the same args is a no-op. Pass an empty string as `value` to delete " +
-    "the key. Keys are conventionally namespaced with the role name " +
+    "the same args is a no-op. Pass `null` as `value` to delete the key " +
+    "(empty string is a legitimate value and is stored verbatim). Keys " +
+    "are conventionally namespaced with the role name " +
     "('editor.processed_hash', 'proposer.processed_hash') so different " +
     "agents' bookkeeping stays legible.",
   inputSchema: z.object({
@@ -781,9 +782,11 @@ const tagEntityTool = defineTool("tag_entity", {
       ),
     value: z
       .string()
+      .nullable()
       .describe(
         "Tag value. Strings only — encode timestamps, hashes, counts as " +
-          "strings. Pass an empty string to delete the key.",
+          "strings. Pass `null` to delete the key. Empty string is a " +
+          "valid value and is stored as an empty string, not a deletion.",
       ),
     space: z.string().nullable().optional().describe(SPACE_PARAM_DESC),
   }),
@@ -802,7 +805,7 @@ const tagEntityTool = defineTool("tag_entity", {
       );
     }
 
-    const deleted = value === "";
+    const deleted = value === null;
     const matched = deleted
       ? await deleteEntityTag(target.name, path, key)
       : await setEntityTag(target.name, path, key, value);

--- a/packages/arkeon/src/server/agents/tools.ts
+++ b/packages/arkeon/src/server/agents/tools.ts
@@ -14,6 +14,8 @@
  *   - edit_file     (insert_at_line | str_replace; read-gated)
  *   - create_file   (new wiki — accepts full HTML or inner fragment)
  *   - delete_wiki   (guarded full-file deletion; not in writer's whitelist)
+ *   - tag_entity    (set/clear agent bookkeeping in entities.tags; survives
+ *                    file re-syncs, used for per-role processing queues)
  */
 
 import { existsSync, readFileSync, statSync } from "node:fs";
@@ -23,10 +25,12 @@ import { z } from "zod";
 import { safeResolve, validateWikiHtmlDocument } from "../lib/file-edits.js";
 import { MAX_QUERY_PATTERNS, searchKeyword } from "../lib/search.js";
 import {
+  deleteEntityTag,
   getEntity,
   listEntities,
   listRedLinks,
   parseEntityTypes,
+  setEntityTag,
   type EntityType,
 } from "../lib/entities.js";
 
@@ -229,8 +233,13 @@ const listEntitiesTool = defineTool("list_entities", {
     "Use to check whether a subject already has a wiki, find unprocessed " +
     "sources (type=file inbound_max=0 → 'nothing links to this file yet'), " +
     "or surface recently-updated articles. Each row carries `space_name`, " +
-    "`source_path`, `type`, `label`, `properties`, and optional " +
-    "`counts.inbound`/`counts.outbound`.",
+    "`source_path`, `type`, `label`, `properties`, `tags`, and optional " +
+    "`counts.inbound`/`counts.outbound`. `properties` is file-derived " +
+    "(rebuilt on every sync from <meta> tags); `tags` is agent-applied " +
+    "bookkeeping (set via `tag_entity`) and persists across content edits. " +
+    "Filter by `has_tag` / `not_has_tag` / `tag_equals` to drive " +
+    "per-role queues (e.g. `not_has_tag='editor.processed_hash'` returns " +
+    "sources the editor hasn't seen yet).",
   inputSchema: z.object({
     type: z
       .string()
@@ -301,6 +310,35 @@ const listEntitiesTool = defineTool("list_entities", {
         "Filter on the most recent edit's by_role ('writer', 'human', etc.). " +
           "Pass null (or omit) to skip the filter.",
       ),
+    has_tag: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "Restrict to entities that have this tag key set. " +
+          "Pass null (or omit) to skip the filter.",
+      ),
+    not_has_tag: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "Restrict to entities that do NOT have this tag key set. " +
+          "Use for 'find untagged-by-me' queue queries (e.g. " +
+          "not_has_tag='editor.processed_hash' returns sources the editor " +
+          "hasn't seen yet). Pass null (or omit) to skip the filter.",
+      ),
+    tag_equals: z
+      .object({ key: z.string(), value: z.string() })
+      .nullable()
+      .optional()
+      .describe(
+        "Restrict to entities where tag `key` equals exactly `value`. " +
+          "Use for content-hash invalidation (e.g. tag_equals " +
+          "{key:'editor.processed_hash', value:<current source_hash>} " +
+          "returns sources the editor processed at the current content). " +
+          "Pass null (or omit) to skip the filter.",
+      ),
     sort: z
       .enum(["updated_at", "label", "inbound", "outbound"])
       .nullable()
@@ -352,6 +390,9 @@ const listEntitiesTool = defineTool("list_entities", {
         outbound_max: input.outbound_max,
         updated_since: input.updated_since,
         edited_by_role: input.edited_by_role,
+        has_tag: input.has_tag,
+        not_has_tag: input.not_has_tag,
+        tag_equals: input.tag_equals,
         sort: input.sort,
         include_counts: input.include_counts,
         limit: input.limit,
@@ -713,6 +754,79 @@ const deleteWikiTool = defineTool("delete_wiki", {
   summarize: (r) => ({ path: r.path, mode: r.mode }),
 });
 
+// ── tag_entity ────────────────────────────────────────────────────
+
+const tagEntityTool = defineTool("tag_entity", {
+  description:
+    "Set or update an agent-applied tag on an entity (any wiki or " +
+    "source). Tags are key/value pairs in a JSON bag separate from " +
+    "`properties` — they persist across content edits and are used for " +
+    "processing bookkeeping (e.g. 'editor.processed_hash' set to the " +
+    "source_hash that was processed). Idempotent — calling twice with " +
+    "the same args is a no-op. Pass an empty string as `value` to delete " +
+    "the key. Keys are conventionally namespaced with the role name " +
+    "('editor.processed_hash', 'proposer.processed_hash') so different " +
+    "agents' bookkeeping stays legible.",
+  inputSchema: z.object({
+    path: z
+      .string()
+      .describe("Relative path of the entity to tag (wiki or source)."),
+    key: z
+      .string()
+      .min(1)
+      .describe(
+        "Tag key. Conventionally namespaced with the role name " +
+          "(e.g. 'editor.processed_hash'). Dotted keys are stored verbatim " +
+          "as JSON object keys (not nested paths).",
+      ),
+    value: z
+      .string()
+      .describe(
+        "Tag value. Strings only — encode timestamps, hashes, counts as " +
+          "strings. Pass an empty string to delete the key.",
+      ),
+    space: z.string().nullable().optional().describe(SPACE_PARAM_DESC),
+  }),
+  call: async ({ path, key, value, space }, ctx) => {
+    // tag_entity always writes to a single space. Mirror edit_file's
+    // single-space semantics: explicit space arg or the triggering one.
+    let target: Space;
+    if (ctx.allowedSpaces.length <= 1) {
+      target = ctx.space;
+    } else if (space != null && space !== "") {
+      target = resolveSpaceArg(space, ctx.allowedSpaces);
+    } else {
+      throw new Error(
+        `tag_entity: this role can write to multiple spaces, so the ` +
+          `\`space\` argument is required. Allowed: ${describeAllowed(ctx.allowedSpaces)}.`,
+      );
+    }
+
+    const deleted = value === "";
+    const matched = deleted
+      ? await deleteEntityTag(target.name, path, key)
+      : await setEntityTag(target.name, path, key, value);
+    if (!matched) {
+      throw new Error(
+        `tag_entity: no entity at '${path}' in space '${target.name}'`,
+      );
+    }
+    return {
+      path,
+      space: target.name,
+      key,
+      value: deleted ? null : value,
+      action: deleted ? ("deleted" as const) : ("set" as const),
+    };
+  },
+  summarize: (r) => ({
+    path: r.path,
+    space: r.space,
+    key: r.key,
+    action: r.action,
+  }),
+});
+
 // ── Registry ──────────────────────────────────────────────────────
 
 export const ALL_TOOLS: Record<string, ToolFactory> = {
@@ -724,4 +838,5 @@ export const ALL_TOOLS: Record<string, ToolFactory> = {
   edit_file: editFileTool,
   create_file: createFileTool,
   delete_wiki: deleteWikiTool,
+  tag_entity: tagEntityTool,
 };

--- a/packages/arkeon/src/server/lib/entities.ts
+++ b/packages/arkeon/src/server/lib/entities.ts
@@ -44,6 +44,12 @@ export interface ListEntitiesOptions {
   updated_since?: string | null;
   /** Filter on the entity's most recent edit's `by_role`. */
   edited_by_role?: string | null;
+  /** Restrict to entities that have this tag key set. */
+  has_tag?: string | null;
+  /** Restrict to entities that do NOT have this tag key set. */
+  not_has_tag?: string | null;
+  /** Restrict to entities where tag `key` equals exactly `value`. */
+  tag_equals?: { key: string; value: string } | null;
   sort?: string | null;
   include_counts?: boolean | null;
   limit?: number | null;
@@ -61,6 +67,7 @@ export interface EntityListRow {
   type: EntityType;
   label: string | null;
   properties: Record<string, unknown> | string;
+  tags: Record<string, unknown> | string;
   created_at: string;
   updated_at: string;
   counts?: EntityCounts;
@@ -138,6 +145,28 @@ export async function listEntities(
     `);
     innerParams.push(opts.edited_by_role);
   }
+  // Tag filters use json_each rather than json_extract($.<key>) — the
+  // dotted-namespace convention ("editor.processed") would otherwise be
+  // parsed as a nested path. json_each iterates over the JSON object's
+  // top-level entries, where `key` matches verbatim.
+  if (opts.has_tag) {
+    innerConditions.push(
+      "EXISTS (SELECT 1 FROM json_each(e.tags) WHERE key = ?)",
+    );
+    innerParams.push(opts.has_tag);
+  }
+  if (opts.not_has_tag) {
+    innerConditions.push(
+      "NOT EXISTS (SELECT 1 FROM json_each(e.tags) WHERE key = ?)",
+    );
+    innerParams.push(opts.not_has_tag);
+  }
+  if (opts.tag_equals) {
+    innerConditions.push(
+      "EXISTS (SELECT 1 FROM json_each(e.tags) WHERE key = ? AND value = ?)",
+    );
+    innerParams.push(opts.tag_equals.key, opts.tag_equals.value);
+  }
 
   const innerWhere = innerConditions.length
     ? `WHERE ${innerConditions.join(" AND ")}`
@@ -169,7 +198,7 @@ export async function listEntities(
 
   const baseSelect = `
     SELECT
-      e.space_name, e.source_path, e.type, e.label, e.properties,
+      e.space_name, e.source_path, e.type, e.label, e.properties, e.tags,
       e.created_at, e.updated_at,
       (SELECT COUNT(*) FROM relationships r
         WHERE r.space_name = e.space_name AND r.target_path = e.source_path) AS inbound,
@@ -195,6 +224,7 @@ export async function listEntities(
     type: EntityType;
     label: string | null;
     properties: Record<string, unknown> | string;
+    tags: Record<string, unknown> | string;
     created_at: string;
     updated_at: string;
     inbound: number;
@@ -226,6 +256,7 @@ export async function listEntities(
         type: row.type,
         label: row.label,
         properties: row.properties,
+        tags: row.tags,
         created_at: row.created_at,
         updated_at: row.updated_at,
         last_edited_by: row.last_edited_by,
@@ -387,7 +418,7 @@ export async function getEntity(
 ): Promise<EntityDetail | null> {
   const sql = createSql();
   const rows = await sql`
-    SELECT space_name, source_path, type, label, properties, created_at, updated_at,
+    SELECT space_name, source_path, type, label, properties, tags, created_at, updated_at,
       (SELECT by_role FROM entity_edits ed
         WHERE ed.space_name = entities.space_name AND ed.entity_path = entities.source_path
         ORDER BY ed.at DESC LIMIT 1) AS last_edited_by
@@ -412,6 +443,7 @@ export async function getEntity(
     type: row.type as EntityType,
     label: row.label as string | null,
     properties: row.properties as Record<string, unknown> | string,
+    tags: row.tags as Record<string, unknown> | string,
     created_at: row.created_at as string,
     updated_at: row.updated_at as string,
     last_edited_by: row.last_edited_by as string | null,
@@ -424,4 +456,60 @@ export async function getEntity(
       link_text: r.link_text as string | null,
     })),
   };
+}
+
+// ── tag helpers ──────────────────────────────────────────────────────
+//
+// `tags` is agent-applied bookkeeping (e.g. `editor.processed_hash`),
+// distinct from `properties` which is file-derived. Tags persist across
+// `syncFile` reconciles — the UPDATE in sync.ts is explicit-column and
+// never touches `tags` — and are cleared only when the entity row is
+// deleted. The merge is done in SQL via json_patch so concurrent writes
+// to different keys on the same entity don't race.
+//
+// We use json_patch + json_object rather than json_set('$.' || key) so
+// dotted keys ("editor.processed") aren't misread as nested paths.
+// RFC 7396 says a null value in the patch removes the key, which is how
+// `deleteEntityTag` works.
+
+/**
+ * Idempotent upsert of a tag key/value on an entity. Returns true if a
+ * row was matched (i.e. the entity exists), false otherwise.
+ */
+export async function setEntityTag(
+  space_name: string,
+  source_path: string,
+  key: string,
+  value: string,
+): Promise<boolean> {
+  const sql = createSql();
+  const patch = JSON.stringify({ [key]: value });
+  const result = await sql`
+    UPDATE entities
+    SET tags = json_patch(COALESCE(tags, '{}'), ${patch})
+    WHERE space_name = ${space_name} AND source_path = ${source_path}
+    RETURNING source_path
+  `;
+  return result.length > 0;
+}
+
+/**
+ * Idempotent removal of a tag key on an entity. Returns true if a row
+ * was matched.
+ */
+export async function deleteEntityTag(
+  space_name: string,
+  source_path: string,
+  key: string,
+): Promise<boolean> {
+  const sql = createSql();
+  // RFC 7396 merge-patch: null removes the key.
+  const patch = JSON.stringify({ [key]: null });
+  const result = await sql`
+    UPDATE entities
+    SET tags = json_patch(COALESCE(tags, '{}'), ${patch})
+    WHERE space_name = ${space_name} AND source_path = ${source_path}
+    RETURNING source_path
+  `;
+  return result.length > 0;
 }

--- a/packages/arkeon/src/server/lib/sql.ts
+++ b/packages/arkeon/src/server/lib/sql.ts
@@ -93,7 +93,7 @@ function parseJson(val: unknown): unknown {
 function hydrateRow(row: Row): Row {
   const out: Row = {};
   for (const [key, val] of Object.entries(row)) {
-    if (key === "properties" && typeof val === "string") {
+    if ((key === "properties" || key === "tags") && typeof val === "string") {
       out[key] = parseJson(val);
     } else {
       out[key] = val;

--- a/packages/arkeon/src/server/routes/space-scoped.ts
+++ b/packages/arkeon/src/server/routes/space-scoped.ts
@@ -64,6 +64,9 @@ spaceScopedRouter.get("/:space/entities", async (c) => {
     outbound_max: parseNumQuery(c.req.query("outbound_max"), "outbound_max"),
     updated_since: c.req.query("updated_since"),
     edited_by_role: c.req.query("edited_by_role"),
+    has_tag: c.req.query("has_tag"),
+    not_has_tag: c.req.query("not_has_tag"),
+    tag_equals: parseTagEquals(c.req.query("tag_equals")),
     sort: c.req.query("sort"),
     include_counts: (c.req.query("include") ?? "").split(",").includes("counts"),
     limit: parseNumQuery(c.req.query("limit"), "limit"),
@@ -251,4 +254,24 @@ function parseNumQuery(raw: string | undefined, name: string): number | undefine
     );
   }
   return n;
+}
+
+/**
+ * Parse `?tag_equals=key:value` into the typed shape `listEntities`
+ * expects. Splits on the FIRST colon so values may contain colons; keys
+ * must not (the conventional dotted-namespace form is colon-free).
+ */
+function parseTagEquals(
+  raw: string | undefined,
+): { key: string; value: string } | undefined {
+  if (raw === undefined || raw === "") return undefined;
+  const idx = raw.indexOf(":");
+  if (idx <= 0) {
+    throw new ApiError(
+      400,
+      "validation_error",
+      `Invalid tag_equals: expected "key:value", got "${raw}"`,
+    );
+  }
+  return { key: raw.slice(0, idx), value: raw.slice(idx + 1) };
 }

--- a/packages/arkeon/test/e2e/agent-runtime.test.ts
+++ b/packages/arkeon/test/e2e/agent-runtime.test.ts
@@ -479,7 +479,7 @@ describe("tag_entity tool + tag filters", () => {
     expect(listed2.entities[0].tags).toEqual({ "editor.processed_hash": "hash-v1" });
   });
 
-  it("tag_entity with empty value deletes the key", async () => {
+  it("tag_entity with null value deletes the key (empty string is a stored value)", async () => {
     await makeSource("sources/b.txt");
 
     const ctx = makeContext(SPACE, "editor");
@@ -487,11 +487,13 @@ describe("tag_entity tool + tag filters", () => {
 
     await exec(tag, { path: "sources/b.txt", key: "foo", value: "bar" });
     await exec(tag, { path: "sources/b.txt", key: "baz", value: "qux" });
+    // Empty string is a legitimate value, not a delete signal.
+    await exec(tag, { path: "sources/b.txt", key: "flag", value: "" });
 
     const result = (await exec(tag, {
       path: "sources/b.txt",
       key: "foo",
-      value: "",
+      value: null,
     })) as { action: string; value: string | null };
     expect(result.action).toBe("deleted");
     expect(result.value).toBe(null);
@@ -500,7 +502,7 @@ describe("tag_entity tool + tag filters", () => {
     const listed = (await exec(list, { path_contains: "sources/b.txt" })) as {
       entities: Array<{ tags: Record<string, string> }>;
     };
-    expect(listed.entities[0].tags).toEqual({ baz: "qux" });
+    expect(listed.entities[0].tags).toEqual({ baz: "qux", flag: "" });
   });
 
   it("tag_entity is idempotent — setting the same value twice is a no-op", async () => {

--- a/packages/arkeon/test/e2e/agent-runtime.test.ts
+++ b/packages/arkeon/test/e2e/agent-runtime.test.ts
@@ -437,6 +437,159 @@ describe("deletion semantics", () => {
   });
 });
 
+describe("tag_entity tool + tag filters", () => {
+  const exec = execTool;
+
+  async function makeSource(path: string, content = "x") {
+    mkdirSync(join(workdir, ...path.split("/").slice(0, -1)), { recursive: true });
+    writeFileSync(join(workdir, path), content);
+    await syncFile(SPACE, path);
+  }
+
+  it("tag_entity sets a tag visible on list_entities + survives file re-sync", async () => {
+    await makeSource("sources/a.txt", "first");
+
+    const ctx = makeContext(SPACE, "editor");
+    const tag = getTool("tag_entity", ctx);
+
+    const result = (await exec(tag, {
+      path: "sources/a.txt",
+      key: "editor.processed_hash",
+      value: "hash-v1",
+    })) as { action: string; value: string | null };
+    expect(result.action).toBe("set");
+    expect(result.value).toBe("hash-v1");
+
+    // List sees the tag.
+    const list = getTool("list_entities", ctx);
+    const listed = (await exec(list, { path_contains: "sources/a.txt" })) as {
+      entities: Array<{ source_path: string; tags: Record<string, string> }>;
+    };
+    const row = listed.entities.find((e) => e.source_path === "sources/a.txt");
+    expect(row?.tags).toEqual({ "editor.processed_hash": "hash-v1" });
+
+    // Re-sync the file with new content — tag must persist (sync.ts UPDATE
+    // is explicit-column and doesn't touch `tags`).
+    writeFileSync(join(workdir, "sources/a.txt"), "second");
+    await syncFile(SPACE, "sources/a.txt");
+
+    const listed2 = (await exec(list, { path_contains: "sources/a.txt" })) as {
+      entities: Array<{ source_path: string; tags: Record<string, string> }>;
+    };
+    expect(listed2.entities[0].tags).toEqual({ "editor.processed_hash": "hash-v1" });
+  });
+
+  it("tag_entity with empty value deletes the key", async () => {
+    await makeSource("sources/b.txt");
+
+    const ctx = makeContext(SPACE, "editor");
+    const tag = getTool("tag_entity", ctx);
+
+    await exec(tag, { path: "sources/b.txt", key: "foo", value: "bar" });
+    await exec(tag, { path: "sources/b.txt", key: "baz", value: "qux" });
+
+    const result = (await exec(tag, {
+      path: "sources/b.txt",
+      key: "foo",
+      value: "",
+    })) as { action: string; value: string | null };
+    expect(result.action).toBe("deleted");
+    expect(result.value).toBe(null);
+
+    const list = getTool("list_entities", ctx);
+    const listed = (await exec(list, { path_contains: "sources/b.txt" })) as {
+      entities: Array<{ tags: Record<string, string> }>;
+    };
+    expect(listed.entities[0].tags).toEqual({ baz: "qux" });
+  });
+
+  it("tag_entity is idempotent — setting the same value twice is a no-op", async () => {
+    await makeSource("sources/c.txt");
+
+    const ctx = makeContext(SPACE, "editor");
+    const tag = getTool("tag_entity", ctx);
+
+    await exec(tag, { path: "sources/c.txt", key: "editor.processed", value: "v1" });
+    await exec(tag, { path: "sources/c.txt", key: "editor.processed", value: "v1" });
+
+    const list = getTool("list_entities", ctx);
+    const listed = (await exec(list, { path_contains: "sources/c.txt" })) as {
+      entities: Array<{ tags: Record<string, string> }>;
+    };
+    expect(listed.entities[0].tags).toEqual({ "editor.processed": "v1" });
+  });
+
+  it("tag_entity errors on a non-existent entity", async () => {
+    const ctx = makeContext(SPACE, "editor");
+    const tag = getTool("tag_entity", ctx);
+    await expect(
+      exec(tag, { path: "sources/missing.txt", key: "k", value: "v" }),
+    ).rejects.toThrow(/no entity at/);
+  });
+
+  it("list_entities filters: has_tag / not_has_tag / tag_equals", async () => {
+    await makeSource("sources/d.txt");
+    await makeSource("sources/e.txt");
+    await makeSource("sources/f.txt");
+
+    const ctx = makeContext(SPACE, "editor");
+    const tag = getTool("tag_entity", ctx);
+    const list = getTool("list_entities", ctx);
+
+    // Tag d and e with the same key; e with the matching value.
+    await exec(tag, { path: "sources/d.txt", key: "editor.processed_hash", value: "old" });
+    await exec(tag, { path: "sources/e.txt", key: "editor.processed_hash", value: "current" });
+    // f gets no tag.
+
+    // has_tag returns d + e.
+    const hasTag = (await exec(list, {
+      type: "file",
+      has_tag: "editor.processed_hash",
+    })) as { entities: Array<{ source_path: string }> };
+    const hasPaths = hasTag.entities.map((r) => r.source_path).sort();
+    expect(hasPaths).toEqual(["sources/d.txt", "sources/e.txt"]);
+
+    // not_has_tag returns f.
+    const notHas = (await exec(list, {
+      type: "file",
+      path_contains: "sources/",
+      not_has_tag: "editor.processed_hash",
+    })) as { entities: Array<{ source_path: string }> };
+    expect(notHas.entities.map((r) => r.source_path)).toContain("sources/f.txt");
+    expect(notHas.entities.map((r) => r.source_path)).not.toContain("sources/d.txt");
+
+    // tag_equals returns only e (the value matches).
+    const eq = (await exec(list, {
+      type: "file",
+      tag_equals: { key: "editor.processed_hash", value: "current" },
+    })) as { entities: Array<{ source_path: string }> };
+    expect(eq.entities.map((r) => r.source_path)).toEqual(["sources/e.txt"]);
+  });
+
+  it("dotted-namespace keys aren't treated as nested JSON paths", async () => {
+    await makeSource("sources/g.txt");
+
+    const ctx = makeContext(SPACE, "editor");
+    const tag = getTool("tag_entity", ctx);
+    const list = getTool("list_entities", ctx);
+
+    await exec(tag, { path: "sources/g.txt", key: "editor.processed_hash", value: "h1" });
+
+    const matched = (await exec(list, {
+      has_tag: "editor.processed_hash",
+    })) as { entities: Array<{ source_path: string }> };
+    expect(matched.entities.map((r) => r.source_path)).toContain("sources/g.txt");
+
+    // The naive json_extract('$.editor.processed_hash') path would parse
+    // as a nested $.editor → .processed_hash lookup and miss. Confirm a
+    // query for the sub-path returns nothing.
+    const nested = (await exec(list, {
+      has_tag: "editor",
+    })) as { entities: Array<{ source_path: string }> };
+    expect(nested.entities.map((r) => r.source_path)).not.toContain("sources/g.txt");
+  });
+});
+
 describe("scheduler", () => {
   it("fires a cron-bearing role on schedule and invokes runAgent", async () => {
     // cron-parser supports a 6-field form where the first field is

--- a/packages/arkeon/test/e2e/api.test.ts
+++ b/packages/arkeon/test/e2e/api.test.ts
@@ -169,6 +169,65 @@ describe("Phase 1 API shape", () => {
     expect(body.keyword.hits.some((h) => h.source_path === "wiki/photosynthesis.html")).toBe(true);
   });
 
+  it("GET /:space/entities exposes the tags column (empty by default)", async () => {
+    const res = await fetch(`${baseUrl}/${SPACE}/entities?type=wiki`);
+    const body = (await res.json()) as {
+      entities: Array<{ source_path: string; tags: Record<string, string> }>;
+    };
+    expect(body.entities.length).toBeGreaterThan(0);
+    for (const row of body.entities) {
+      expect(row.tags).toEqual({});
+    }
+  });
+
+  it("GET /:space/entities filters by has_tag / not_has_tag / tag_equals", async () => {
+    // Seed a tag directly via the helper (no HTTP write path yet — the
+    // agent tool is the canonical writer; the route just reads).
+    const { setEntityTag } = await import("../../src/server/lib/entities.js");
+    await setEntityTag(SPACE, "wiki/photosynthesis.html", "editor.processed_hash", "h-current");
+
+    const hasTag = await fetch(
+      `${baseUrl}/${SPACE}/entities?has_tag=editor.processed_hash`,
+    );
+    const hasBody = (await hasTag.json()) as { entities: Array<{ source_path: string }> };
+    expect(hasBody.entities.map((r) => r.source_path)).toContain(
+      "wiki/photosynthesis.html",
+    );
+
+    const notHas = await fetch(
+      `${baseUrl}/${SPACE}/entities?type=wiki&not_has_tag=editor.processed_hash`,
+    );
+    const notBody = (await notHas.json()) as { entities: Array<{ source_path: string }> };
+    expect(notBody.entities.map((r) => r.source_path)).not.toContain(
+      "wiki/photosynthesis.html",
+    );
+    expect(notBody.entities.map((r) => r.source_path)).toContain(
+      "wiki/biology/chlorophyll.html",
+    );
+
+    // tag_equals encoded as `key:value`.
+    const eqHit = await fetch(
+      `${baseUrl}/${SPACE}/entities?tag_equals=${encodeURIComponent("editor.processed_hash:h-current")}`,
+    );
+    const eqHitBody = (await eqHit.json()) as { entities: Array<{ source_path: string }> };
+    expect(eqHitBody.entities.map((r) => r.source_path)).toEqual([
+      "wiki/photosynthesis.html",
+    ]);
+
+    const eqMiss = await fetch(
+      `${baseUrl}/${SPACE}/entities?tag_equals=${encodeURIComponent("editor.processed_hash:stale")}`,
+    );
+    const eqMissBody = (await eqMiss.json()) as { entities: Array<unknown> };
+    expect(eqMissBody.entities).toEqual([]);
+  });
+
+  it("GET /:space/entities rejects malformed tag_equals", async () => {
+    const res = await fetch(`${baseUrl}/${SPACE}/entities?tag_equals=missing-colon`);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("validation_error");
+  });
+
   it("POST /:space/chat returns 501 (Phase 3 stub)", async () => {
     const res = await fetch(`${baseUrl}/${SPACE}/chat`, {
       method: "POST",


### PR DESCRIPTION
## Summary

Adds a `tags` JSON column on `entities`, parallel to `properties` but distinct by origin:

- `properties` — file-derived (rebuilt by `syncFile()` on every reconcile from `<meta>` tags)
- `tags` — agent-applied bookkeeping (e.g. `editor.processed_hash`); survives content re-syncs, cleared only when the entity row is deleted

Motivation: multi-agent pipelines need a per-entity bookkeeping slot. `inbound_max=0` only distinguishes "linked / not linked" — too coarse once an editor and proposer (and future synthesizer/archivist) each produce inbound from different artifacts.

### What's new

- New `tag_entity` agent tool: `{path, key, value}` (empty `value` deletes the key). Idempotent. No read-gate interaction — tags aren't file content.
- New filters on `list_entities` (both the agent tool and `GET /:space/entities`): `has_tag`, `not_has_tag`, `tag_equals`.
- HTTP encoding: `?has_tag=editor.processed_hash`, `?not_has_tag=...`, `?tag_equals=key:value` (split on first colon; malformed returns 400).
- `tags` column surfaces on `EntityListRow` and `EntityDetail`, hydrated alongside `properties`.

### Implementation note

The proposal's `json_extract('$.' || ?)` + `json_set('$.' || ?, ?)` would silently misparse the recommended dotted-namespace key convention (`editor.processed_hash` → nested `$.editor.processed_hash` lookup, never matches). Swapped to:

- Filters: `json_each(e.tags) WHERE key = ?`
- Writes: `json_patch(coalesce(tags, '{}'), json_object(?, ?))` for set; same with a JSON `null` value for delete (RFC 7396 merge-patch removes null-valued keys)

Verified by the "dotted-namespace keys aren't treated as nested JSON paths" test: querying `has_tag='editor'` against a row tagged with `editor.processed_hash='h1'` correctly returns nothing.

### Sync safety

`syncFile()`'s UPDATE clauses (both `syncWiki` and `syncSource`) are explicit-column — `tags` is not in the SET list, so file re-syncs preserve agent bookkeeping. Verified by the "tag survives file re-sync" test.

## Test plan

- [x] `npm run typecheck -w packages/arkeon` — clean
- [x] `npm test -w packages/arkeon` — 127/127 unit pass
- [x] `npm run test:e2e -w packages/arkeon` — 31/31 e2e pass (8 new: 5 agent-runtime + 3 api.test.ts)
- [x] Migration applies cleanly on a fresh DB (`002-entity-tags.sql ... OK` in test output)
- [x] Dotted-namespace key handling verified end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)