### PR TITLE
Docs: opinionate via instructions:, refresh agent runtime guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ arkeon-wiki start              # foreground (for use under pm2/launchd/etc.)
 
 ## Agents (LLM-powered)
 
-arkeon-wiki ships a small AI agent runtime with a single built-in role — `writer` — that turns recent sources and red-link demand into HTML articles. Configure it in `.arkeon/agents.yaml` (committed) and put your API key in `~/.arkeon-wiki/.env` (per-user, machine-local).
+arkeon-wiki ships a three-role agent pipeline — `editor`, `proposer`, `writer` — that ingests sources, proposes the questions worth answering, and drafts the HTML articles. All three run on cron, serialized per-space. Configure them in `.arkeon/agents.yaml` (committed) and put your API key in `~/.arkeon-wiki/.env` (per-user, machine-local).
 
 ```bash
 arkeon-wiki config init                                       # template config
@@ -112,6 +112,23 @@ arkeon-wiki config show                                        # confirm what'll
 ```
 
 Roles run on OpenAI, Anthropic, or any OpenAI-compatible backend (Ollama, LM Studio, OpenRouter, Groq, vLLM, …). Each role can use a different provider; secrets stay in `.env`, never YAML. Custom user-defined roles are first-class.
+
+### Opinionating your wiki
+
+A bare config will produce a generic wiki that takes every source seriously and writes articles on whatever it finds. To get an *opinionated* wiki — one with a point of view, a scope, a house style — set `instructions:` in `.arkeon/agents.yaml`. It's appended to every role's system prompt without disturbing the workflow, so it's the one knob you reach for first.
+
+```yaml
+defaults:
+  instructions: |
+    This wiki is about distributed systems, with a bias toward
+    primary-source engineering writeups (postmortems, design docs,
+    papers) over secondary commentary. Skip vendor blog posts.
+    Tone: skeptical, evidence-led, no marketing voice.
+    Audience: practitioners, not students — assume the reader knows
+    what consensus and replication are.
+```
+
+This is the most consequential setting in the file. The default article structure (`Question / Current answer / Evidence / Open threads`) is a soft convention baked into the bundled prompts — if it doesn't fit your domain, override the `writer` role's `system:` directly. Otherwise, treat `instructions:` as the place to spend your editorial judgment.
 
 Full setup guide: [docs/user/AGENT_RUNTIME.md](./docs/user/AGENT_RUNTIME.md).
 

--- a/docs/user/AGENT_RUNTIME.md
+++ b/docs/user/AGENT_RUNTIME.md
@@ -77,7 +77,7 @@ The package ships three roles that compose into a question-driven wiki pipeline.
 | Role | Job |
 |---|---|
 | `editor` | Integrates each new source into existing articles. Adds citation-bearing paragraphs to Evidence sections; revises a thesis when a source reshapes it; adds open-thread red links for questions the source raises. Never creates new articles. |
-| `proposer` | After the editor has handled a source, identifies the questions the editor did *not* integrate and emits them as red links in a per-source plan wiki. Never edits existing articles. |
+| `proposer` | After the editor has handled a source, identifies the questions the editor did *not* integrate and emits them as red links in a per-source plan wiki (`wiki/_plans/<source-slug>.html` with `<meta name="kind" content="plan">`). Never edits existing articles or writes article bodies — only red-link slugs. |
 | `writer` | Drains the red-link queue. Picks the highest-demand red link, follows it back to the articles and plan wikis that point at it, reads the cited sources, and creates the target article. Never edits existing articles. |
 
 The three roles run on cron and coordinate via tags on source files (`editor.processed_hash`, `proposer.processed_hash`) — when an editor finishes a source, the proposer's next tick sees it as queue-ready. There's no message-passing; each role re-derives its work from current state.
@@ -210,7 +210,7 @@ Roles call tools to read state, search, and mutate the wiki. The registry is sma
 |---|---|
 | `read_file` | Read one file with line numbers. Required before `edit_file` on the same path. |
 | `read_files` | Batched `read_file`, up to 10 paths in one call. |
-| `list_entities` | Filtered listing of wikis and sources. Supports `type`, `label_contains`, `path_contains`, `inbound_min`/`max`, `outbound_min`/`max`, `has_tag`, `not_has_tag`, `tag_current`, `tag_outdated`, sort, limit, offset. |
+| `list_entities` | Filtered listing of wikis and sources. Supports `type`, `label_contains`, `path_contains`, `inbound_min`/`max`, `outbound_min`/`max`, `updated_since`, `edited_by_role`, `has_tag`, `not_has_tag`, `tag_equals`, `tag_current`, `tag_outdated`, `sort`, `include_counts`, `limit`, `offset`. Full filter set is the Zod schema in `tools.ts`. |
 | `list_redlinks` | Link targets without an entity row, ranked by demand. Carries up to 3 `linked_from` paths per target. |
 | `get_entity` | Single entity with inbound + outbound link neighborhoods. |
 | `get_entities` | Batched `get_entity`, up to 10 paths. |
@@ -219,7 +219,7 @@ Roles call tools to read state, search, and mutate the wiki. The registry is sma
 | `create_file` | Create a new wiki under `wiki/**.html`. Validates the HTML envelope. |
 | `delete_wiki` | Guarded full-file deletion. Reason required. Restricted to `wiki/**`. |
 | `tag_entity` | Set or clear an agent-applied tag on any entity. Idempotent. |
-| `mark_processed` | Shorthand for `tag_entity(role + "processed_hash", entity.source_hash)`. |
+| `mark_processed` | Shorthand for `tag_entity(role + ".processed_hash", entity.source_hash)`. The server reads the entity's current `source_hash` on the agent's behalf, so role pipelines can gate on `tag_outdated` / `tag_current` without the agent ever handling the hash. |
 
 When you list `tools:` on a role, the runtime exposes exactly that subset to the model — any tool not listed is invisible, even if the model knows about it from training. Custom roles must declare their `tools:` array explicitly; bundled roles inherit theirs from the template.
 

--- a/docs/user/AGENT_RUNTIME.md
+++ b/docs/user/AGENT_RUNTIME.md
@@ -1,8 +1,8 @@
 # Agent runtime
 
