### PR TITLE
Refresh README + AGENT_RUNTIME guide for the editor/proposer/writer pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ arkeon-wiki start              # foreground (for use under pm2/launchd/etc.)
 
 ## Agents (LLM-powered)
 
-arkeon-wiki ships a small AI agent runtime with a single built-in role — `writer` — that turns recent sources and red-link demand into HTML articles. Configure it in `.arkeon/agents.yaml` (committed) and put your API key in `~/.arkeon-wiki/.env` (per-user, machine-local).
+arkeon-wiki ships a small AI agent runtime with three built-in roles — `editor`, `proposer`, and `writer` — that work in sequence per source: the editor integrates a new source into existing articles (citations and open-thread red links), the proposer emits a per-source plan wiki of red links the editor didn't integrate, and the writer drains the red-link queue by creating new articles. Configure them in `.arkeon/agents.yaml` (committed) and put your API key in `~/.arkeon-wiki/.env` (per-user, machine-local).
 
 ```bash
 arkeon-wiki config init                                       # template config

--- a/docs/user/AGENT_RUNTIME.md
+++ b/docs/user/AGENT_RUNTIME.md
@@ -1,6 +1,6 @@
 # Agent runtime
 
-arkeon-wiki ships a small AI agent runtime that lets you wire LLMs into the wiki without writing code. Built-in roles cover the common jobs (extracting subjects from sources, drafting wiki bodies); you tune their model, focus, and instructions in YAML and add your own custom roles when you need them.
+arkeon-wiki ships a small AI agent runtime that lets you wire LLMs into the wiki without writing code. Three built-in roles — `editor`, `proposer`, and `writer` — work in sequence per source: the editor integrates a new source into existing articles, the proposer emits a plan wiki of red links the editor didn't integrate, and the writer drains the red-link queue by creating new articles. You tune their model, focus, and instructions in YAML and add your own custom roles when you need them.
 
 This page is the from-scratch setup guide. If you only want to know what the runtime does, see [README.md](../../README.md).
 
@@ -65,26 +65,26 @@ Run `arkeon-wiki config init` once per repo. It writes a fully-commented templat
 ```yaml
 defaults:
   provider: openai             # openai | anthropic | openai-compatible
-  model: gpt-5-mini
+  model: gpt-5.4-mini
 
   # Operator notes appended to every role's system prompt. Use this to
   # steer subjects, tone, and scope without rewriting the workflow.
   instructions: |
-    This wiki tracks researchers in climate science. Skip subjects
-    not directly relevant to the field. Use British English.
+    This wiki tracks researchers in climate science. Lean toward
+    article topics relevant to that field. Use British English.
 
-# Per-role overrides. The bundled `ingestor` and `consolidator` roles
-# ship as YAML templates in the package and are inherited automatically
-# — fields you omit fall back to the template. Custom roles appear
-# here too.
+# Per-role overrides. The bundled `editor`, `proposer`, and `writer`
+# roles ship as YAML templates in the package and are inherited
+# automatically — fields you omit fall back to the template. Custom
+# roles appear here too.
 roles:
-  ingestor:
-    model: gpt-5-mini
-    max_steps: 20
+  writer:
+    model: gpt-5.4-mini
+    max_steps: 25
+    cron: "*/15 * * * *"        # tighten or relax the cadence
     instructions: |
-      Each new wiki body is 2-4 paragraphs grounded in the source.
-      Always include a markdown link from the wiki body back to the
-      source path. Skip generic terms — only cover named subjects.
+      Lead each article with its thesis in the first sentence. Cite
+      every claim inline as <a href> to the source file.
 
   link-checker:                # custom user-defined role
     provider: anthropic        # different provider per role is fine
@@ -92,12 +92,14 @@ roles:
     api_key_env: ANTHROPIC_API_KEY
     tools: [list_entities, read_file, edit_file]
     max_steps: 30
+    cron: "0 */6 * * *"        # custom roles MUST set a cron
     system: |
-      You find wikis with broken or missing cross-references and add
-      markdown links to the wikis they should connect to. Use search
-      and list_entities to discover candidates.
+      You find articles with broken or missing cross-references and
+      add anchors to the wikis they should connect to. Use search and
+      list_entities to discover candidates.
     user: |
