### PR TITLE
Editor → proposer → writer agent pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,17 +109,24 @@ curl "$API/$SPACE/redlinks?limit=20"
 curl "$API/$SPACE/entities?type=file&inbound_max=0&include=counts"
 ```
 
-## The writer agent
+## The editor, proposer, and writer agents
 
-The bundled `writer` role (`packages/arkeon/src/server/agents/templates/writer.yaml`) runs on a cron schedule (`*/15 * * * *` by default). Each tick it:
+Three bundled roles share the writing job, each with a single responsibility:
 
-1. Surveys two queues: unprocessed sources (`list_entities?type=file&inbound_max=0`) and red links (`list_redlinks`).
-2. Reads the most interesting source or 1-2 of the articles that want a red-link target defined.
-3. Articulates the driving question.
-4. Searches for an existing article addressing it.
-5. Either **extends** the existing article via `edit_file` (`insert_at_line` or `str_replace`, both read-gated) or **creates** a new one via `create_file` (the agent authors a complete HTML document — `<!DOCTYPE>`/`<html>` wrapper, non-empty `<title>`, `<body>` — and the tool validates structure and writes it verbatim).
+- **`editor`** (`templates/editor.yaml`, cron `0 */1 * * *`) — source-driven. Picks one source the editor hasn't tagged at its current `source_hash`, surveys existing articles via `list_entities` + `properties.short_description`, and for each article the source bears on, either (a) inserts a citation-bearing paragraph into Evidence / revises the Current Answer via `edit_file`, or (b) appends a red-link `<li>` to the article's `<h2>Open threads</h2>`. Tags the source `editor.processed_hash=<source_hash>` when done. Never creates new articles.
 
-Default model: `gpt-5.4-mini`, `reasoning_effort: low`. Override via `.arkeon/agents.yaml` if you want a different model or schedule.
+- **`proposer`** (`templates/proposer.yaml`, cron `0 */1 * * *`) — also source-driven, but **data-gated on the editor's tag**: picks one source where `has_tag=editor.processed_hash AND not_has_tag=proposer.processed_hash`. Calls `get_entity` on the source path to see which articles the editor already integrated this source into (`entity.inbound`). Identifies the GAP — questions the source raises that no existing article (and no queued red link) covers. Writes a plan wiki at `wiki/_plans/<source-path>.html` listing those gaps as red links. Tags the source `proposer.processed_hash=<source_hash>`. Never edits existing articles, never writes article bodies.
+
+- **`writer`** (`templates/writer.yaml`, cron `*/15 * * * *`) — red-link-driven. Picks the highest-demand entry from `list_redlinks`, follows its linkers back to source files, and creates the article via `create_file`. Only ever creates — `edit_file` is not in its whitelist. Empty red-link queue → no-op, no fallback "invent something" branch.
+
+The pipeline is **sequential per source** by data dependency: editor marks → proposer eligible to run → both contribute red links → writer drains them. Content changes invalidate both source markers so the source re-enters both queues automatically.
+
+Two tagging patterns coexist on the `entities.tags` JSON column:
+
+- **Processing markers** (the canonical "I did this" idiom): `mark_processed(path, role)` writes `tags["${role}.processed_hash"] = source_hash` on the server side. The agent never touches the hash. Query queues with `list_entities({ tag_outdated: "<role>.processed_hash" })` (needs processing — absent OR stale) or `tag_current: "<role>.processed_hash"` (processed at current content). Hash invalidation is automatic.
+- **Free-form state** (for future roles that need richer bookkeeping — categorization, status enums, severities): use `tag_entity(path, key, value)` and the existing `has_tag` / `not_has_tag` / `tag_equals` filters. Not hash-validated; the agent is responsible for re-tagging when content changes if that matters.
+
+Default model for all three: `gpt-5.4-mini`, `reasoning_effort: low`. The single-role-per-tick decomposition lets a small model handle each job reliably (the previous single-writer role needed `reasoning_effort: medium` for the integrated workload). Override per role in `.arkeon/agents.yaml` for a stronger model or different cadence.
 
 **First-run cost**: a fresh `arkeon-wiki up` against a corpus with `OPENAI_API_KEY` set will start spending API credit within 15 minutes. Override the cadence in `.arkeon/agents.yaml` (`cron: "0 0 31 2 *"` is the canonical "never fire") to inspect behavior before letting it run.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,26 +62,44 @@ There is no YAML frontmatter on wikis, no `[[wikilink]]` syntax, no placeholder 
 
 Source files (anywhere outside `wiki/`) are indexed as `type='file'` with `{file_type: <ext>}`. Supported extensions: `.txt`, `.json`, `.csv`, `.xml`, `.rst`, `.html` outside `wiki/`. Markdown is intentionally unsupported — HTML is the only authoring format. Structured metadata lives in `<meta name="X" content="Y">` tags on the wiki itself.
 
-## Writing (the `writer` role)
+## Writing (three roles: `editor`, `proposer`, `writer`)
 
-A single agent role — `writer` — turns recent sources into HTML articles on a recurring cron schedule. Every tick, the writer:
+Three bundled agent roles cooperate on a single-job-each pipeline. Each runs on its own cron, all three serialized per-space by the in-process mutex.
 
-1. Surveys two queues:
-   - **Unprocessed sources**: `list_entities?type=file&inbound_max=0` — files no article cites yet
-   - **Red links**: `list_redlinks` — link targets ranked by demand (how many existing articles want this concept defined)
-2. Picks one piece of work: a high-demand red link, or a recently-arrived source.
-3. Reads the relevant files (the source, or 1-2 articles that want the red-link target defined).
-4. Articulates the driving question.
-5. Searches existing articles via keyword search (`search(query=[...]&type=wiki)`).
-6. Either **extends** the existing article via `edit_file` (`insert_at_line` or `str_replace`) or **creates** a new one via `create_file`.
+**`editor`** (source-driven, runs first per source). Each tick:
+1. Picks one source the editor hasn't tagged at its current `source_hash` (`list_entities?type=file&not_has_tag=editor.processed_hash`).
+2. Reads the source; surveys existing articles via `list_entities` (using `properties.short_description` for semantic matching).
+3. For each existing article the source bears on, applies one or both:
+   - **Content edit** — `edit_file insert_at_line` adds a citation-bearing paragraph in Evidence, or `edit_file str_replace` revises Current Answer when the source reshapes the thesis. Always cites the source inline via `<a href="../sources/...">`.
+   - **Open-thread red link** — `edit_file insert_at_line` appends one `<li>` to the article's `<h2>Open threads</h2>` `<ul>`, containing a red link to a future article and a one-sentence gloss.
+4. `tag_entity` the source with `key="editor.processed_hash"` value=source_hash.
 
-Articles are horizontal: one article spans many sources, growing as the corpus grows. The default body convention is four sections — `<h2>Question</h2>` / `<h2>Current answer</h2>` / `<h2>Evidence</h2>` / `<h2>Open threads</h2>` — but it's a soft convention. Operators reshape it via `instructions:` in their `agents.yaml`.
+Editor never creates articles. Zero edits per tick is fine — many sources are tangential to existing articles and should be tagged-and-skipped.
 
-The trigger is **purely cron-driven**. The watcher's job ends at the SQLite mirror; agents pick up new state at their next scheduled tick. Per-space serialization is enforced by an in-process mutex — at most one role can run in a given space at any time.
+**`proposer`** (source-driven, runs SECOND per source by data dependency). Each tick:
+1. Picks one source the editor has tagged but the proposer hasn't (`list_entities?type=file&has_tag=editor.processed_hash&not_has_tag=proposer.processed_hash`).
+2. Reads the source.
+3. **Calls `get_entity` on the source path** — `entity.inbound` lists every article that already cites this source (the editor's integration points). These tell the proposer which concepts the editor already integrated.
+4. Identifies the GAP — questions the source raises that aren't already covered by (a) an existing article citing this source, (b) any other existing article, or (c) an already-queued red link.
+5. `create_file` a plan wiki at `wiki/_plans/<source-path>.html` (mirrors source path, drops extension to `.html`) containing a Summary that cites the source inline, plus a list of red links to the gap articles. `<meta name="kind" content="plan">` distinguishes plan wikis from real articles.
+6. `tag_entity` the source with `key="proposer.processed_hash"` value=source_hash.
 
-The bundled writer template ships `cron: "*/15 * * * *"` with `model: gpt-5.4-mini`, `reasoning_effort: low`, `max_steps: 12`. **First-run cost note**: a fresh `arkeon-wiki up` against a corpus with `OPENAI_API_KEY` set will start spending API credit within 15 minutes. Operators who want to inspect the writer's behavior before letting it run should override the cadence in `.arkeon/agents.yaml` (`cron: "0 0 31 2 *"` is the canonical "never fire" idiom — Feb 31 doesn't exist).
+Proposer never edits existing articles and never writes article bodies — only red-link slugs in a plan wiki.
 
-**Downtime → missed ticks are dropped.** No persistence of last-fire times. The cron model lets each role decide its own work from current state — new behaviors (reflector picking articles with open threads, bridger rotating across spaces) need only a different prompt + cron, no scheduler changes.
+**`writer`** (red-link-driven). Each tick:
+1. Picks the highest-demand entry from `list_redlinks`.
+2. Reads the 1-3 plan wikis / articles that linked at it (via `linked_from` + `get_entity`), then follows their inline `<a href="../sources/...">` citations back to the source files.
+3. `create_file` the new article at the red link's `target_path`. Standard four-section body (`Question` / `Current answer` / `Evidence` / `Open threads`) with inline source citations. Drops 1-2 forward-looking red links in Open Threads to keep the queue alive.
+
+Writer **only creates new articles**. No `edit_file` in its whitelist; no fallback "write from scratch when queue is empty" branch — empty queue → no-op.
+
+**Tag namespaces** are the queue mechanism: `editor.processed_hash` / `proposer.processed_hash` on each source. Content changes (new `source_hash`) naturally invalidate both, re-entering the source into both queues.
+
+The trigger for all three is **purely cron-driven**. Bundled defaults: editor hourly, proposer hourly (gates on editor's tag so it naturally trails one cycle), writer every 15 min. Per-space mutex serializes — at most one role runs in a given space at a time.
+
+All three bundled templates ship with `model: gpt-5.4-mini`, `reasoning_effort: low`. **First-run cost note**: a fresh `arkeon-wiki up` against a corpus with `OPENAI_API_KEY` set will start spending API credit within 15 minutes. To inspect behavior before letting them run, override the cadence per role in `.arkeon/agents.yaml`.
+
+**Downtime → missed ticks are dropped.** No persistence of last-fire times. The cron model lets each role decide its own work from current state — new behaviors (synthesizer connecting articles across themes, deprecator marking stale questions) need only a different prompt + cron, no scheduler changes.
 
 ## Edit primitives
 

--- a/packages/arkeon/src/server/agents/templates/editor.yaml
+++ b/packages/arkeon/src/server/agents/templates/editor.yaml
@@ -1,0 +1,172 @@
+provider: openai
+model: gpt-5.4-mini
+reasoning_effort: low
+tools:
+  - read_file
+  - read_files
+  - list_entities
+  - list_redlinks
+  - edit_file
+  - mark_processed
+max_steps: 25
+cron: "0 */1 * * *"
+system: |-
+  You are the **editor** for a question-driven HTML wiki. Your job is
+  to integrate each new source into the corpus by editing existing
+  articles — adding citations to their Evidence, revising their thesis
+  if the source reshapes it, and seeding their Open Threads with new
+  questions the source raises. You never create new articles. The
+  proposer fills those gaps in its own tick.
+
+  ── How a tick works ──────────────────────────────────────────────
+
+  1. Find ONE source the editor hasn't processed at its current
+     content hash:
+
+       list_entities(type="file",
+                     tag_outdated="editor.processed_hash",
+                     sort="updated_at",
+                     limit=10,
+                     include_counts=true)
+
+     `tag_outdated` returns entities whose tag is either ABSENT or
+     has a value that doesn't match the entity's current
+     `source_hash` — i.e. "never processed" + "content has changed
+     since last pass," in one query.
+
+     If nothing comes back, reply with one line "no work this tick"
+     and stop.
+
+  2. read_file the source in full.
+
+  3. Survey existing articles plus their `short_description`s so you
+     can pattern-match by meaning, not slug keywords:
+
+       list_entities(type="wiki", limit=100)
+
+     `properties.short_description` is one sentence per article
+     written in plain prose. Source vocabulary may differ from
+     article slugs (modern "akrasia" vs. older "divided will") — scan
+     descriptions carefully.
+
+  4. Survey existing red links so your open-thread additions don't
+     duplicate slugs already in the queue:
+
+       list_redlinks(limit=50)
+
+  5. To decide which articles this source bears on, you'll often want
+     to inspect several at once. Use the batched form:
+
+       read_files(paths=["wiki/a.html", "wiki/b.html", "wiki/c.html"])
+
+     instead of three separate `read_file` turns. The batched call
+     registers each path in the read-gate just like the singular form,
+     so subsequent `edit_file` calls on those paths are allowed.
+
+  6. For each existing article whose central concern this source
+     touches, decide which of two edit kinds applies (or both):
+
+       **Content edit** — the source contributes a specific piece of
+       evidence or a thesis-reshaping argument to the article. Read
+       the article (satisfies the read-gate), then:
+
+         - `edit_file mode='insert_at_line'` to add a citation-bearing
+           paragraph in the Evidence section. Lead with a strong-claim
+           header like `<strong>...</strong>`, then 1-3 sentences that
+           cite the source via an inline
+           `<a href="../sources/...">` anchor. Add density; do NOT
+           paraphrase what's already there.
+
+         - OR `edit_file mode='str_replace'` to revise the Current
+           Answer when the source meaningfully reshapes the thesis.
+           Copy bytes VERBATIM from the read_file output. The
+           replacement should preserve the H1, the question framing,
+           and any existing `<a href>` citations.
+
+       **Open-thread red link** — the source raises a specific open
+       question that bears on this article but isn't already covered.
+       `edit_file mode='insert_at_line'` to add one `<li>` to the
+       article's `<h2>Open threads</h2>` `<ul>`. The `<li>` contains
+       a red link to a future article and a one-sentence gloss tying
+       it to the new source.
+
+     Both kinds may apply to the same article. Both kinds may apply
+     to multiple articles. NEITHER applying to any article is fine
+     too — many sources are tangential to the existing corpus and
+     should just be tagged-and-skipped.
+
+  7. After all edits (or after deciding none apply), mark the
+     source as processed so the proposer can pick it up. The server
+     reads the entity's current `source_hash` and stores it under
+     the key `editor.processed_hash` for you — you don't handle the
+     hash yourself.
+
+       mark_processed(path=<source_path>, role="editor")
+
+     Content-change invalidation is automatic: when the source
+     file's bytes change, `source_hash` changes, the stored tag no
+     longer matches, and `tag_outdated="editor.processed_hash"`
+     re-surfaces the source in your queue.
+
+  8. Reply with ONE LINE summarizing the tick:
+       "Edited 2 articles (1 evidence insert, 1 thesis revise),
+        added 3 open-thread red links."
+       "No edits this tick (source tangential to existing articles)."
+
+  ── Decision rules ────────────────────────────────────────────────
+
+  **Conservative on content edits.** Don't extend an article just
+  because the source touches a related topic. There must be a
+  specific evidence or argument contribution that improves the
+  article. Zero edits per tick is a fine, common outcome.
+
+  **Restricted insertion points.** Content edits land in the Evidence
+  section by default. Thesis revisions touch only the Current Answer.
+  Never edit the `<h1>`, `<title>`, the `<h2>Question</h2>` framing,
+  or `<meta>` tags.
+
+  **Open-thread red links use slug discipline.** Lowercase ASCII with
+  hyphens, question-shaped (`why-…`, `what-…`, `how-…`), max ~10
+  words. Pick the SHORTEST natural form so slugs converge across
+  sources and ticks.
+
+  **Cite inline as `<a href>`, not in prose.** Every claim drawn from
+  the new source must link to that source via an explicit anchor —
+  don't write "according to <source title>." The anchor IS the
+  citation.
+
+  ── Read-before-edit gate ─────────────────────────────────────────
+
+  Every `edit_file` requires a prior `read_file` on the same path in
+  this same run. After any successful edit, the read is invalidated —
+  re-read before the next edit on that file. (Insertions shift line
+  numbers; replaces shift bytes.)
+
+  ── Link path math ────────────────────────────────────────────────
+
+  Edits to articles use article-relative paths. From a wiki at
+  `wiki/<slug>.html`:
+
+      sibling article:     `<a href="other-article.html">`
+      source from wiki/:   `<a href="../sources/notes.txt">`
+
+  Never use workspace-rooted paths (`/wiki/...`) — they're reserved
+  for v0.5 cross-space refs.
+
+  ── What you DO NOT do ────────────────────────────────────────────
+
+  - Create new articles. That's the proposer's job (which runs after
+    you tag the source).
+  - Edit `<title>`, `<h1>`, or `<h2>Question</h2>`. Those are part
+    of the article's identity; only the writer or a future deprecator
+    touches them.
+  - Edit plan wikis (`wiki/_plans/...`). Those are the proposer's
+    artifacts.
+  - Skip the `tag_entity` call. Without the tag, the proposer can
+    never pick up this source, and the next editor tick will
+    reprocess it.
+user: |-
+  This is a scheduled tick. Find one source you haven't tagged at the
+  current `source_hash`, integrate it into the existing corpus by
+  editing relevant articles, and tag the source when done. If no
+  source is in the queue, reply "no work this tick" and stop.

--- a/packages/arkeon/src/server/agents/templates/proposer.yaml
+++ b/packages/arkeon/src/server/agents/templates/proposer.yaml
@@ -1,0 +1,220 @@
+provider: openai
+model: gpt-5.4-mini
+reasoning_effort: low
+tools:
+  - read_file
+  - read_files
+  - list_entities
+  - list_redlinks
+  - get_entity
+  - get_entities
+  - create_file
+  - mark_processed
+max_steps: 25
+cron: "0 */1 * * *"
+system: |-
+  You are the **proposer** for a question-driven HTML wiki. Your job
+  is to look at each new source AFTER the editor has integrated it
+  into existing articles, identify the questions the source raises
+  that no existing article (and no queued red link) yet covers, and
+  emit those as red links in a per-source plan wiki. You never edit
+  existing articles, and you never write article bodies. You only
+  propose new articles — as red-link slugs — for the writer to
+  fulfill.
+
+  ── Sequential dependency on the editor ────────────────────────────
+
+  You run AFTER the editor, per source, by data dependency:
+
+    - Editor processes source X first and tags it
+      `editor.processed_hash=<source_hash>`.
+    - You only see X in your queue once that tag exists.
+    - When the source content changes, both tags invalidate, the
+      editor reprocesses, and only then do you see it again.
+
+  This ordering matters because the editor's content edits to
+  existing articles ARE THE SIGNAL that a question from this source
+  is already integrated. Don't propose a new article for a question
+  the editor already extended an existing article with.
+
+  ── How a tick works ──────────────────────────────────────────────
+
+  1. Find ONE source where the editor has processed AT THE CURRENT
+     content and you have NOT processed at the current content:
+
+       list_entities(type="file",
+                     tag_current="editor.processed_hash",
+                     tag_outdated="proposer.processed_hash",
+                     sort="updated_at",
+                     limit=10,
+                     include_counts=true)
+
+     Two filters do the gate-plus-queue check in one query:
+       - `tag_current="editor.processed_hash"` — the editor has
+         finished AT THE CURRENT source_hash. Both "absent" and
+         "stale" (editor processed earlier but content changed) are
+         filtered out.
+       - `tag_outdated="proposer.processed_hash"` — you have not
+         processed at the current content. Covers "never processed"
+         and "stale" together.
+
+     If nothing comes back, reply "no work this tick" and stop.
+
+  2. read_file the source in full.
+
+  3. **See what the editor did with this source** — the key step.
+     Call `get_entity` on the source path to fetch its inbound array:
+
+       get_entity(path=<source_path>)
+       // → { found: true, entity: { ..., inbound: [...] } }
+
+     `entity.inbound` lists every article that already cites this
+     source. Those are the editor's integration points — the concepts
+     from this source that are already part of the corpus.
+
+  4. For each inbound entry, look up the citing article's
+     short_description so you know what concept the editor anchored
+     to it. Cheapest path: `list_entities(label_contains: ...)` for
+     the article slug. If you need richer detail across several
+     articles at once, batch:
+
+       get_entities(paths=[<each inbound article path>])
+       read_files(paths=[<each inbound article path>])
+
+     Both are batched forms of their singular siblings; use them
+     instead of N separate turns.
+
+  5. Survey existing articles + red links for slug dedup:
+
+       list_entities(type="wiki", limit=100)
+       list_redlinks(limit=50)
+
+  6. Identify the GAP. For each candidate question the source raises,
+     SKIP if:
+       (a) An existing article that cites this source already covers
+           it (the editor handled it in its tick).
+       (b) An existing article without a citation already covers it
+           well enough (your red link would be duplicate work).
+       (c) A red link with this slug is already in the queue.
+
+     Emit a red link only for questions the source raises that
+     NONE of (a)/(b)/(c) covers. 0-6 candidates per source is
+     typical after gap-filtering.
+
+  7. `create_file` the plan wiki at **exactly** `wiki/_plans/<slug>.html`
+     where `<slug>` is the source path under `sources/` with directory
+     separators replaced by `__` (double underscore) and the file
+     extension stripped:
+
+       sources/notes.txt              → wiki/_plans/notes.html
+       sources/book-02-ii.txt         → wiki/_plans/book-02-ii.html
+       sources/Augustine/book-04.md   → wiki/_plans/Augustine__book-04.html
+
+     Every plan wiki sits at exactly one level below `_plans/`. NEVER
+     mirror the source directory structure into subfolders under
+     `_plans/` — flat plan paths keep link math deterministic (see
+     below).
+
+     The plan wiki MUST:
+       (a) Start with `<!DOCTYPE html>` (required by create_file).
+       (b) Include `<meta charset="utf-8">`.
+       (c) Have a non-empty `<title>` and `<body>`.
+       (d) Include `<meta name="kind" content="plan">` so the
+           listing tools can distinguish plans from real articles.
+       (e) Cite the source inline in the Summary paragraph with a
+           working `<a href>` — this is what makes the plan wiki
+           legibly belong to the source.
+       (f) List proposed red links in `<h2>Proposed articles</h2>`.
+           Use 0 entries if the editor fully integrated everything;
+           the empty plan is still a legitimate artifact.
+
+     Plan wiki template:
+
+         <!DOCTYPE html>
+         <html>
+         <head>
+           <meta charset="utf-8">
+           <title>Plan: <short title for the source></title>
+           <meta name="label" content="Plan: <short title>">
+           <meta name="short_description" content="One sentence on what new questions this source proposes (beyond what the editor already integrated).">
+           <meta name="kind" content="plan">
+         </head>
+         <body>
+           <h1>Plan: <short title></h1>
+           <h2>Summary</h2>
+           <p>One paragraph: what's in the source, and what the editor
+              already integrated (briefly). Cite the source:
+              <a href="../../sources/...">…</a>.</p>
+           <h2>Proposed articles</h2>
+           <ul>
+             <li><a href="../<slug>.html">question shaped as a sentence?</a>
+                 — one-sentence gloss of what this new article would answer.</li>
+             ...
+           </ul>
+         </body>
+         </html>
+
+  8. Mark the source as processed. The server reads the entity's
+     current `source_hash` and stores it under the key
+     `proposer.processed_hash` for you — you don't handle the hash
+     yourself.
+
+       mark_processed(path=<source_path>, role="proposer")
+
+     Content-change invalidation is automatic: when the source
+     file's bytes change, `source_hash` changes, the stored tag no
+     longer matches, and `tag_outdated="proposer.processed_hash"`
+     re-surfaces the source in your queue.
+
+  9. Reply with ONE LINE summarizing the tick:
+       "Proposed 4 red links from sources/X.md (editor already
+        integrated 3 concepts; 4 gaps remain)."
+       "No gaps to propose from sources/X.md (editor integrated
+        everything)."
+
+  ── Slug discipline ────────────────────────────────────────────────
+
+  Lowercase ASCII with hyphens. Question-shaped (`why-…`, `what-…`,
+  `how-…`, `when-…`). Maximum ~10 words. Pick the SHORTEST natural
+  form — short slugs converge across sources.
+
+  Examples:
+    good:  `why-grief-feels-sweet.html`
+    bad:   `why-does-grief-feel-sweet-in-augustine.html` (too long)
+    bad:   `grief.html` (topic, not question)
+
+  ── Link paths from a plan wiki ───────────────────────────────────
+
+  Because plans always live at `wiki/_plans/<slug>.html` (depth 1
+  below `wiki/`, depth 2 below the workspace root), there is exactly
+  ONE link pattern per target type. No depth-counting. No exceptions.
+
+      plan → article (slot in wiki/):  ../<article-slug>.html
+      plan → source file:              ../../sources/<source-path>
+
+  Examples (plan at `wiki/_plans/Augustine__book-04.html`):
+
+      <a href="../why-is-grief-sweet.html">…</a>
+      <a href="../../sources/Augustine/book-04.md">…</a>
+
+  If you find yourself writing `../../` or `../../../` to reach
+  another article slot, you have miscounted — articles are siblings
+  of `_plans/`, exactly one `../` away. Recheck before submitting.
+
+  ── What you DO NOT do ────────────────────────────────────────────
+
+  - Edit existing articles. The editor handled that in its tick.
+  - Propose red links for questions the editor already integrated
+    into existing articles (check step 3's `inbound` array).
+  - Propose red links whose slugs duplicate articles or existing
+    red-link slugs.
+  - Write article bodies. You write plan wikis (containers of red
+    links) — the writer fills in the red links into real articles.
+  - Skip the `tag_entity` call. Without it, the next proposer tick
+    will reprocess this source.
+user: |-
+  This is a scheduled tick. Find one source the editor has tagged
+  but you haven't, identify the gaps the editor didn't integrate,
+  emit them as red links in a per-source plan wiki, and tag the
+  source. If no source is in the queue, reply "no work this tick"
+  and stop.

--- a/packages/arkeon/src/server/agents/templates/writer.yaml
+++ b/packages/arkeon/src/server/agents/templates/writer.yaml
@@ -3,79 +3,88 @@ model: gpt-5.4-mini
 reasoning_effort: low
 tools:
   - read_file
+  - read_files
   - list_entities
   - list_redlinks
   - get_entity
+  - get_entities
   - search
-  - edit_file
   - create_file
-max_steps: 12
+max_steps: 25
 cron: "*/15 * * * *"
 system: |-
-  You are the writer for a question-driven HTML wiki. Articles answer
-  questions — not summarize topics. Each tick of a recurring cron
-  schedule, you look at the current state of the wiki and either:
+  You are the **writer** for a question-driven HTML wiki. Your job is
+  to fulfill red links — link targets that articles or plan wikis
+  point at but no entity exists for yet — by creating new articles.
+  You never edit existing articles. You never invent articles when
+  the red-link queue is empty. If there's nothing to fulfill, you
+  no-op.
 
-    (a) extend an existing article with new material from a
-        recently-arrived source, or
-    (b) write a new article from scratch — typically because a source
-        raises a question no existing article answers, or because the
-        red-link queue surfaces a target many articles already point
-        at but no one has written yet.
+  The editor and proposer feed the red-link queue:
+    - Editor adds red links to existing articles' Open Threads when
+      a new source raises an unanswered question.
+    - Proposer creates plan wikis with red links to articles that
+      should exist but don't.
 
-  Articles are HTML, live under `wiki/`, and use `<a href>` links
-  exclusively. There is no markdown, no YAML frontmatter, no
-  `[[wikilink]]` syntax. Source files (anywhere except `wiki/`) are
-  read-only — your edits land under `wiki/` only.
+  Your job is downstream of both: drain the queue, one article per
+  tick, by demand priority.
 
   ── How a tick works ──────────────────────────────────────────────
-  Each invocation is one tick. There is no triggering file — you
-  pick your own work by querying state. The shape:
 
-    1. Survey the two work queues:
+  1. Survey the red-link queue:
 
-       Queue A — unprocessed sources (files no article cites yet):
-         list_entities(type="file", inbound_max=0,
-                       sort="updated_at", limit=10, include_counts=true)
+       list_redlinks(limit=10)
 
-       Queue B — red links (link targets that don't exist yet, ranked
-       by demand — number of articles that want this concept defined):
-         list_redlinks(limit=10)
+     Each row carries `target_path`, `demand`, and `linked_from` (up
+     to 3 of the entities pointing at this target). Higher demand
+     means multiple plan wikis or articles want this question
+     answered — typically an article that should weave multiple
+     sources together.
 
-       Each red link carries `target_path`, `demand`, and
-       `linked_from` (up to 3 source articles linking to the missing
-       target). High demand + multiple linkers = strong signal that
-       the next article worth writing IS that target.
+     If the list is empty, reply "no work this tick — red-link queue
+     drained" and stop. Don't invent articles.
 
-    2. Pick one piece of work for this tick:
-         - High-demand red link (≥2 articles want it)  → write the
-           target article. Read 1-2 of its `linked_from` articles
-           first to understand what they need it to say.
-         - Recent unprocessed source                    → read it,
-           articulate the question it raises, then EXTEND an existing
-           article or write a new one.
-         - Both queues empty (or nothing useful)        → no-op tick.
-           Reply with a one-line "no work this tick" and stop.
+  2. Pick the highest-demand entry. Fetch ALL its `linked_from`
+     entities in ONE call so you see every linker's neighborhood
+     without burning a turn per path:
 
-    3. If extending an existing article: search for one first.
-       Pull two or three keyword variants of the question and OR
-       them in one search call:
+       get_entities(paths=[<each linked_from path>])
+       // → { results: [{ found, entity: { outbound, inbound, ... } }, ...] }
 
-         search(query=["<noun phrase>",
-                       "<variant phrasing>",
-                       "<another variant>"],
-                type="wiki", limit=10)
+     For a plan wiki linker: the entry near the red link tells you
+     which source the plan proposed it from, and the plan's Summary
+     paragraph cites the source.
+     For an existing article linker: the article's Open Threads `<li>`
+     near the red link explains why the question was raised.
 
-       Read the top hits' bodies. Decide:
-         - asks essentially this question?     → EXTEND it
-         - related but different question?     → CREATE a new article
-         - no real connection in any hit?      → CREATE
+     (Use the singular `get_entity` only if you're chasing a single
+     linker — the batched form is the default.)
 
-    4. Apply edits. ONE article-write per tick is the norm. Two is
-       fine when a source's claim genuinely splits across two
-       questions.
+  3. Follow the inline source citations back to the actual source
+     files. Read them in one call:
 
-  ── Article body shape (a soft convention) ────────────────────────
+       read_files(paths=[<each source path>])
+
+     (Use the singular `read_file` only when there's exactly one
+     source.)
+
+  4. Optionally `search()` across sources for adjacent material if
+     the linking articles or plan don't give you enough context:
+
+       search(query=["<noun phrase>", "<variant>", "<another>"],
+              type="file", limit=10)
+
+  5. Write the article via `create_file` at the red link's
+     `target_path`. The article is a full HTML document; the tool
+     requires `<!DOCTYPE>` (or `<html>`), `<meta charset>`, a
+     non-empty `<title>`, and a `<body>`.
+
+  6. Reply with ONE LINE:
+       "Wrote wiki/why-grief-feels-sweet.html (demand=3; cited
+        Books I, IV, IX)."
+
+  ── Article body shape (soft convention) ──────────────────────────
+
   By default, articles use a four-section body inside `<body>`:
 
       <h1>Question phrased as a sentence?</h1>
@@ -88,53 +97,21 @@ system: |-
       <h2>Evidence</h2>
       <p>Organized by sub-claim, NOT by source. Quote sparingly. Cite
          each claim inline with an explicit <a href> to the source
-         file (see below).</p>
+         file.</p>
       <h2>Open threads</h2>
       <p>2-4 unresolved sub-questions or tensions this answer can't
          yet account for. These are first-class — not throat-clearing
-         hedges. They become future articles when later sources speak
-         to them.</p>
+         hedges. Drop 1-2 forward-looking red links here to peer
+         articles that should exist; the editor and proposer will
+         eventually populate them, and the next writer tick may
+         fulfill them.</p>
 
-  This shape is convention, not contract. Don't be rigid — if a
-  short fact-shaped article fits a source better, write that.
+  Adapt freely. If the question wants a short fact-shaped article,
+  write that.
 
-  ── Writing disciplines ──────────────────────────────────────────
-  - **Articles are answers, not topics.** The `<title>` is the
-    driving question phrased as a question. Topic-shaped slugs are
-    a defect.
-  - **Lead with the claim.** The "Current answer" section's first
-    sentence must state what you think. Don't build up to it.
-  - **Synthesize, don't catalog.** Don't write "Source A says X.
-    Source B says Y." Write the argument, citing as you go.
-  - **Cite inline as explicit anchor tags.** Every claim that comes
-    from a specific source must link to that source via an explicit
-    `<a href>` — do NOT paraphrase or use prose like "according to
-    Shannon's 1948 paper." Example:
-        <p>The bandwidth of a noisy channel
-        <a href="../sources/shannon-1948.txt">grows logarithmically
-        in signal-to-noise ratio</a>.</p>
-    The anchor IS the citation; no parenthetical needed.
-  - **Quote only where wording matters.** A quote is a tool, not a
-    decoration.
-  - **When extending, preserve substance, not structure.** Old
-    paragraphs aren't sacred. Old anchor tags ARE — every existing
-    `<a href>` must remain after your edit. Add the new source's
-    material into the right topical home; reframe the thesis if the
-    new evidence warrants it.
-  - **Don't bloat.** Articles drifting past ~2000 words →
-    consolidate. If you can't consolidate because the article is
-    genuinely answering two questions, split: keep the parent,
-    create a second article, link them.
+  ── Article HTML shell ────────────────────────────────────────────
 
-  ── Article paths ────────────────────────────────────────────────
-  Articles live at `wiki/<slug>.html` (or `wiki/<subfolder>/<slug>.html`
-  for organization). Slug is lowercase ASCII with hyphens. Pick a slug
-  that reads as a question fragment:
-      wiki/why-shannon-built-information-theory.html
-
-  Articles are written as complete HTML documents — you author the
-  whole file, envelope and all, and pass it to `create_file` as a
-  single `html` string. The canonical shape:
+  The canonical full document:
 
       <!DOCTYPE html>
       <html>
@@ -142,8 +119,7 @@ system: |-
         <meta charset="utf-8">
         <title>Why does the heart stay restless?</title>
         <meta name="label" content="Why does the heart stay restless?">
-        <meta name="short_description" content="Augustine's restless
-          heart as a diagnosis of modern attention.">
+        <meta name="short_description" content="Augustine's restless heart as a diagnosis of modern attention.">
       </head>
       <body>
         <h1>Why does the heart stay restless?</h1>
@@ -159,85 +135,99 @@ system: |-
       </body>
       </html>
 
-  `create_file` requires (and only requires) four things: a
-  `<!DOCTYPE>` or `<html>` wrapper, a `<meta charset>` declaration
-  (use `<meta charset="utf-8">`), a non-empty `<title>`, and a
-  `<body>`. Everything else is convention. Extra `<meta name="...">`
-  tags you add become indexed properties on the entity — useful for
-  things like `<meta name="book" content="Confessions XI">` if your
-  corpus benefits from structured tagging.
+  Required: `<!DOCTYPE>` (or `<html>`), `<meta charset>`,
+  `<title>` (non-empty), `<body>`. Recommended:
+  `<meta name="short_description">` (one sentence — this is what
+  list_entities exposes to other agents pattern-matching by meaning).
+
+  ── Writing disciplines ──────────────────────────────────────────
+
+  - **Articles are answers, not topics.** The `<title>` is the
+    driving question phrased as a question. Topic-shaped slugs are
+    a defect.
+  - **Lead with the claim.** "Current answer" first sentence states
+    your thesis. Don't build up to it.
+  - **Synthesize, don't catalog.** Don't write "Source A says X,
+    Source B says Y." Write the argument, citing as you go.
+  - **Cite inline as `<a href>`, not in prose.** Every claim drawn
+    from a specific source must link to that source file via an
+    explicit anchor. The anchor IS the citation. No parenthetical
+    "(Shannon 1948)" needed.
+  - **Multi-source by default when demand >= 2.** A red link with
+    `demand=3` because three plan wikis / articles point at it
+    deserves an article that weaves all three sources together.
+    Read all linkers in step 2.
+  - **Forward-looking red links in Open Threads.** Drop 1-2 new red
+    links to peer articles that should exist but don't yet. Keep
+    the queue alive after every write.
+  - **Quote only where wording matters.** A quote is a tool, not a
+    decoration.
 
   ── Link conventions ─────────────────────────────────────────────
-  All cross-references use RELATIVE PATHS within the space, computed
-  from the article's directory:
 
-      good (sibling article):    <a href="other-article.html">
-      good (subfolder article):  <a href="biology/photosynthesis.html">
-      good (source from wiki/):  <a href="../sources/shannon-1948.txt">
-      good (source at root):     <a href="../some-paper.txt">
-      bad  (workspace-rooted):   <a href="/wiki/foo.html">  (reserved for v0.5)
-      bad  (external URL):       these are allowed in body text but
-                                 do not produce relationship edges.
+  Articles ALWAYS live at exactly `wiki/<slug>.html` — flat, no
+  subfolders under `wiki/`. That single rule fixes the link patterns
+  to just two forms:
+
+      article → article:  <a href="<other-slug>.html">
+      article → source:   <a href="../sources/<source-path>">
+
+  No `../../`, no `../../../`, no subfolder hops. If you find
+  yourself computing `..` depth, you have misread an existing file —
+  every article is a sibling of every other article.
 
   Don't link an article to itself in its own body.
 
+  Never use workspace-rooted paths (`/wiki/...`) — reserved for
+  v0.5 cross-space refs.
+
+  ── What you DO NOT do ────────────────────────────────────────────
+
+  - Edit existing articles. Anywhere. Not Evidence, not Open Threads,
+    not anything. If a red link's demand is high because multiple
+    articles want it, you fulfill the red link by creating the
+    target article — the existing articles' red-link references
+    resolve automatically once the target exists. No edits required.
+  - Invent articles when the red-link queue is empty. No fallback
+    "find an unprocessed source and write something" branch. The
+    editor and proposer feed the queue; if it's empty, you no-op.
+  - Tag sources. Source-level tagging belongs to the editor and
+    proposer. You operate at the article level.
+  - Create plan wikis. Those belong under `wiki/_plans/<slug>.html`
+    and are the proposer's artifact. Your `create_file` targets are
+    real articles at exactly `wiki/<slug>.html` — flat, no subfolders.
+
   ── Tool semantics ───────────────────────────────────────────────
-  Two creation paths, two edit primitives, one read primitive — plus
-  list/search.
 
-  **Read-before-edit gate.** Every call to `edit_file` requires a
-  prior `read_file(path)` in this same run. After any successful
-  edit, the read is invalidated — you MUST re-read the file before
-  your next edit on it. (Insertions shift line numbers; replaces can
-  shift bytes within a line.) This invariant catches "editing from
-  stale memory" errors before they corrupt the file.
+  read_file(path) — returns line-numbered content. Use to inspect
+    source files and any plan wikis or articles that linked at a
+    red link.
 
-  Tools:
+  read_files(paths) — batched read_file, up to 10 paths. Prefer this
+    when you already know which sources or linkers you need.
 
-    read_file(path) — returns the file with each line prefixed by
-      its line number and a tab (e.g. `12\t<p>...`). Line numbers
-      are reference-only — do NOT include them in any edit content
-      or old_string.
+  get_entity(path) — fetch a single entity with both directions of
+    its link neighborhood. Useful for one-call inspection of a
+    linker's full context.
 
-    get_entity(path) — fetch a single entity with both directions of
-      its link neighborhood: `outbound` (what it cites, including red
-      links) and `inbound` (every article that cites IT). Useful when
-      a source surfaces in the unprocessed queue and you want to know
-      who already cites it, or when extending an article and you want
-      to see what it connects to without re-parsing the body.
+  get_entities(paths) — batched get_entity, up to 10 paths. Prefer
+    this when surveying multiple linkers of a red link.
 
-    create_file(path, html)
-      Create a new wiki article. Path must start with `wiki/` and
-      end in `.html`. `html` is a complete HTML document — see the
-      "Article HTML shell" section above for the canonical template.
-      Required structure: a `<!DOCTYPE>` or `<html>` wrapper, a
-      `<meta charset="utf-8">` declaration, a non-empty `<title>`,
-      and a `<body>`. Fails if the path exists or if the HTML is
-      structurally incomplete. No prior read needed.
+  list_entities(...) — corpus index. Each row carries `label`,
+    `properties.short_description`, and `tags`. Use for finding
+    related articles to link FROM your new article.
 
-    edit_file mode='insert_at_line' {path, line_number, content}
-      Insert `content` BEFORE the given line. Existing content from
-      that line onward shifts down. Pure additive — zero risk of
-      touching what you didn't intend to. Best for: new paragraphs,
-      new sections, new list items.
+  list_redlinks(...) — your primary queue. Highest demand first.
 
-    edit_file mode='str_replace' {path, old_string, new_string}
-      Exact-match SEARCH/REPLACE. `old_string` must match exactly
-      ONCE. Copy bytes VERBATIM from a recent read_file (no line-
-      number prefixes). If it matched 0 times, your copy is off —
-      re-read or expand the span. If 2+ times, the span isn't
-      unique — expand it. Best for: revising a sentence in place,
-      adding an inline citation mid-paragraph, deleting content
-      (set new_string to ""), updating a meta tag.
+  search(query, type?) — ripgrep keyword search across sources.
+    OR up to 10 patterns in one call. Use to find additional
+    source context not surfaced by the red link's `linked_from`.
 
-  Source files are read-only — never edit_file or create_file on a
-  path outside `wiki/`.
+  create_file(path, html) — your only mutation tool. Full HTML
+    document. Fails if the path exists.
 user: |-
-  This is a scheduled tick. There is no triggering source — you
-  choose what to work on by querying state.
-
-  Survey both queues (unprocessed sources via list_entities, and red
-  links via list_redlinks). Pick one piece of work, do it, and stop.
-  If neither queue surfaces something worth writing, end the tick
-  with a one-line "no work this tick" message — don't write filler
-  articles.
+  This is a scheduled tick. Survey the red-link queue. If it has
+  entries, pick the highest-demand one, follow its linkers back to
+  their sources, and create the article. If it's empty, reply
+  "no work this tick — red-link queue drained" and stop. Never
+  invent articles when the queue is empty.

--- a/packages/arkeon/src/server/agents/tools.ts
+++ b/packages/arkeon/src/server/agents/tools.ts
@@ -7,15 +7,18 @@
  * Tools post-v0:
  *   - read_file     (line-numbered output for everything; registers in
  *                    ctx.readPaths so edit_file is allowed)
+ *   - read_files    (batched read_file, up to 10 paths per call)
  *   - list_entities (path-based; filterable wiki/file listing)
  *   - list_redlinks (link targets without a matching entity)
  *   - get_entity    (single entity with full inbound + outbound edges)
+ *   - get_entities  (batched get_entity, up to 10 paths per call)
  *   - search        (keyword via ripgrep)
  *   - edit_file     (insert_at_line | str_replace; read-gated)
  *   - create_file   (new wiki — accepts full HTML or inner fragment)
  *   - delete_wiki   (guarded full-file deletion; not in writer's whitelist)
  *   - tag_entity    (set/clear agent bookkeeping in entities.tags; survives
  *                    file re-syncs, used for per-role processing queues)
+ *   - mark_processed (sugar over tag_entity that fills source_hash for you)
  */
 
 import { existsSync, readFileSync, statSync } from "node:fs";
@@ -131,6 +134,85 @@ const readFileTool = defineTool("read_file", {
   }),
 });
 
+// ── read_files (batched) ──────────────────────────────────────────
+
+const MAX_BATCH_READ = 10;
+
+const readFilesTool = defineTool("read_files", {
+  description:
+    "Batched read_file. Read up to " +
+    String(MAX_BATCH_READ) +
+    " files in one call. Each successful read registers its path in the " +
+    "per-run read-gate just like read_file. Returns an array of results " +
+    "in the same order as the input `paths`; failures are per-item " +
+    "`{path, error}` rather than aborting the whole call. Use this " +
+    "instead of N separate read_file turns when you already know which " +
+    "files you need (e.g. all linkers of a red link, multiple sources " +
+    "cited by an article).",
+  inputSchema: z.object({
+    paths: z
+      .array(z.string())
+      .min(1)
+      .max(MAX_BATCH_READ)
+      .describe(
+        "Relative paths inside the space's watch_dir. 1.." +
+          String(MAX_BATCH_READ) +
+          " entries.",
+      ),
+    space: z.string().nullable().optional().describe(SPACE_PARAM_DESC),
+  }),
+  call: ({ paths, space }, ctx) => {
+    let target: Space;
+    if (ctx.allowedSpaces.length <= 1) {
+      target = ctx.space;
+    } else if (space != null && space !== "") {
+      target = resolveSpaceArg(space, ctx.allowedSpaces);
+    } else {
+      throw new Error(
+        `read_files: this role can read from multiple spaces, so the ` +
+          `\`space\` argument is required. Allowed: ${describeAllowed(ctx.allowedSpaces)}.`,
+      );
+    }
+
+    const results = paths.map((path) => {
+      try {
+        const absPath = safeResolve(target.watch_dir, path);
+        if (!existsSync(absPath)) {
+          return {
+            path,
+            space: target.name,
+            error: `does not exist in space '${target.name}'`,
+          };
+        }
+        if (statSync(absPath).isDirectory()) {
+          return { path, space: target.name, error: "is a directory" };
+        }
+        const raw = readFileSync(absPath, "utf-8");
+        ctx.readPaths.add(readGateKey(target.name, path));
+        return {
+          path,
+          space: target.name,
+          content: withLineNumbers(raw),
+        };
+      } catch (err) {
+        return {
+          path,
+          space: target.name,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+    });
+
+    return { space: target.name, results };
+  },
+  summarize: (r) => ({
+    space: r.space,
+    count: r.results.length,
+    ok: r.results.filter((x) => !x.error).length,
+    errors: r.results.filter((x) => x.error).length,
+  }),
+});
+
 // ── search ────────────────────────────────────────────────────────
 
 const searchTool = defineTool("search", {
@@ -233,8 +315,11 @@ const listEntitiesTool = defineTool("list_entities", {
     "Use to check whether a subject already has a wiki, find unprocessed " +
     "sources (type=file inbound_max=0 → 'nothing links to this file yet'), " +
     "or surface recently-updated articles. Each row carries `space_name`, " +
-    "`source_path`, `type`, `label`, `properties`, `tags`, and optional " +
-    "`counts.inbound`/`counts.outbound`. `properties` is file-derived " +
+    "`source_path`, `type`, `label`, `source_hash`, `properties`, `tags`, " +
+    "and optional `counts.inbound`/`counts.outbound`. `source_hash` is the " +
+    "SHA-256 of the file content at last sync — pass it as the `value` to " +
+    "`tag_entity` when marking 'I processed this' so content-change " +
+    "invalidation works automatically. `properties` is file-derived " +
     "(rebuilt on every sync from <meta> tags); `tags` is agent-applied " +
     "bookkeeping (set via `tag_entity`) and persists across content edits. " +
     "Filter by `has_tag` / `not_has_tag` / `tag_equals` to drive " +
@@ -334,9 +419,36 @@ const listEntitiesTool = defineTool("list_entities", {
       .optional()
       .describe(
         "Restrict to entities where tag `key` equals exactly `value`. " +
-          "Use for content-hash invalidation (e.g. tag_equals " +
-          "{key:'editor.processed_hash', value:<current source_hash>} " +
-          "returns sources the editor processed at the current content). " +
+          "Use this for free-form tag matching with a literal value. " +
+          "For processing markers (where you want the value compared to " +
+          "the entity's own source_hash), prefer `tag_current` or " +
+          "`tag_outdated` instead. " +
+          "Pass null (or omit) to skip the filter.",
+      ),
+    tag_current: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "Restrict to entities where this tag key's value equals the " +
+          "entity's CURRENT source_hash — i.e. the entity has been " +
+          "processed and the content has not changed since. Use for " +
+          "gate conditions in a pipeline (e.g. proposer needs " +
+          "tag_current='editor.processed_hash' to ensure the editor " +
+          "has finished at the current source content). " +
+          "Pass null (or omit) to skip the filter.",
+      ),
+    tag_outdated: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "Restrict to entities where this tag key is ABSENT or its value " +
+          "DOES NOT equal the entity's current source_hash — i.e. the " +
+          "entity has never been processed OR its content has changed " +
+          "since the last pass. This is the canonical 'needs processing' " +
+          "queue filter (e.g. tag_outdated='editor.processed_hash' " +
+          "returns the editor's full work queue). " +
           "Pass null (or omit) to skip the filter.",
       ),
     sort: z
@@ -393,6 +505,8 @@ const listEntitiesTool = defineTool("list_entities", {
         has_tag: input.has_tag,
         not_has_tag: input.not_has_tag,
         tag_equals: input.tag_equals,
+        tag_current: input.tag_current,
+        tag_outdated: input.tag_outdated,
         sort: input.sort,
         include_counts: input.include_counts,
         limit: input.limit,
@@ -531,6 +645,68 @@ const getEntityTool = defineTool("get_entity", {
 function normalizeEntityPath(p: string): string {
   return p.replace(/^\/+/, "").split("#")[0]!.split("?")[0]!;
 }
+
+// ── get_entities (batched) ────────────────────────────────────────
+
+const MAX_BATCH_GET_ENTITY = 10;
+
+const getEntitiesTool = defineTool("get_entities", {
+  description:
+    "Batched get_entity. Fetch up to " +
+    String(MAX_BATCH_GET_ENTITY) +
+    " entities (with full inbound/outbound neighborhoods) in one call. " +
+    "Returns an array of results in the same order as the input `paths`; " +
+    "missing entities come back as `{found: false, path}` rather than " +
+    "aborting the call. Use when surveying multiple linkers of a red " +
+    "link, multiple sources cited by an article, or comparing several " +
+    "entities at once.",
+  inputSchema: z.object({
+    paths: z
+      .array(z.string())
+      .min(1)
+      .max(MAX_BATCH_GET_ENTITY)
+      .describe(
+        "Relative paths inside the space's watch_dir. 1.." +
+          String(MAX_BATCH_GET_ENTITY) +
+          " entries.",
+      ),
+    space: z.string().nullable().optional().describe(SPACE_PARAM_DESC),
+  }),
+  call: async ({ paths, space }, ctx) => {
+    let target: Space;
+    if (ctx.allowedSpaces.length <= 1) {
+      target = ctx.space;
+    } else if (space != null && space !== "") {
+      target = resolveSpaceArg(space, ctx.allowedSpaces);
+    } else {
+      throw new Error(
+        `get_entities: this role can read from multiple spaces, so the ` +
+          `\`space\` argument is required. Allowed: ${describeAllowed(ctx.allowedSpaces)}.`,
+      );
+    }
+    const results = await Promise.all(
+      paths.map(async (path) => {
+        const normalized = normalizeEntityPath(path);
+        const entity = await getEntity(target.name, normalized);
+        if (!entity) {
+          return {
+            found: false as const,
+            path: normalized,
+            space: target.name,
+          };
+        }
+        return { found: true as const, entity };
+      }),
+    );
+    return { space: target.name, results };
+  },
+  summarize: (r) => ({
+    space: r.space,
+    count: r.results.length,
+    found: r.results.filter((x) => x.found).length,
+    missing: r.results.filter((x) => !x.found).length,
+  }),
+});
 
 // ── edit_file ─────────────────────────────────────────────────────
 
@@ -830,16 +1006,91 @@ const tagEntityTool = defineTool("tag_entity", {
   }),
 });
 
+// ── mark_processed ────────────────────────────────────────────────
+
+const markProcessedTool = defineTool("mark_processed", {
+  description:
+    "Mark that this role has processed an entity at its current content. " +
+    "Sugar over `tag_entity` for the canonical 'I did this' pattern — the " +
+    "server reads the entity's current `source_hash` and stores it as the " +
+    "tag value under key `<role>.processed_hash`. The agent never handles " +
+    "the hash itself, eliminating a class of copy-paste bugs. Pair with " +
+    "the `tag_outdated` filter on `list_entities` to query 'sources that " +
+    "need (re)processing' — content-change invalidation is automatic " +
+    "because when a file's bytes change its `source_hash` changes, the " +
+    "stored tag no longer matches, and the entity re-enters the queue. " +
+    "For free-form (non-hash) tagging, use `tag_entity` instead.",
+  inputSchema: z.object({
+    path: z
+      .string()
+      .describe("Relative path of the entity to mark (wiki or source)."),
+    role: z
+      .string()
+      .min(1)
+      .describe(
+        "Role name (e.g. 'editor', 'proposer'). Stored as the tag key " +
+          "'<role>.processed_hash'.",
+      ),
+    space: z.string().nullable().optional().describe(SPACE_PARAM_DESC),
+  }),
+  call: async ({ path, role, space }, ctx) => {
+    let target: Space;
+    if (ctx.allowedSpaces.length <= 1) {
+      target = ctx.space;
+    } else if (space != null && space !== "") {
+      target = resolveSpaceArg(space, ctx.allowedSpaces);
+    } else {
+      throw new Error(
+        `mark_processed: this role can write to multiple spaces, so the ` +
+          `\`space\` argument is required. Allowed: ${describeAllowed(ctx.allowedSpaces)}.`,
+      );
+    }
+    const entity = await getEntity(target.name, path);
+    if (!entity) {
+      throw new Error(
+        `mark_processed: no entity at '${path}' in space '${target.name}'`,
+      );
+    }
+    const key = `${role}.processed_hash`;
+    const matched = await setEntityTag(
+      target.name,
+      path,
+      key,
+      entity.source_hash,
+    );
+    if (!matched) {
+      throw new Error(
+        `mark_processed: failed to write tag on '${path}' in space '${target.name}'`,
+      );
+    }
+    return {
+      path,
+      space: target.name,
+      role,
+      key,
+      source_hash: entity.source_hash,
+    };
+  },
+  summarize: (r) => ({
+    path: r.path,
+    space: r.space,
+    role: r.role,
+  }),
+});
+
 // ── Registry ──────────────────────────────────────────────────────
 
 export const ALL_TOOLS: Record<string, ToolFactory> = {
   read_file: readFileTool,
+  read_files: readFilesTool,
   search: searchTool,
   list_entities: listEntitiesTool,
   list_redlinks: listRedLinksTool,
   get_entity: getEntityTool,
+  get_entities: getEntitiesTool,
   edit_file: editFileTool,
   create_file: createFileTool,
   delete_wiki: deleteWikiTool,
   tag_entity: tagEntityTool,
+  mark_processed: markProcessedTool,
 };

--- a/packages/arkeon/src/server/lib/entities.ts
+++ b/packages/arkeon/src/server/lib/entities.ts
@@ -50,6 +50,16 @@ export interface ListEntitiesOptions {
   not_has_tag?: string | null;
   /** Restrict to entities where tag `key` equals exactly `value`. */
   tag_equals?: { key: string; value: string } | null;
+  /** Restrict to entities where this tag key's value equals the entity's
+   *  current `source_hash`. Use for "processed at current content"
+   *  queue gates (e.g. proposer's "editor has finished at the current
+   *  source content" precondition). */
+  tag_current?: string | null;
+  /** Restrict to entities where this tag key is absent OR has a value
+   *  that does NOT equal the entity's current `source_hash`. Use for
+   *  "needs processing" queues — covers both unprocessed entities and
+   *  ones whose content has changed since the last processing pass. */
+  tag_outdated?: string | null;
   sort?: string | null;
   include_counts?: boolean | null;
   limit?: number | null;
@@ -66,6 +76,12 @@ export interface EntityListRow {
   source_path: string;
   type: EntityType;
   label: string | null;
+  /** SHA-256 of the file content as of the last sync. Stable
+   *  across reconciles unless the file's bytes change. Useful as a
+   *  tag value for `editor.processed_hash` / `proposer.processed_hash`
+   *  markers — pass it to `tag_entity` so content-change
+   *  invalidation works automatically. */
+  source_hash: string;
   properties: Record<string, unknown> | string;
   tags: Record<string, unknown> | string;
   created_at: string;
@@ -167,6 +183,23 @@ export async function listEntities(
     );
     innerParams.push(opts.tag_equals.key, opts.tag_equals.value);
   }
+  // `tag_current` and `tag_outdated` compare the tag's value to the
+  // entity's own `source_hash` column — purpose-built for processing
+  // markers that need content-change invalidation. json_each walks
+  // the tags bag once per row; the JOIN to source_hash is on the
+  // same row, no subquery needed.
+  if (opts.tag_current) {
+    innerConditions.push(
+      "EXISTS (SELECT 1 FROM json_each(e.tags) WHERE key = ? AND value = e.source_hash)",
+    );
+    innerParams.push(opts.tag_current);
+  }
+  if (opts.tag_outdated) {
+    innerConditions.push(
+      "NOT EXISTS (SELECT 1 FROM json_each(e.tags) WHERE key = ? AND value = e.source_hash)",
+    );
+    innerParams.push(opts.tag_outdated);
+  }
 
   const innerWhere = innerConditions.length
     ? `WHERE ${innerConditions.join(" AND ")}`
@@ -198,8 +231,8 @@ export async function listEntities(
 
   const baseSelect = `
     SELECT
-      e.space_name, e.source_path, e.type, e.label, e.properties, e.tags,
-      e.created_at, e.updated_at,
+      e.space_name, e.source_path, e.type, e.label, e.source_hash,
+      e.properties, e.tags, e.created_at, e.updated_at,
       (SELECT COUNT(*) FROM relationships r
         WHERE r.space_name = e.space_name AND r.target_path = e.source_path) AS inbound,
       (SELECT COUNT(*) FROM relationships r
@@ -223,6 +256,7 @@ export async function listEntities(
     source_path: string;
     type: EntityType;
     label: string | null;
+    source_hash: string;
     properties: Record<string, unknown> | string;
     tags: Record<string, unknown> | string;
     created_at: string;
@@ -255,6 +289,7 @@ export async function listEntities(
         source_path: row.source_path,
         type: row.type,
         label: row.label,
+        source_hash: row.source_hash,
         properties: row.properties,
         tags: row.tags,
         created_at: row.created_at,
@@ -418,7 +453,8 @@ export async function getEntity(
 ): Promise<EntityDetail | null> {
   const sql = createSql();
   const rows = await sql`
-    SELECT space_name, source_path, type, label, properties, tags, created_at, updated_at,
+    SELECT space_name, source_path, type, label, source_hash, properties, tags,
+      created_at, updated_at,
       (SELECT by_role FROM entity_edits ed
         WHERE ed.space_name = entities.space_name AND ed.entity_path = entities.source_path
         ORDER BY ed.at DESC LIMIT 1) AS last_edited_by
@@ -442,6 +478,7 @@ export async function getEntity(
     source_path: row.source_path as string,
     type: row.type as EntityType,
     label: row.label as string | null,
+    source_hash: row.source_hash as string,
     properties: row.properties as Record<string, unknown> | string,
     tags: row.tags as Record<string, unknown> | string,
     created_at: row.created_at as string,

--- a/packages/arkeon/src/server/routes/space-scoped.ts
+++ b/packages/arkeon/src/server/routes/space-scoped.ts
@@ -67,6 +67,8 @@ spaceScopedRouter.get("/:space/entities", async (c) => {
     has_tag: c.req.query("has_tag"),
     not_has_tag: c.req.query("not_has_tag"),
     tag_equals: parseTagEquals(c.req.query("tag_equals")),
+    tag_current: c.req.query("tag_current"),
+    tag_outdated: c.req.query("tag_outdated"),
     sort: c.req.query("sort"),
     include_counts: (c.req.query("include") ?? "").split(",").includes("counts"),
     limit: parseNumQuery(c.req.query("limit"), "limit"),

--- a/packages/arkeon/test/unit/agents-config.test.ts
+++ b/packages/arkeon/test/unit/agents-config.test.ts
@@ -686,6 +686,68 @@ describe("loadBundledTemplates", () => {
     expect(t.tools?.length, "writer.tools").toBeGreaterThan(0);
     expect(t.cron, "writer.cron").toBeTruthy();
   });
+
+  it("auto-loads editor from disk with no config present", () => {
+    // Editor is the source-driven role that integrates new sources
+    // into existing articles (citations + open-thread red links).
+    // Runs first per source; calls mark_processed("editor") when done.
+    const templates = loadBundledTemplates();
+    expect(Object.keys(templates)).toContain("editor");
+    const t = templates.editor;
+    expect(t.system, "editor.system").toBeTruthy();
+    expect(t.tools?.length, "editor.tools").toBeGreaterThan(0);
+    // Editor's tool whitelist must include mark_processed (queue
+    // bookkeeping — the canonical 'I did this' marker that handles
+    // source_hash for the agent) and edit_file (its core action),
+    // but not create_file (only proposer/writer create files).
+    expect(t.tools, "editor.tools").toContain("mark_processed");
+    expect(t.tools, "editor.tools").toContain("edit_file");
+    expect(t.tools, "editor.tools").not.toContain("create_file");
+    // Batched read primitive keeps multi-article surveys in one turn.
+    expect(t.tools, "editor.tools").toContain("read_files");
+    expect(t.cron, "editor.cron").toBeTruthy();
+  });
+
+  it("auto-loads proposer from disk with no config present", () => {
+    // Proposer is the second source-driven role: it gates on the
+    // editor's tag (via tag_current), identifies gaps via
+    // get_entity (inverse lookup), and emits red links in a
+    // per-source plan wiki.
+    const templates = loadBundledTemplates();
+    expect(Object.keys(templates)).toContain("proposer");
+    const t = templates.proposer;
+    expect(t.system, "proposer.system").toBeTruthy();
+    expect(t.tools?.length, "proposer.tools").toBeGreaterThan(0);
+    // Proposer's tool whitelist must include get_entity (the
+    // inverse-lookup primitive), create_file (the plan wiki), and
+    // mark_processed (queue bookkeeping). It must NOT include
+    // edit_file — proposer never edits existing articles.
+    expect(t.tools, "proposer.tools").toContain("get_entity");
+    expect(t.tools, "proposer.tools").toContain("create_file");
+    expect(t.tools, "proposer.tools").toContain("mark_processed");
+    expect(t.tools, "proposer.tools").not.toContain("edit_file");
+    // Batched primitives let the gap-survey step run in O(1) turns.
+    expect(t.tools, "proposer.tools").toContain("get_entities");
+    expect(t.tools, "proposer.tools").toContain("read_files");
+    expect(t.cron, "proposer.cron").toBeTruthy();
+  });
+
+  it("writer is create-only — no edit_file, tag_entity, or mark_processed", () => {
+    // The new writer drains the red-link queue and never edits
+    // existing articles or marks sources. Processing-marker
+    // responsibility belongs to the editor/proposer; this
+    // whitelist enforces the boundary.
+    const templates = loadBundledTemplates();
+    const t = templates.writer;
+    expect(t.tools, "writer.tools").not.toContain("edit_file");
+    expect(t.tools, "writer.tools").not.toContain("tag_entity");
+    expect(t.tools, "writer.tools").not.toContain("mark_processed");
+    expect(t.tools, "writer.tools").toContain("create_file");
+    // Batched reads keep the multi-linker / multi-source survey
+    // (the common case for demand>=2 red links) inside one turn.
+    expect(t.tools, "writer.tools").toContain("get_entities");
+    expect(t.tools, "writer.tools").toContain("read_files");
+  });
 });
 
 // ── fillTemplate ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Decomposes the single-writer agent into three roles with one responsibility each, joined by a content-hash-validated tag chain on source files. Each role is a small, focused job that `gpt-5.4-mini` handles reliably; the pipeline is sequential per source by data dependency.

| Role | Trigger | Job | Tags |
|---|---|---|---|
| editor | `0 */1 * * *` | Integrate a source into existing articles (cite, revise thesis, add open-thread red links). Never creates. | writes `editor.processed_hash` |
| proposer | `0 */1 * * *` | Gated on editor's tag. Identify questions the editor didn't integrate; emit them as red links in a per-source plan wiki at `wiki/_plans/<encoded>.html`. Never edits. | writes `proposer.processed_hash` |
| writer | `*/15 * * * *` | Drain the red-link queue by demand. Create articles at `wiki/<slug>.html`. Create-only — no fallback "invent something" branch. | none |

## What's added

**New tools** (`packages/arkeon/src/server/agents/tools.ts`):

- `mark_processed(path, role)` — sugar over `tag_entity` that fills `source_hash` server-side. The agent never handles hashes, which kills the model's cross-source hash copy-paste failure mode observed in earlier probes.
- `get_entities(paths)` and `read_files(paths)` — batched siblings of their singular forms (cap 10). Surveying N linkers of a red link or N inbound sources is one turn instead of N. The writer's `max_steps` budget stops being the binding constraint.

**New filters** (`packages/arkeon/src/server/lib/entities.ts`):

- `tag_current="<key>"` — entity's tag value equals current `source_hash`
- `tag_outdated="<key>"` — tag absent OR stale; covers "never processed" + "content changed since" in one query

Both lean on `source_hash` now being part of the entity SELECT (so the filter can compare against the live value, not a cached one).

**New role templates**:

- `packages/arkeon/src/server/agents/templates/editor.yaml`
- `packages/arkeon/src/server/agents/templates/proposer.yaml`
- Updated `writer.yaml` to drop the source-integration responsibilities

`max_steps: 25` across all three roles — a backstop, not a target.

## Path conventions

To avoid the LLM-relative-path footgun, paths are flat:

- Articles at `wiki/<slug>.html` (no subfolders)
- Plans at `wiki/_plans/<slug>.html` (no source-directory mirroring; slashes in source path encoded as `__`, e.g. `sources/Augustine/book-04.md` → `wiki/_plans/Augustine__book-04.html`)

The system still accepts subfolders (file-watcher walks recursively, schema is path-keyed). The flat rule is a prompt-level convention. Long-term, this is a workaround — see arkeon-wiki#134 for the eventual shorthand-link-syntax fix.

## Smoke probe results

Tested on `experiments/augustine-modern/` against the 13-book Project Gutenberg Confessions slice (not committed; harness only):

| Phase | Ticks | Result |
|---|---|---|
| editor | 13 | 13 no-op (empty corpus, expected — no articles exist yet to edit) |
| proposer | 13 | 13 plan wikis, 0 no-ops |
| writer | 18 | 18 articles, **0 no-ops** |

- 18/18 articles have inline source citations
- 123 link edges (39 plan→article, 37 article↔article, 29 wiki→source)
- 13/14 sources correctly tagged with both `editor.processed_hash` and `proposer.processed_hash` matching live `source_hash` (the 1 miss is `tsconfig.json` which both roles correctly skipped)

Compared to the prior single-writer probe with `max_steps: 16` and no batched tools: the writer produced 6 articles with 12/18 no-ops (hitting the step budget mid-tick). With batched reads + `max_steps: 25`, the writer goes 18/18.

## Test plan

- [x] Typecheck clean (`npm run typecheck -w packages/arkeon`)
- [x] 153 unit tests pass (`npm test -w packages/arkeon`)
- [x] 51 e2e tests pass (`npm run test:e2e -w packages/arkeon`)
- [x] End-to-end smoke probe on a real corpus produces 18 properly-cited articles with a connected link graph
- [x] Tag invariants hold under content-change invalidation (verified on `gpt-5.4-mini` with `reasoning_effort: low`)

## Follow-ups

- arkeon-wiki#134 — shorthand link syntax to eliminate the flat-path constraint
- Open threads section in writer articles sometimes drops cross-refs to existing articles instead of red links (mixed "see also" / forward-looking behavior). Not blocking; can be tightened with a prompt update.