-arkeon-wiki ships a small AI agent runtime that lets you wire LLMs into the wiki without writing code. Built-in roles cover the common jobs (extracting subjects from sources, drafting wiki bodies); you tune their model, focus, and instructions in YAML and add your own custom roles when you need them.
+arkeon-wiki ships a small AI agent runtime that lets you wire LLMs into the wiki without writing code. Bundled roles cover the common jobs (integrating sources, proposing questions, drafting articles); you tune their model, focus, and instructions in YAML and add your own custom roles when you need them.
 
-This page is the from-scratch setup guide. If you only want to know what the runtime does, see [README.md](../../README.md).
+This page is the setup guide. If you only want to know what the runtime does, see [README.md](../../README.md).
 
 ## TL;DR
 
@@ -58,47 +58,139 @@ roles:
     model: llama-3.3-70b
 ```
 
+## How the runtime works
+
+Three things to know:
+
+1. **Roles run on cron.** Each role declares a cron expression and the scheduler fires it on that cadence. There is no queue, no file-watcher dispatch, no event bus — when a tick fires, the role surveys current state via its tools and decides what to do.
+
+2. **One role at a time per space.** A per-space mutex serializes role runs. If a tick fires while another role is already running in the same space, the tick is skipped (skip-if-busy) and the next firing is scheduled from "now." Different spaces run in parallel.
+
+3. **Roles are LLMs with tools.** A role is a system prompt plus a whitelist of tools (read, search, edit, create, tag). Each run is a Vercel AI SDK loop: the model calls tools, the runtime executes them, the result feeds back in, until the model emits a final reply or hits `max_steps`.
+
+Roles ship as YAML templates inside the package and are loaded fresh on every run. Your `.arkeon/agents.yaml` layers on top: any field you set there overrides the template's value; anything you omit falls through to the template.
+
+## Bundled roles
+
+The package ships three roles that compose into a question-driven wiki pipeline. You can run all three, run a subset, or replace them entirely.
+
+| Role | Job |
+|---|---|
+| `editor` | Integrates each new source into existing articles. Adds citation-bearing paragraphs to Evidence sections; revises a thesis when a source reshapes it; adds open-thread red links for questions the source raises. Never creates new articles. |
+| `proposer` | After the editor has handled a source, identifies the questions the editor did *not* integrate and emits them as red links in a per-source plan wiki. Never edits existing articles. |
+| `writer` | Drains the red-link queue. Picks the highest-demand red link, follows it back to the articles and plan wikis that point at it, reads the cited sources, and creates the target article. Never edits existing articles. |
+
+The three roles run on cron and coordinate via tags on source files (`editor.processed_hash`, `proposer.processed_hash`) — when an editor finishes a source, the proposer's next tick sees it as queue-ready. There's no message-passing; each role re-derives its work from current state.
+
+Default cadences (set in each role's template):
+
+| Role | Cron |
+|---|---|
+| `editor` | hourly |
+| `proposer` | hourly (gates on editor's tag, so naturally trails one cycle) |
+| `writer` | every 15 minutes |
+
+**Cost note.** All three bundled templates default to `gpt-5.4-mini` with `reasoning_effort: low`. A fresh `arkeon-wiki up` against a populated corpus with `OPENAI_API_KEY` set will start spending API credit within 15 minutes. To inspect behavior before letting them run, override the cadence per role in `.arkeon/agents.yaml` (e.g. an off-hours cron, or a far-future schedule while you experiment).
+
 ## Configuration: `.arkeon/agents.yaml`
 
-Run `arkeon-wiki config init` once per repo. It writes a fully-commented template you can edit:
+### Opinionating your wiki via `instructions:`
+
+The single most consequential field in this file is `defaults.instructions:`. It's appended to every role's system prompt and is the way you give the wiki a point of view — what it's about, what it's not about, what tone, what audience. Without it, the agents produce a generic wiki that takes every source at face value. With it, the corpus develops editorial judgment.
 
 ```yaml
 defaults:
-  provider: openai             # openai | anthropic | openai-compatible
-  model: gpt-5-mini
-
-  # Operator notes appended to every role's system prompt. Use this to
-  # steer subjects, tone, and scope without rewriting the workflow.
   instructions: |
-    This wiki tracks researchers in climate science. Skip subjects
-    not directly relevant to the field. Use British English.
+    This wiki is about <topic>, with a bias toward <preferred source
+    types> over <deprioritized source types>. Skip <out-of-scope
+    subjects>. Tone: <voice>. Audience: <reader profile> — assume
+    they already know <prerequisite knowledge>.
+```
 
-# Per-role overrides. The bundled `ingestor` and `consolidator` roles
-# ship as YAML templates in the package and are inherited automatically
-# — fields you omit fall back to the template. Custom roles appear
-# here too.
+Treat `instructions:` as the place you spend your editorial judgment. The bundled role workflows are deliberately generic; `instructions:` is where you make them yours. If even that isn't enough — e.g. you want a different article structure entirely — override the role's `system:` directly. But reach for `instructions:` first; it leaves the validated workflow intact.
+
+### The template `config init` writes
+
+`arkeon-wiki config init` drops a fully-commented `.arkeon/agents.yaml` into the current repo. Out of the box the only thing it sets is `defaults.provider` and `defaults.model` plus a commented-out `instructions:` block to fill in. Everything else (per-role tool whitelists, prompts, cron expressions) inherits from the bundled templates until you override it.
+
+Edit the file, then run `arkeon-wiki config show` to see the merged effective config.
+
+### Three tiers of customization
+
+Pick the lightest one that does what you need.
+
+**1. Defaults that apply to every role.** Anything under `defaults:` propagates to all roles — bundled and custom alike — unless the role overrides the field. Most operators only need this tier:
+
+```yaml
+defaults:
+  provider: openai
+  model: gpt-5-mini
+  instructions: |
+    This wiki is about distributed systems. Skip vendor marketing.
+```
+
+**2. Per-role field overrides.** Under `roles.<name>:`, override only the fields you care about. Field-level inheritance from the template means you can swap a model without re-supplying the prompt, or extend the prompt with extra `instructions:` without rewriting the workflow:
+
+```yaml
 roles:
-  ingestor:
-    model: gpt-5-mini
-    max_steps: 20
+  writer:
+    model: gpt-5                  # stronger model just for the writer
+    cron: "0 */2 * * *"           # every 2 hours instead of every 15 min
     instructions: |