-      Wiki to check: {{trigger_entity_id}}
+      Scheduled tick — check the recently-edited articles in space
+      {{space_name}}.
 ```
 
 ### Config commands
@@ -115,22 +117,31 @@ arkeon-wiki config validate           # schema-check the YAML
 | Section | Behavior when set in both global and repo |
 |---|---|
 | `defaults` | **Field-level merge.** `defaults.provider` from global + `defaults.model` from repo combine. Repo wins on shared fields. |
-| `roles.<name>` | **Per-role replacement.** If `roles.ingestor` exists in both files, the repo entry replaces the global entry **wholesale** — fields you don't repeat are *not* inherited from the global. |
+| `roles.<name>` | **Per-role replacement.** If `roles.writer` exists in both files, the repo entry replaces the global entry **wholesale** — fields you don't repeat are *not* inherited from the global. |
 
-This asymmetry keeps role overrides predictable: when you write `roles.ingestor:` in your repo's YAML, you're declaring exactly what that role looks like for this repo, not partially patching whatever your `~/` happens to have.
+This asymmetry keeps role overrides predictable: when you write `roles.writer:` in your repo's YAML, you're declaring exactly what that role looks like for this repo, not partially patching whatever your `~/` happens to have.
 
 To carry over a field from a global role override, copy it. The most common case is global YAML setting universal `defaults` and the per-repo file overriding individual roles — that works without copying anything because `defaults` *do* merge.
 
 ## Bundled role templates
 
-| Role | Tools | Job |
-|---|---|---|
-| `ingestor` | `read_file`, `list_entities`, `search`, `edit_file` | Read a source file, identify the distinct subjects it discusses, and for each one either edit the existing wiki to weave the new material in (with a markdown link back to the source) or create a new wiki under `wiki/{subject_type}/{slug}.md` with a 2-4 paragraph body. |
-| `consolidator` | `read_file`, `list_entities`, `search`, `edit_file`, `delete_wiki` | Per-wiki cascade after the ingestor: surveys the corpus for related material and either cross-links, bleeds into another wiki, or merges the subject away. Outward-only — never replaces other wikis' content. |
+Three roles, each with one job, joined by a content-hash-validated tag chain on source files. Each role runs on its own cron tick; per-space serialization is enforced by an in-process mutex (at most one role at a time per space).
 
-The templates ship as YAML files in the package (`src/server/agents/templates/<name>.yaml`) and are loaded fresh from disk on every agent run. You can override any field of a template (`provider`, `model`, `tools`, `max_steps`, `instructions`, `system`, `user`, `triggers`, `phases`) in your `.arkeon/agents.yaml` without redefining the whole role. To inherit the workflow but bias the focus, set `instructions:` only.
+| Role | Cron | Tools | Job |
+|---|---|---|---|
+| `editor` | `0 */1 * * *` | `read_file`, `read_files`, `list_entities`, `list_redlinks`, `edit_file`, `mark_processed` | Pick one source not yet tagged at its current content hash, survey existing articles via `list_entities` + `properties.short_description`, and for each article the source bears on either (a) insert a citation-bearing paragraph into Evidence / revise the Current Answer via `edit_file`, or (b) append a red-link `<li>` to the article's `<h2>Open threads</h2>`. Tags the source `editor.processed_hash=<source_hash>` when done. Never creates new articles. |
+| `proposer` | `0 */1 * * *` | `read_file`, `read_files`, `list_entities`, `list_redlinks`, `get_entity`, `get_entities`, `create_file`, `mark_processed` | Gated on the editor's tag (`tag_current="editor.processed_hash"`). Calls `get_entity` on the source path to see which articles the editor integrated this source into, identifies the GAP — questions the source raises that no existing article (and no queued red link) covers — and writes a plan wiki at `wiki/_plans/<encoded>.html` listing those gaps as red links. Tags the source `proposer.processed_hash`. Never edits existing articles. |
+| `writer` | `*/15 * * * *` | `read_file`, `read_files`, `list_entities`, `list_redlinks`, `get_entity`, `get_entities`, `search`, `create_file` | Red-link-driven. Picks the highest-demand entry from `list_redlinks`, follows its linkers back to source files, and creates the article via `create_file` at `wiki/<slug>.html`. Create-only — `edit_file` is not in its whitelist. Empty red-link queue → no-op, no fallback "invent something" branch. |
 
-Provenance: the `ingestor` writes a markdown link from each wiki body back to the source path it drew material from. The existing link-resolution path turns those into edges in the `relationships` table — so "which sources contributed to this wiki?" is a SQL query over `relationships`, not a separate inbox.
+The pipeline is **sequential per source** by data dependency: editor marks → proposer eligible to run → both contribute red links → writer drains them. Content changes invalidate both source markers so the source re-enters both queues automatically.
+
+The templates ship as YAML files in the package (`src/server/agents/templates/<name>.yaml`) and are loaded fresh from disk on every agent run. You can override any field of a template (`provider`, `model`, `tools`, `max_steps`, `cron`, `reasoning_effort`, `instructions`, `system`, `user`) in your `.arkeon/agents.yaml` without redefining the whole role. To inherit the workflow but bias the focus, set `instructions:` only.
+
+Default model for all three: `gpt-5.4-mini`, `reasoning_effort: low`. The single-role-per-tick decomposition lets a small model handle each job reliably — the previous single-writer role needed `reasoning_effort: medium` for the integrated workload.
+
+**First-run cost note**: a fresh `arkeon-wiki up` against a corpus with `OPENAI_API_KEY` set will start spending API credit within 15 minutes. Override the cadence in `.arkeon/agents.yaml` (`cron: "0 0 31 2 *"` is the canonical "never fire" idiom — Feb 31 doesn't exist) to inspect behavior before letting it run.
+
+Provenance: every article authored by `writer` cites its source inline as `<a href="../sources/...">`. The existing link-resolution path turns those into edges in the `relationships` table — so "which sources contributed to this article?" is a SQL query over `relationships`, not a separate inbox.
 
 ## Custom roles
 
@@ -138,17 +149,26 @@ Define a custom role by adding any name under `roles:` that doesn't match a bund
 
 - `system:` — the full system prompt (the workflow)
 - `tools:` — list of tool names from the registry
+- `cron:` — when to fire (the scheduler is purely cron-driven; no file-event triggers)
 
-Optional: `provider`, `model`, `api_key_env`, `base_url`, `max_steps`, `user` (template), `instructions`.
+Optional: `provider`, `model`, `api_key_env`, `base_url`, `max_steps`, `reasoning_effort`, `user` (template), `instructions`.
 
 The available tools are:
 
 | Tool | Use |
 |---|---|
-| `list_entities` | Frontmatter-aware enumeration: filter by `subject_type`, `status`, `label_contains` (case-insensitive substring match — `"Baker Street"` finds `"221B Baker Street"`). |
-| `search` | Keyword search via ripgrep, returns ranked entity hits with snippets. |
-| `read_file` | Read a file's contents (markdown returns parsed frontmatter + body). |
-| `edit_file` | The single file-mutation tool. Three modes dispatched on `search` and whether the path exists:<br>**CREATE** — empty `search`, file doesn't exist → creates the file with `replace` as content.<br>**APPEND** — empty `search`, file exists → appends `replace` to the body.<br>**REPLACE** — non-empty `search` (must match exactly once) → Aider-style SEARCH/REPLACE.<br>There's no overwrite path; to change a wiki's label, REPLACE just the `label:` line. |
+| `list_entities` | Filter the corpus by `type` (`wiki` / `file`), `label_contains`, `path_contains`, inbound/outbound counts, `edited_by_role`, `updated_since`, and tag predicates (`tag_current`, `tag_outdated`, `has_tag`, `not_has_tag`, `tag_equals`). |
+| `list_redlinks` | Link targets without a matching entity row, aggregated by demand. The writer's primary queue. |
+| `search` | Keyword search via ripgrep. OR up to 10 patterns in one call. Returns ranked file hits with snippets. |
+| `read_file` | Read one file's contents (line-numbered for use with `insert_at_line`). Registers the path in the per-run read-gate so `edit_file` is allowed on it. |
+| `read_files` | Batched `read_file` (up to 10 paths in one turn). Same read-gate semantics. |
+| `get_entity` | Fetch one entity with both directions of its link neighborhood (`inbound` + `outbound`). The single-call answer to "what cites this?" and "what does this connect to?". |
+| `get_entities` | Batched `get_entity` (up to 10 paths). The standard primitive for surveying N linkers of a red link. |
+| `edit_file` | Mutate an existing file. Two modes: `insert_at_line { line_number, content }` (additive; lines shift down) and `str_replace { old_string, new_string }` (exact-match SEARCH/REPLACE, must match once). Read-gated: refuses paths the agent hasn't `read_file`-ed in this run. |
+| `create_file` | New wiki under `wiki/<slug>.html`. Requires a full HTML document (`<!DOCTYPE>` or `<html>` + non-empty `<title>` + `<body>`). Fails if the path exists. |
+| `delete_wiki` | Guarded full-file deletion (only paths under `wiki/**`, required `reason` arg). Not in the bundled roles' whitelists. |
+| `tag_entity` | Set or clear an agent-applied tag (`entities.tags` JSON column, distinct from `properties`). Pass `null` to delete. Free-form key/value bookkeeping for multi-agent pipelines. |
+| `mark_processed` | Sugar over `tag_entity` for the canonical "I did this" idiom — writes `tags["${role}.processed_hash"] = source_hash` server-side. The agent never handles hashes, so content-change invalidation is automatic. |
 
 ### Prompt template variables
 
@@ -156,10 +176,10 @@ Both `system:` and `user:` are templates. Available variables:
 
 | Variable | Resolves to |
 |---|---|
-| `{{trigger_path}}` | The path that triggered this run (source file path, wiki path, etc.). Empty if the agent was invoked without a trigger. |
-| `{{trigger_entity_id}}` | The entity id of the trigger. Empty if none. |
-| `{{space_id}}` / `{{space_name}}` / `{{space_watch_dir}}` | The space the agent is running in. |
 | `{{role_name}}` | The role being run. |
+| `{{trigger_path}}` | The path that triggered this run (cron ticks pass an empty string; reserved for future programmatic triggers). |
+| `{{space_name}}` | The space the agent is running in. |
+| `{{space_watch_dir}}` | The absolute filesystem path the space watches. |
 
 Unknown placeholders resolve to the empty string (no errors).
 
@@ -199,28 +219,28 @@ Then put `OPENROUTER_API_KEY=sk-or-v1-…` in `~/.arkeon-wiki/.env`.
 ```yaml
 defaults:
   provider: openai
-  model: gpt-5-mini
+  model: gpt-5.4-mini
 
 roles:
-  ingestor:                   # default ingestion on cheap OpenAI
-    model: gpt-5-mini
+  editor:                     # default editor on cheap OpenAI
+    model: gpt-5.4-mini
+  proposer:
+    model: gpt-5.4-mini
+  writer:                     # promote the writer to Claude for prose quality
+    provider: anthropic
+    model: claude-opus-4-7
+    api_key_env: ANTHROPIC_API_KEY
   reviewer:                   # custom role on stronger Claude
     provider: anthropic
     model: claude-opus-4-7
     api_key_env: ANTHROPIC_API_KEY
     tools: [list_entities, read_file, edit_file]
+    cron: "0 */6 * * *"
     system: |