-      Each new wiki body is 2-4 paragraphs grounded in the source.
-      Always include a markdown link from the wiki body back to the
-      source path. Skip generic terms — only cover named subjects.
+      Lean toward shorter articles. Two paragraphs of Evidence is enough.
+  editor:
+    reasoning_effort: medium      # spend more thinking on integrations
+```
 
-  link-checker:                # custom user-defined role
-    provider: anthropic        # different provider per role is fine
+**3. Custom roles.** Add a role name that isn't bundled and the runtime treats it as user-defined. Custom roles must supply at minimum `system:`, `tools:`, and `cron:`:
+
+```yaml
+roles:
+  curator:
+    provider: anthropic
     model: claude-opus-4-7
     api_key_env: ANTHROPIC_API_KEY
-    tools: [list_entities, read_file, edit_file]
+    tools: [list_entities, read_file, search, edit_file]
     max_steps: 30
+    cron: "0 4 * * *"             # daily at 04:00
     system: |
-      You find wikis with broken or missing cross-references and add
-      markdown links to the wikis they should connect to. Use search
-      and list_entities to discover candidates.
-    user: |
-      Wiki to check: {{trigger_entity_id}}
+      You find articles whose theses no longer match their evidence and
+      rewrite the thesis. Read the article, scan the cited sources, decide
+      whether the Current Answer still holds, and if not, str_replace the
+      thesis paragraph.
 ```
+
+A custom role without `cron:` is template-only and won't auto-fire — that's how you keep a role checked into the YAML for documentation while disabling it.
+
+### Available fields
+
+Every field is optional unless your role is custom (in which case `system:`, `tools:`, and `cron:` are required for it to auto-run).
+
+| Field | What it controls |
+|---|---|
+| `provider` | `openai`, `anthropic`, or `openai-compatible`. |
+| `model` | Model name passed to the provider. |
+| `api_key_env` | Override which env var the runtime reads. Defaults to the standard per-provider name. |
+| `base_url` | Required for `openai-compatible`; ignored otherwise. |
+| `tools` | List of tool names from the registry (see below). |
+| `max_steps` | Per-tick cap on tool-call iterations. |
+| `reasoning_effort` | `minimal` \| `low` \| `medium` \| `high`. OpenAI-only; silently ignored for other providers. |
+| `system` | Full system prompt. Replaces the template's prompt entirely. Use sparingly — `instructions:` is usually enough. |
+| `user` | First user message template. Variables: `{{space_name}}`, `{{space_watch_dir}}`, `{{trigger_path}}`, `{{role_name}}`. |
+| `instructions` | Operator notes appended to whatever `system` resolves to. The recommended customization knob. |
+| `phases` | Multi-phase shape: each phase has its own prompt, model, and tool whitelist; conversation history carries across phase boundaries. Mutually exclusive with `user:`. |
+| `phase_models` | Per-phase model overrides keyed by phase name. Lets you stick with the template's phase prompts but swap models. |
+| `cron` | Five-field cron expression (`min hour day month dow`). Omitted = role never fires automatically. |
+| `spaces` | Spaces the role can *read* from. `[self]` (default), a list of space names, or `["*"]` for all. Writes always target the firing space. |
+
+### How merging works
+
+| Section | Behavior when set in both global and repo files |
+|---|---|
+| `defaults` | **Field-level merge.** `defaults.provider` from global + `defaults.model` from repo combine; repo wins on shared fields. Bundled-template defaults apply per-role under that. |
+| `roles.<name>` | **Per-role replacement** between user-global and repo-local. The repo's role entry wholesale replaces the global's — fields you don't repeat in the repo file are *not* inherited from the global override. (Both still inherit from the bundled template.) |
+
+To carry a field from a global role override into the repo file, copy it. The asymmetry keeps role overrides predictable: when you write `roles.writer:` in your repo's YAML, you're declaring exactly what that role looks like for this repo.
 
 ### Config commands
 
@@ -108,66 +200,34 @@ arkeon-wiki config show               # print merged effective config
 arkeon-wiki config validate           # schema-check the YAML
 ```
 
-`config show` is the source of truth for "what is actually going to run" — it reflects the merged result of `~/.arkeon-wiki/agents.yaml`, `.arkeon/agents.yaml`, and the bundled role templates that ship with the package.
+`config show` is the source of truth for "what is actually going to run" — it reflects the merged result of `~/.arkeon-wiki/agents.yaml`, `.arkeon/agents.yaml`, and the bundled role templates.
 
-### How merging works
+## Tools
 
-| Section | Behavior when set in both global and repo |
-|---|---|
-| `defaults` | **Field-level merge.** `defaults.provider` from global + `defaults.model` from repo combine. Repo wins on shared fields. |
-| `roles.<name>` | **Per-role replacement.** If `roles.ingestor` exists in both files, the repo entry replaces the global entry **wholesale** — fields you don't repeat are *not* inherited from the global. |
-
-This asymmetry keeps role overrides predictable: when you write `roles.ingestor:` in your repo's YAML, you're declaring exactly what that role looks like for this repo, not partially patching whatever your `~/` happens to have.
-
-To carry over a field from a global role override, copy it. The most common case is global YAML setting universal `defaults` and the per-repo file overriding individual roles — that works without copying anything because `defaults` *do* merge.
-
-## Bundled role templates
-
-| Role | Tools | Job |
-|---|---|---|
-| `ingestor` | `read_file`, `list_entities`, `search`, `edit_file` | Read a source file, identify the distinct subjects it discusses, and for each one either edit the existing wiki to weave the new material in (with a markdown link back to the source) or create a new wiki under `wiki/{subject_type}/{slug}.md` with a 2-4 paragraph body. |
-| `consolidator` | `read_file`, `list_entities`, `search`, `edit_file`, `delete_wiki` | Per-wiki cascade after the ingestor: surveys the corpus for related material and either cross-links, bleeds into another wiki, or merges the subject away. Outward-only — never replaces other wikis' content. |
-
-The templates ship as YAML files in the package (`src/server/agents/templates/<name>.yaml`) and are loaded fresh from disk on every agent run. You can override any field of a template (`provider`, `model`, `tools`, `max_steps`, `instructions`, `system`, `user`, `triggers`, `phases`) in your `.arkeon/agents.yaml` without redefining the whole role. To inherit the workflow but bias the focus, set `instructions:` only.
-
-Provenance: the `ingestor` writes a markdown link from each wiki body back to the source path it drew material from. The existing link-resolution path turns those into edges in the `relationships` table — so "which sources contributed to this wiki?" is a SQL query over `relationships`, not a separate inbox.
-
-## Custom roles
-
-Define a custom role by adding any name under `roles:` that doesn't match a bundled template. Custom roles **must** specify:
-
-- `system:` — the full system prompt (the workflow)
-- `tools:` — list of tool names from the registry
-
-Optional: `provider`, `model`, `api_key_env`, `base_url`, `max_steps`, `user` (template), `instructions`.
-
-The available tools are:
+Roles call tools to read state, search, and mutate the wiki. The registry is small on purpose — agents do less harm with fewer levers.
 
 | Tool | Use |
 |---|---|