-      You review recently-edited wikis for clarity and citation quality...
-  drafter:                    # local model for offline drafting
-    provider: openai-compatible
-    base_url: http://localhost:11434/v1
-    model: llama3.1:70b
-    tools: [list_entities, read_file, edit_file]
-    system: |
-      You draft wiki bodies offline...
+      You review recently-edited articles for clarity and citation quality...
 ```
 
-Each role gets its own provider and key. Set `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` in `~/.arkeon-wiki/.env`; the local model needs no key.
+Each role gets its own provider and key. Set `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` in `~/.arkeon-wiki/.env`; local backends need no key.
 
 ## Verifying setup
 
@@ -240,7 +260,7 @@ If you have the package source checked out:
 npm run test:manual -w packages/arkeon
 ```
 
-This runs the `ingestor` role against a synthetic source paragraph and prints the wikis that landed, token usage, and total cost.
+This runs the bundled roles against a synthetic source paragraph and prints the articles that landed, token usage, and total cost.
 
 ## Troubleshooting
 
@@ -262,23 +282,24 @@ Check the unknown field name; the schema is strict. The likely candidates:
 - `max_steps` must be a positive integer
 - `tools` is an array of strings (tool names)
 
-## How auto-triggering works
+## How scheduling works
 
-When the daemon is running and you drop, edit, or save a file under the space's watch directory, the chain is:
+The scheduler is **purely cron-driven**. Each role has its own `cron` expression and fires independently. The file watcher's job ends at the SQLite mirror — agents pick up new state at their next scheduled tick, not on every save.
 