-| `list_entities` | Frontmatter-aware enumeration: filter by `subject_type`, `status`, `label_contains` (case-insensitive substring match — `"Baker Street"` finds `"221B Baker Street"`). |
-| `search` | Keyword search via ripgrep, returns ranked entity hits with snippets. |
-| `read_file` | Read a file's contents (markdown returns parsed frontmatter + body). |
-| `edit_file` | The single file-mutation tool. Three modes dispatched on `search` and whether the path exists:<br>**CREATE** — empty `search`, file doesn't exist → creates the file with `replace` as content.<br>**APPEND** — empty `search`, file exists → appends `replace` to the body.<br>**REPLACE** — non-empty `search` (must match exactly once) → Aider-style SEARCH/REPLACE.<br>There's no overwrite path; to change a wiki's label, REPLACE just the `label:` line. |
+| `read_file` | Read one file with line numbers. Required before `edit_file` on the same path. |
+| `read_files` | Batched `read_file`, up to 10 paths in one call. |
+| `list_entities` | Filtered listing of wikis and sources. Supports `type`, `label_contains`, `path_contains`, `inbound_min`/`max`, `outbound_min`/`max`, `has_tag`, `not_has_tag`, `tag_current`, `tag_outdated`, sort, limit, offset. |
+| `list_redlinks` | Link targets without an entity row, ranked by demand. Carries up to 3 `linked_from` paths per target. |
+| `get_entity` | Single entity with inbound + outbound link neighborhoods. |
+| `get_entities` | Batched `get_entity`, up to 10 paths. |
+| `search` | Ripgrep keyword search; OR up to 10 patterns in one pass. |
+| `edit_file` | Two modes: `insert_at_line` (additive insert before a given line) and `str_replace` (exact-match search/replace). Path must have been `read_file`-ed in this run. |
+| `create_file` | Create a new wiki under `wiki/**.html`. Validates the HTML envelope. |
+| `delete_wiki` | Guarded full-file deletion. Reason required. Restricted to `wiki/**`. |
+| `tag_entity` | Set or clear an agent-applied tag on any entity. Idempotent. |
+| `mark_processed` | Shorthand for `tag_entity(role + "processed_hash", entity.source_hash)`. |
 
-### Prompt template variables
-
-Both `system:` and `user:` are templates. Available variables:
-
-| Variable | Resolves to |
-|---|---|
-| `{{trigger_path}}` | The path that triggered this run (source file path, wiki path, etc.). Empty if the agent was invoked without a trigger. |
-| `{{trigger_entity_id}}` | The entity id of the trigger. Empty if none. |
-| `{{space_id}}` / `{{space_name}}` / `{{space_watch_dir}}` | The space the agent is running in. |
-| `{{role_name}}` | The role being run. |
-
-Unknown placeholders resolve to the empty string (no errors).
+When you list `tools:` on a role, the runtime exposes exactly that subset to the model — any tool not listed is invisible, even if the model knows about it from training. Custom roles must declare their `tools:` array explicitly; bundled roles inherit theirs from the template.
 
 ## Providers
 
 | Provider | What it covers | Required fields |
 |---|---|---|
-| `openai` | Anything on `api.openai.com` (GPT-5, GPT-4o, etc.) | `model` |
+| `openai` | Anything on `api.openai.com` (GPT-5 family, GPT-4o, etc.) | `model` |
 | `anthropic` | Claude (Sonnet, Opus, Haiku) | `model` |
 | `openai-compatible` | Ollama, LM Studio, llama.cpp `--server`, vLLM, OpenRouter, Groq, Together, Fireworks, DeepInfra — anything speaking the OpenAI chat-completions shape | `model`, `base_url` |
 
@@ -202,45 +262,26 @@ defaults:
   model: gpt-5-mini
 
 roles:
-  ingestor:                   # default ingestion on cheap OpenAI
+  editor:                       # cheap fast model for source integration
     model: gpt-5-mini
-  reviewer:                   # custom role on stronger Claude
+  writer:                       # stronger model for article drafting
     provider: anthropic
     model: claude-opus-4-7
     api_key_env: ANTHROPIC_API_KEY
-    tools: [list_entities, read_file, edit_file]
-    system: |
-      You review recently-edited wikis for clarity and citation quality...
-  drafter:                    # local model for offline drafting
-    provider: openai-compatible
-    base_url: http://localhost:11434/v1
-    model: llama3.1:70b
-    tools: [list_entities, read_file, edit_file]
-    system: |
-      You draft wiki bodies offline...
 ```
 
-Each role gets its own provider and key. Set `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` in `~/.arkeon-wiki/.env`; the local model needs no key.
+Each role gets its own provider and key. Set `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` in `~/.arkeon-wiki/.env`; local models need no key.
 
 ## Verifying setup
 
-A real-LLM smoke test ships with the package:
-
 ```bash
-npm install -g arkeon-wiki    # if not already installed
-# (with key set in ~/.arkeon-wiki/.env or shell)
 arkeon-wiki up
 arkeon-wiki init
-arkeon-wiki config show       # confirm merged config
+arkeon-wiki config show       # confirm merged config — provider, model, instructions
+arkeon-wiki logs -f           # tail the daemon log to watch agent runs
 ```
 
-If you have the package source checked out:
-
-```bash
-npm run test:manual -w packages/arkeon
-```
-
-This runs the `ingestor` role against a synthetic source paragraph and prints the wikis that landed, token usage, and total cost.
+Agent runs emit human-readable lines as `[agent/<role>/<level>] ...` in the daemon log. For structured per-event traces, set `ARKEON_WIKI_AGENT_TRACE=1` before starting the daemon — one JSON object per line lands in `<arkeonHome>/agent-trace.jsonl`.
 
 ## Troubleshooting
 
@@ -251,34 +292,17 @@ Your YAML resolved to `provider: openai`, but no key was found. Drop one in `~/.
 You set `provider: openai-compatible` (often inherited from a default) but didn't set `base_url`. Either set it or change to `openai` / `anthropic`.
 
 **`Role 'X': no system prompt`**
-You defined a custom role but left out `system:`. Built-in roles fall back to a template; custom roles must supply their own.
+You defined a custom role but left out `system:`. Bundled roles fall back to a template; custom roles must supply their own.
 
 **`Role 'X': no tools configured`**
-Same idea — custom roles must specify `tools:`.
+Same idea — custom roles must declare `tools:` explicitly.
+
+**`agents.yaml uses the legacy 'triggers:' field`**
+The runtime is now cron-paced. Replace `triggers:` with `cron: "<expression>"` (e.g. `cron: "*/15 * * * *"`). Per-space serialization is handled by the runtime, so the old `by_role` / `by_role_not` loop-safety options are gone.
 
 **Schema errors from `config validate`**
-Check the unknown field name; the schema is strict. The likely candidates:
+Check the unknown field name; the schema is strict. The common candidates:
 - `provider` accepts only `openai | anthropic | openai-compatible`
-- `max_steps` must be a positive integer
-- `tools` is an array of strings (tool names)
-
-## How auto-triggering works
-
-When the daemon is running and you drop, edit, or save a file under the space's watch directory, the chain is:
-
-1. The file watcher fires.
-2. `syncFile` updates the SQLite index.
-3. The scheduler sees the path and asks `shouldTrigger`: is it under `wiki/**` or `.arkeon/**`? If yes, drop the event (this is what prevents the ingestor from re-firing on its own writes). Otherwise, enqueue a row in `agent_queue` keyed by `(space, role, source_path)`.
-4. A per-space worker claims the next pending row, calls `runAgent` for the `ingestor` role, and on success deletes the row. On failure it resets `started_at` to null with `last_error` set; the next claim retries.
-
-Rapid saves of the same file are coalesced: the `UNIQUE(space, role, path)` constraint means five saves in a second produce one queue row that runs against the latest content.
-
-The queue is crash-safe via a 5-minute lease. If the daemon dies while a row is in flight, the next daemon startup runs `reclaimOrphans()` which resets stale `started_at` values back to pending.
-
-In v1 the trigger filter is hardcoded: every non-`wiki/`, non-`.arkeon/` file event fires the ingestor. User-tunable include/exclude lands later when there's a real use case.
-
-## What's not yet wired
-
-- **User-tunable trigger filters** — currently hardcoded to "everything except `wiki/**` and `.arkeon/**`". When operators need to scope it (e.g., only files under `inbox/**`), an opt-in `trigger.include` field lands in agents.yaml.
-- **Per-role budgets / cost caps** — set `max_steps` for now; spending caps are a planned follow-up.
-- **Streaming output** — `runAgent` currently waits for the full response. Streaming will come with the daemon integration.
+- `max_steps` must be a positive integer ≤ 100
+- `tools` is an array of strings (tool names from the registry)
+- `cron` must be a valid five-field unix-cron expression

--- a/docs/user/API.md
+++ b/docs/user/API.md
@@ -1,8 +1,15 @@
 # API reference
 
-Default base URL: `http://localhost:8000` (or the port reported by `arkeon-wiki status` for named instances).
+Default base URL: `http://localhost:8000` (or the port reported by `arkeon-wiki status` for named instances — derived from the instance name as `8000 + sha256(name) mod 999 + 1`).
 
-No auth. No content negotiation — every endpoint returns JSON. Errors follow the [error contract](../dev/ERROR_CONTRACT.md).
+No auth. JSON responses for the data routes; the reader routes return HTML (documented at the bottom). Errors follow the [error contract](../dev/ERROR_CONTRACT.md).
+
+Routes split into two halves:
+
+- **`/spaces` and `/{space}/...`** — JSON API for programmatic access.
+- **`/`, `/{space}/`, `/{space}/wiki/*`, `/{space}/*`** — human-facing reader (HTML).
+
+The reader is mounted last; `/{space}/*` only matches URLs no JSON route has claimed.
 
 ---
 
@@ -10,7 +17,7 @@ No auth. No content negotiation — every endpoint returns JSON. Errors follow t
 
 ### `GET /health`
 
-Liveness. Always returns `200` if the process is up.
+Liveness. Returns `200` if the process is up.
 
 ```json
 { "status": "ok" }
@@ -20,15 +27,11 @@ Liveness. Always returns `200` if the process is up.
 
 Readiness. Returns `200` if SQLite is reachable, `503` otherwise.
 
-```json
-{ "status": "ready" }
-```
-
 ---
 
 ## Spaces
 
-A space is a registered directory the daemon watches.
+A space is a registered directory the daemon watches. Spaces are keyed by **name** (the primary key) — there is no separate ULID.
 
 ### `POST /spaces`
 
@@ -40,21 +43,22 @@ Register a new space. The file watcher starts in the background; the response re
 { "name": "my-notes", "watch_dir": "/Users/me/notes" }
 ```
 
+`name` must match `[a-zA-Z0-9][a-zA-Z0-9._-]*` and be ≤100 chars (no slashes, no whitespace, no `..` — the name becomes a URL path segment). Collisions return `409`.
+
 **Response:** `201`
 
 ```json
-{ "id": "01JSG...", "name": "my-notes", "watch_dir": "/Users/me/notes" }
+{ "name": "my-notes", "watch_dir": "/Users/me/notes" }
 ```
 
 ### `GET /spaces`
 
-List all spaces with entity counts.
+List every registered space with its entity count.
 
 ```json
 {
   "spaces": [
     {
-      "id": "01JSG...",
       "name": "my-notes",
       "watch_dir": "/Users/me/notes",
       "created_at": "2026-04-26T18:00:00.000Z",
@@ -64,42 +68,44 @@ List all spaces with entity counts.
 }
 ```
 