-1. The file watcher fires.
-2. `syncFile` updates the SQLite index.
-3. The scheduler sees the path and asks `shouldTrigger`: is it under `wiki/**` or `.arkeon/**`? If yes, drop the event (this is what prevents the ingestor from re-firing on its own writes). Otherwise, enqueue a row in `agent_queue` keyed by `(space, role, source_path)`.
-4. A per-space worker claims the next pending row, calls `runAgent` for the `ingestor` role, and on success deletes the row. On failure it resets `started_at` to null with `last_error` set; the next claim retries.
+1. The file watcher fires; `syncFile` updates the SQLite index (no agent activity here).
+2. On the next cron tick for a role, the scheduler attempts to acquire the per-space mutex.
+3. If the mutex is free, `runAgent` runs with the role's config; on completion the mutex is released. If another role is already running in that space, the tick is **skipped** (no queue, no retry).
+4. The role decides its own work from current state — typically by querying for entities with `tag_outdated="<role>.processed_hash"` (covers "never processed" + "content changed since" in one query).
 
-Rapid saves of the same file are coalesced: the `UNIQUE(space, role, path)` constraint means five saves in a second produce one queue row that runs against the latest content.
+This means:
 
-The queue is crash-safe via a 5-minute lease. If the daemon dies while a row is in flight, the next daemon startup runs `reclaimOrphans()` which resets stale `started_at` values back to pending.
-
-In v1 the trigger filter is hardcoded: every non-`wiki/`, non-`.arkeon/` file event fires the ingestor. User-tunable include/exclude lands later when there's a real use case.
+- **Downtime → missed ticks are dropped.** No persistence of last-fire times, no replay. Each role's queries against current state naturally surface anything that needs work.
+- **Content invalidation is automatic.** `mark_processed(path, role)` stores the source's `source_hash` under `tags["<role>.processed_hash"]`; when the file changes, the hash changes, and `tag_outdated` resurfaces the entity.
+- **Per-space serialization** prevents two roles from racing on the same file. If your editor and proposer crons line up at `:00`, one runs while the other defers to its next tick.
+- **New behaviors don't need scheduler changes** — a reflector role that picks articles with open threads, a bridger that rotates across spaces, etc., need only a different prompt + cron.
 
 ## What's not yet wired
 