-### `GET /spaces/:id`
+### `GET /spaces/:name`
 
-Single space. Returns `404` if not found.
+Single space + its entity count. Returns `404` if not found.
 
 ---
 
 ## Entities
 
-Three kinds live in the `entities` table and are surfaced through one endpoint:
+Two kinds live in the `entities` table:
 
-- `type='wiki'` — markdown files under `wiki/` with YAML frontmatter.
-- `type='file'` — every other file the watcher picks up (sources, notes, plain text).
-- `type='stub'` — placeholder entities created when a wiki body contains a `[[Label]]` or `[[Label|subject_type]]` reference whose target doesn't yet exist. Stubs hold the slot until a real wiki is written there, at which point the entity is upgraded in place. They're GC'd at the end of every sync once nothing points at them anymore.
+- `type='wiki'` — HTML files under `wiki/` with `<title>` + `<meta>` tags.
+- `type='file'` — every other indexed file (sources, notes, plain text).
 
-### `GET /entities`
+Identity is `(space_name, source_path)` — no separate ID column. Link targets without a matching entity row are **red links**, surfaced via `/{space}/redlinks`.
 
-Generic listing with structural, frontmatter, link-count, and recency filters.
+### `GET /{space}/entities`
+
+Filterable listing scoped to one space.
 
 **Query parameters:**
 
-| Param | Default | Notes |
-|---|---|---|
-| `space_id` | — | Filter to one space. |
-| `type` | — | Comma-separated: any of `wiki`, `file`, `stub`. Omit to include all types. |
-| `subject_type` | — | Match `properties.subject_type` exactly (e.g. `person`, `organization`). Wiki-only in practice — files and stubs don't carry frontmatter. |
-| `status` | — | Match `properties.status` exactly. Free-form. |
-| `label_contains` | — | Case-insensitive substring match on `label`. |
-| `inbound_min`, `inbound_max` | — | Inclusive bounds on inbound relationship count. `inbound_max=0` finds entities nothing points at — useful for "uncited sources". |
-| `outbound_min`, `outbound_max` | — | Inclusive bounds on outbound relationship count. |
-| `has_unresolved_outbound` | — | `true` finds entities with at least one outbound edge to a stub (i.e. wikis with open threads). `false` finds entities whose outbound links all resolve. |
-| `updated_since` | — | ISO timestamp; only entities with `updated_at >=` this. |
-| `edited_by_role` | — | Filter on the most-recent-edit's `by_role` (joins the `entity_latest_edit` view). Use `human` for filesystem-driven edits. |
-| `sort` | `updated_at` | `updated_at` (DESC), `label` (ASC), `inbound` (DESC), or `outbound` (DESC). |
-| `include` | — | Comma-separated. `relationships` adds a top-level `relationships` array (every edge touching a matched entity). `counts` attaches `{ inbound, outbound }` to each row. |
-| `limit` | `100` | Max `10000`. |
-| `offset` | `0` | Pagination offset. |
+| Param | Notes |
+|---|---|
+| `type` | Comma-separated: `wiki`, `file`, or both. Omit to include all. |
+| `label_contains` | Case-insensitive substring match on `label`. |
+| `path_contains` | Case-insensitive substring match on `source_path`. |
+| `inbound_min`, `inbound_max` | Inclusive bounds on inbound link count. `inbound_max=0` finds entities nothing points at. |
+| `outbound_min`, `outbound_max` | Inclusive bounds on outbound link count. |
+| `updated_since` | ISO timestamp; only entities with `updated_at >=` this. |
+| `edited_by_role` | Filter on the most-recent edit's `by_role` (joins `entity_edits`). Use `human` for filesystem-driven edits. |
+| `has_tag`, `not_has_tag` | Filter on the presence/absence of a top-level key in `entities.tags`. Dotted keys (`editor.processed_hash`) are handled verbatim. |
+| `tag_equals` | `key:value` — match entities whose `tags[key] == value`. Splits on the first colon, so values may contain colons. |
+| `tag_current` | Key name. Match entities where the stored tag value equals the entity's current `source_hash` — "already processed at the current content." |
+| `tag_outdated` | Inverse of `tag_current`: tag absent OR value doesn't match — covers "never processed" + "stale" in one query. |
+| `sort` | `updated_at` (DESC, default), `label` (ASC), `inbound` (DESC), or `outbound` (DESC). |
+| `include` | Comma-separated. `counts` attaches `{inbound, outbound}` to each row. |
+| `limit` | Default `100`, max `10000`. |
+| `offset` | Pagination offset. |
 
 **Response:**
 
@@ -107,20 +113,17 @@ Generic listing with structural, frontmatter, link-count, and recency filters.
 {
   "entities": [
     {
-      "id": "01JSG...",
-      "space_id": "01JSF...",
+      "space_name": "my-notes",
+      "source_path": "wiki/photosynthesis.html",
       "type": "wiki",
-      "label": "Claude Shannon",
-      "source_path": "wiki/person/claude-shannon.md",
-      "properties": { "subject_type": "person", "birth_year": 1916 },
+      "label": "Photosynthesis",
+      "source_hash": "ab12cd...",
+      "properties": { "short_description": "How plants convert light to chemical energy." },
+      "tags": { "editor.processed_hash": "ab12cd..." },
       "created_at": "2026-04-26T18:00:00.000Z",
       "updated_at": "2026-04-26T18:00:00.000Z",
-      "has_unresolved_outbound": false,
-      "last_edited_by": "human",
-      "counts": {
-        "inbound": 5,
-        "outbound": 1
-      }
+      "last_edited_by": "writer",
+      "counts": { "inbound": 3, "outbound": 5 }
     }
   ],
   "total": 142,
@@ -129,133 +132,191 @@ Generic listing with structural, frontmatter, link-count, and recency filters.
 }
 ```
 
-`properties` is stored as JSON text in SQLite but the API parses it before returning, so callers get an object (or array, or `null`) — not a string. `counts` is only present when `include=counts`. `has_unresolved_outbound` and `last_edited_by` are always present.
+`properties` (file-derived: `<meta>` tags + `file_type`) and `tags` (agent-applied bookkeeping) are stored as JSON text in SQLite but parsed before being returned. `counts` is only present with `include=counts`. `last_edited_by` is always present and is `null` if no edits have been recorded.
 
-### `GET /entities/:id`
+### `GET /{space}/entities/*`
 
-Properties plus incoming and outgoing relationships for any entity (wiki, file, or stub). Returns `404` if `id` is unknown.
+Single entity by path. The path is everything after `/entities/` — e.g. `/my-notes/entities/wiki/photosynthesis.html` resolves to the entity at `wiki/photosynthesis.html` in space `my-notes`. Returns `404` if the path is unknown.
 
 **Query parameters:**
 
 | Param | Notes |
 |---|---|
-| `include` | Comma-separated. `content` reads the file from disk and adds a `content` field (skipped for stubs, which don't have a file). |
+| `include` | Comma-separated. `content` reads the file from disk and adds a `content` field with the UTF-8 body (or `null` if unreadable). |
 
-**Response:**
+**Response:** the entity row plus `inbound` and `outbound` arrays of relationships:
 
 ```json
 {
-  "id": "01JSG...",
-  "space_id": "01JSF...",
+  "space_name": "my-notes",
+  "source_path": "wiki/photosynthesis.html",
   "type": "wiki",
-  "label": "Claude Shannon",
-  "source_path": "wiki/person/claude-shannon.md",
-  "properties": { "subject_type": "person" },
-  "created_at": "2026-04-26T18:00:00.000Z",
-  "updated_at": "2026-04-26T18:00:00.000Z",
-  "relationships": {
-    "outgoing": [
-      {
-        "id": "01JSH...",
-        "target_id": "01JSI...",
-        "predicate": "references",
-        "link_text": "Bell Labs",
-        "link_path": "../organization/bell-labs.md",
-        "target_label": "Bell Labs",
-        "target_type": "wiki",
-        "target_source_path": "wiki/organization/bell-labs.md"
-      }
-    ],
-    "incoming": []
-  }
+  "label": "Photosynthesis",
+  "source_hash": "ab12cd...",
+  "properties": { "short_description": "..." },
+  "tags": {},
+  "created_at": "...",
+  "updated_at": "...",
+  "last_edited_by": "writer",
+  "inbound": [
+    { "source_path": "wiki/plants.html", "link_text": "photosynthesis" }
+  ],
+  "outbound": [
+    { "target_path": "wiki/chloroplast.html", "link_text": "chloroplasts" }
+  ]
 }
 ```
 
-With `?include=content`, a `content` field is added with the file's full UTF-8 text (or `null` if the file isn't readable). Stubs always read back `content: null`.
+There is no separate "history" endpoint — see `/{space}/recent` for the edit feed.
 
-### `GET /entities/:id/history`
+---
 
-Chronological audit log of edits to this entity (newest first), sourced from the `entity_edits` table.
+## Red links
+
+### `GET /{space}/redlinks`
+
+Link targets in this space with no matching entity row, aggregated by `target_path` and ranked by demand (the number of relationships pointing at them). The writer drains this queue.
 
 **Query parameters:**
 
 | Param | Default | Notes |
 |---|---|---|
-| `limit` | `50` | Max `500`. |
+| `limit` | `100` | Max `10000`. |
 | `offset` | `0` | Pagination offset. |
-| `since` | — | ISO timestamp; only edits at-or-after this. |
-| `role` | — | Restrict to a single `by_role`. |
 
 **Response:**
 
 ```json
 {
-  "entity_id": "01JSG...",
+  "redlinks": [
+    {
+      "target_path": "wiki/why-grief-feels-sweet.html",
+      "demand": 3,
+      "linked_from": [
+        "wiki/_plans/Augustine__book-04.html",
+        "wiki/the-restless-heart.html",
+        "wiki/_plans/Augustine__book-09.html"
+      ]
+    }
+  ],
+  "total": 17,
+  "limit": 100,
+  "offset": 0
+}
+```
+
+`linked_from` carries the last 3 source paths pointing at each target (most recent first).
+
+---
+
+## Recent edits
+
+### `GET /{space}/recent`
+
+The `entity_edits` feed for this space, newest first.
+
+**Query parameters:**
+
+| Param | Default | Notes |
+|---|---|---|
+| `since` | — | ISO timestamp; only edits at-or-after this. |
+| `role` | — | Restrict to a single `by_role` (e.g. `human`, `writer`, `editor`). |
+| `limit` | `50` | Max `500`. |
+| `offset` | `0` | Pagination offset. |
+
+**Response:**
+
+```json
+{
+  "space": "my-notes",
   "edits": [
     {
-      "id": 42,
-      "by_role": "ingestor",
-      "edit_kind": "append",
-      "edit_note": "added Bell Labs paragraph",
+      "entity_path": "wiki/photosynthesis.html",
+      "by_role": "writer",
+      "edit_kind": "create",
+      "edit_note": null,
       "content_hash": "ab12cd...",
-      "at": "2026-04-26T19:30:00.000Z"
+      "at": "2026-04-26T19:30:00.123"
     }
   ]
 }
 ```
 
-### `DELETE /entities/:id`
-
-Remove an entity from the index. The file on disk is **not** deleted — but if it still exists, the watcher will re-index it on the next change. Returns `404` if `id` is unknown. Cascades through relationships and chunks.
-
-```json
-{ "deleted": true, "id": "01JSG...", "label": "Claude Shannon", "type": "wiki" }
-```
+`at` carries millisecond precision (sourced from `strftime('%f')`) so same-second writes don't collide.
 
 ---
 
 ## Search
 
-### `GET /search`
+### `GET /{space}/search`
 
-Keyword search via ripgrep. The daemon spawns ripgrep against each space's `watch_dir`, parses `--json` output, and joins the matched paths back to entities. Results are ranked by `match_count` descending; ties broken by `entity_id`.
+Keyword search via ripgrep, scoped to one space. The daemon spawns ripgrep against the space's `watch_dir`, parses `--json` output, and joins matched paths back to entities. Ranked by `match_count` descending.
 
 **Query parameters:**
 
 | Param | Default | Notes |
 |---|---|---|
-| `q` | — | **Required.** Literal substring by default. |
-| `space_id` | — | Restrict to one space. Omit to search every registered space. |
+| `q` | — | **Required.** Repeatable up to 10 times to OR patterns in one pass (`?q=foo&q=bar`). |
+| `type` | — | Comma-separated entity types to restrict hits to (`wiki`, `file`). |
 | `limit` | `20` | Max `200`. |
 | `snippets` | `3` | Max snippets per file. `0` returns counts only. Snippets are truncated to 240 chars. |
-| `regex` | `false` | When `true`, treat `q` as a regular expression. |
-
-ripgrep runs with `--smart-case`, skips `.arkeon/`, `.git/`, and `node_modules/`, and only searches files of types `md`, `txt`, `json`, `csv`, `xml`, `html`, `rst`.
+| `regex` | `false` | When `true`, treat each `q` as a regular expression. |
 
 **Response:**
 
 ```json
 {
   "query": "shannon",
-  "hits": [
-    {
-      "entity_id": "01JSG...",
-      "space_id": "01JSF...",
-      "type": "wiki",
-      "label": "Claude Shannon",
-      "source_path": "wiki/person/claude-shannon.md",
-      "match_count": 7,
-      "snippets": [
-        { "line_number": 12, "text": "Claude Shannon was the father..." },
-        { "line_number": 34, "text": "Shannon's 1948 paper..." }
-      ]
-    }
-  ],
-  "unmatched_files": 0
+  "keyword": {
+    "hits": [
+      {
+        "space_name": "my-notes",
+        "source_path": "wiki/claude-shannon.html",
+        "type": "wiki",
+        "label": "Claude Shannon",
+        "match_count": 7,
+        "snippets": [
+          { "line_number": 12, "text": "Claude Shannon was the father..." }
+        ]
+      }
+    ],
+    "total": 1,
+    "unmatched_files": 0
+  }
 }
 ```
 
-`unmatched_files` counts files ripgrep matched but for which no entity exists in the index — usually means the watcher hasn't caught up yet, or the file was matched outside the indexed file types.
+`query` echoes the input shape (string or string array). `unmatched_files` counts files ripgrep matched but for which no entity exists in the index — usually a watcher lag.
+
+---
+
+## Chat (Phase 3 stubs)
+
+Three routes are reserved for the chat-with-article feature. All currently return `501`:
+
+```
+POST   /{space}/chat
+GET    /{space}/chat/:conversation_id
+DELETE /{space}/chat/:conversation_id
+```
+
+The `conversations` and `conversation_messages` tables are in place; the handlers ship in Phase 3.
+
+---
+
+## Reader (HTML)
+
+The reader serves human-facing HTML pages. Always mounted last, so it never shadows a JSON route.
+
+| Route | Returns |
+|---|---|
+| `GET /` | Alphabetical list of registered spaces with per-space entity counts. |
+| `GET /{space}` | `301` redirect to `/{space}/`. |
+| `GET /{space}/` | Article index — `type='wiki'` entries alphabetical by `label`, with `short_description` subtitles. |
+| `GET /{space}/wiki/*` | Wiki article with `<div id="arkeon-chrome">` injected and link classes (`arkeon-wiki`, `arkeon-file`, `arkeon-redlink`). Anchors are decorated, not rewritten — the same HTML opens identically over `file://`. |
+| `GET /{space}/*` | Static-file fallback for non-wiki paths inside the watch dir. Markdown → `text/markdown`, PDF → `application/pdf`, images → `image/*`, etc. Path-traversal escapes return `404`. |
+
+URL structure mirrors disk structure within a space: `wiki/foo.html` on disk → `/{space}/wiki/foo.html` over HTTP.
 
 ---
 

--- a/packages/arkeon/src/cli/commands/repo/config.ts
+++ b/packages/arkeon/src/cli/commands/repo/config.ts
@@ -46,11 +46,17 @@ const TEMPLATE = `# .arkeon/agents.yaml
 defaults:
   provider: openai             # openai | anthropic | openai-compatible
   model: gpt-5-mini
-  # Operator-supplied focus / style notes. Appended to every role's
-  # system prompt. Use this to steer subjects, tone, scope.
+  # 'instructions' is THE knob that makes your wiki opinionated.
+  # It's appended to every role's system prompt — editor, proposer,
+  # writer — without disturbing their workflows. Use it to declare
+  # what the wiki is about, what it's NOT about, what tone to take,
+  # and who the audience is. Without this, agents will write a
+  # generic wiki on whatever they find. With it, the corpus develops
+  # a point of view.
   # instructions: |
-  #   This wiki tracks researchers in climate science. Skip subjects
-  #   not directly relevant. Cross-link to existing wikis.
+  #   This wiki is about <topic>. Skip <out-of-scope subjects>.
+  #   Bias toward <preferred source types>. Tone: <voice>.
+  #   Audience: <reader profile>.
 
 # Per-role overrides (the bundled roles inherit by name). Add
 # custom roles here too — they need at least 'system', 'tools',


### PR DESCRIPTION
Closes #127.

## Summary

- Adds an "Opinionating your wiki" callout to the root README and `docs/user/AGENT_RUNTIME.md` making it explicit that `defaults.instructions:` is the knob for giving the wiki a point of view (topic, scope, tone, audience). Without it the agents write a generic wiki on whatever they find; with it the corpus develops editorial judgment.
- Strengthens the comment block above `instructions:` in the template `arkeon-wiki config init` writes, so new users see the framing immediately.
- Refreshes `docs/user/AGENT_RUNTIME.md` to match the current runtime — the old version described `ingestor`/`consolidator`, the deleted `agent_queue` table, and the file-watcher-driven trigger model. New version covers the three bundled roles (`editor`, `proposer`, `writer`), cron-paced scheduling + per-space mutex, three tiers of customization (defaults → per-role overrides → custom roles), and the current 12-tool registry.
- Rewrites `docs/user/API.md` to match the current path-keyed, space-scoped, HTML-wiki API. Drops the stale ULID-keyed routes, `subject_type`/`status`/`has_unresolved_outbound` filters, `type='stub'` and `[[Label]]` mechanism, `.md` wiki paths, and `entity_id`/`space_id` request params.

## Test plan

- [ ] `arkeon-wiki config init` in a fresh repo writes the updated template; the `instructions:` comment block reads as intended
- [ ] `docs/user/AGENT_RUNTIME.md` renders cleanly on GitHub (tables, code fences)
- [ ] `docs/user/API.md` cross-checks against route handlers in `packages/arkeon/src/server/routes/`
- [ ] README "Opinionating your wiki" section reads as the recommended path before "override `system:` directly"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