-- **User-tunable trigger filters** — currently hardcoded to "everything except `wiki/**` and `.arkeon/**`". When operators need to scope it (e.g., only files under `inbox/**`), an opt-in `trigger.include` field lands in agents.yaml.
 - **Per-role budgets / cost caps** — set `max_steps` for now; spending caps are a planned follow-up.
-- **Streaming output** — `runAgent` currently waits for the full response. Streaming will come with the daemon integration.
+- **Streaming output** — `runAgent` currently waits for the full response. Streaming will come with first-class chat surfaces in Phase 3.
+- **Cross-space agent runs** — schema supports it (`relationships.target_path` is unconstrained text; the `/{other-space}/...` URL form is committed), but role prompts and the scheduler are single-space today. Returns at v0.5.


### PR DESCRIPTION
## Summary

Documentation refresh after [#135](https://github.com/Arkeon-Technologies/arkeon-wiki/pull/135). Two files were stale; this brings them back in sync with the shipped runtime.

**`README.md`** — single-line claim of "one built-in role — `writer`" replaced with a short summary of the editor → proposer → writer sequence.

**`docs/user/AGENT_RUNTIME.md`** had drifted further than this PR fixed:
- Referenced the long-dead `ingestor` and `consolidator` roles (predecessors of `writer`, removed in #106; never replaced when #135 introduced the three-role split).
- "How auto-triggering works" described the `agent_queue` table and event-driven scheduling — both gone in #106's cron rewrite.
- Custom-role tools table listed an old `edit_file` three-mode signature and was missing six tools (`read_files`, `list_redlinks`, `get_entity`, `get_entities`, `create_file`, `delete_wiki`, `tag_entity`, `mark_processed`).
- Template-variable list included `trigger_entity_id` and `space_id` which the runtime no longer exposes.

This PR is **docs-only**; no runtime changes.

## What's in the AGENT_RUNTIME refresh

- **Bundled-roles section** — three-role table with cron schedule, full tool whitelist, and one-paragraph job per role. Followed by a "sequential per source by data dependency" callout so operators understand why the crons are paced the way they are.
- **Custom roles** — `cron:` is now listed as a required field (it always was; doc never said so). Tool table has all 12 current tools with one-line semantics each.
- **Template variables** — trimmed to what the runtime actually exposes (`role_name`, `trigger_path`, `space_name`, `space_watch_dir`).
- **YAML examples** — both the `defaults` block and the "mixing providers per role" snippet rewritten with current role names and `gpt-5.4-mini` as the default.
- **"How scheduling works"** — replaces "How auto-triggering works." Pure cron, per-space mutex, missed-tick-is-dropped semantics, automatic content-hash invalidation via `tag_outdated`.
- **"What's not yet wired"** updated to reflect what's actually deferred (per-role cost caps, streaming output, cross-space agent runs).

## Test plan

- [x] All stale role names (`ingestor`, `consolidator`) and table references (`agent_queue`, `subject_type`, `frontmatter`) gone — `grep` returns clean
- [x] Cross-references to other docs (CLAUDE.md, README.md) still resolve
- [x] No code changes, so no test suite to run