### PR TITLE
init: write .arkeon/agents.yaml + gitignore .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,15 @@ arkeon-wiki start              # foreground (for use under pm2/launchd/etc.)
 
 ## Agents (LLM-powered)
 
-arkeon-wiki ships a three-role agent pipeline — `editor`, `proposer`, `writer` — that ingests sources, proposes the questions worth answering, and drafts the HTML articles. All three run on cron, serialized per-space. Configure them in `.arkeon/agents.yaml` (committed) and put your API key in `~/.arkeon-wiki/.env` (per-user, machine-local).
+arkeon-wiki ships a three-role agent pipeline — `editor`, `proposer`, `writer` — that ingests sources, proposes the questions worth answering, and drafts the HTML articles. All three run on cron, serialized per-space. `arkeon-wiki init` lays down `.arkeon/agents.yaml` from the bundled `wiki` template (committed so the team shares it); secrets go in `~/.arkeon-wiki/.env` (per-user, machine-local).
 
 ```bash
-arkeon-wiki config init                                       # template config
 echo "OPENAI_API_KEY=sk-..." > ~/.arkeon-wiki/.env             # one key for all spaces
 $EDITOR .arkeon/agents.yaml                                    # set provider/model/instructions
 arkeon-wiki config show                                        # confirm what'll run
 ```
+
+`init` skips the template if `.arkeon/agents.yaml` already exists. To re-create one (or pick a different template later) run `arkeon-wiki config init --template <name>` (use `--force` to overwrite).
 
 Roles run on OpenAI, Anthropic, or any OpenAI-compatible backend (Ollama, LM Studio, OpenRouter, Groq, vLLM, …). Each role can use a different provider; secrets stay in `.env`, never YAML. Custom user-defined roles are first-class.
 
@@ -143,7 +144,7 @@ All state lives in `~/.arkeon-wiki/` (override with `ARKEON_WIKI_HOME` or `--dat
 | `--port <port>` flag | API port (default: 8000) |
 | `--name <name>` flag | Run a named instance side-by-side with others |
 | `~/.arkeon-wiki/.env` | Universal API keys (OpenAI, Anthropic, etc.) — auto-loaded |
-| `<repo>/.env` | Per-repo API key override (gitignored by `init`) |
+| `<repo>/.env` | Per-repo API key override. Gitignored by `init` (alongside `.arkeon/state.json`). |
 | `.arkeon/agents.yaml` | Per-repo agent config: providers, models, operator instructions, custom roles. Committed. See [AGENT_RUNTIME.md](./docs/user/AGENT_RUNTIME.md). |
 
 ## Development

--- a/packages/arkeon/src/cli/commands/repo/config.ts
+++ b/packages/arkeon/src/cli/commands/repo/config.ts
@@ -31,9 +31,6 @@ import { output } from "../../lib/output.js";
 
 export const AGENTS_YAML_RELATIVE_PATH = join(".arkeon", "agents.yaml");
 
-// Kept as a const for back-compat with anything still importing it.
-const REPO_RELATIVE_PATH = AGENTS_YAML_RELATIVE_PATH;
-
 export const DEFAULT_AGENTS_TEMPLATE = "wiki";
 
 const WIKI_TEMPLATE = `# .arkeon/agents.yaml
@@ -245,7 +242,7 @@ async function runInit(force: boolean, template: string): Promise<void> {
 
 async function runValidate(): Promise<void> {
   const cwd = process.cwd();
-  const target = resolve(cwd, REPO_RELATIVE_PATH);
+  const target = resolve(cwd, AGENTS_YAML_RELATIVE_PATH);
 
   if (!existsSync(target)) {
     output.result({

--- a/packages/arkeon/src/cli/commands/repo/config.ts
+++ b/packages/arkeon/src/cli/commands/repo/config.ts
@@ -29,9 +29,14 @@ import { loadBundledTemplates } from "../../../server/agents/templates.js";
 import { listAvailableRoles } from "../../../server/agents/role-builder.js";
 import { output } from "../../lib/output.js";
 
-const REPO_RELATIVE_PATH = join(".arkeon", "agents.yaml");
+export const AGENTS_YAML_RELATIVE_PATH = join(".arkeon", "agents.yaml");
 
-const TEMPLATE = `# .arkeon/agents.yaml
+// Kept as a const for back-compat with anything still importing it.
+const REPO_RELATIVE_PATH = AGENTS_YAML_RELATIVE_PATH;
+
+export const DEFAULT_AGENTS_TEMPLATE = "wiki";
+
+const WIKI_TEMPLATE = `# .arkeon/agents.yaml
 #
 # Per-repo agent configuration. Committed to the repo so the team
 # shares the same focus, model choices, and operator instructions.
@@ -82,6 +87,62 @@ defaults:
 #       and rewrite the thesis.
 `;
 
+/**
+ * Registry of named templates that `arkeon-wiki init` and
+ * `arkeon-wiki config init` can lay down. Today there's one (`wiki`);
+ * the indirection exists so additional templates (e.g. a
+ * source-archive-only template, a notebook template) can land as new
+ * entries without changing the CLI surface.
+ */
+export const AGENTS_YAML_TEMPLATES: Record<string, string> = {
+  wiki: WIKI_TEMPLATE,
+};
+
+export interface WriteAgentsYamlOptions {
+  /** The repo root. The file is written at {targetDir}/.arkeon/agents.yaml. */
+  targetDir: string;
+  /** Named template from AGENTS_YAML_TEMPLATES. Defaults to "wiki". */
+  template?: string;
+  /** Overwrite an existing file. Defaults to false. */
+  force?: boolean;
+}
+
+export interface WriteAgentsYamlResult {
+  /** False if the file already existed and force was not set. */
+  created: boolean;
+  /** Absolute path to the target file. */
+  path: string;
+  /** Resolved template name. */
+  template: string;
+}
+
+/**
+ * Write `.arkeon/agents.yaml` from a named template. Idempotent unless
+ * `force` is set: an existing file is left untouched.
+ *
+ * Throws if the template name isn't registered — the error lists what
+ * names are available so the caller can correct a typo.
+ */
+export function writeAgentsYamlTemplate(
+  opts: WriteAgentsYamlOptions,
+): WriteAgentsYamlResult {
+  const templateName = opts.template ?? DEFAULT_AGENTS_TEMPLATE;
+  const content = AGENTS_YAML_TEMPLATES[templateName];
+  if (!content) {
+    const available = Object.keys(AGENTS_YAML_TEMPLATES).sort().join(", ");
+    throw new Error(
+      `Unknown agents.yaml template '${templateName}'. Available: ${available}.`,
+    );
+  }
+  const target = resolve(opts.targetDir, AGENTS_YAML_RELATIVE_PATH);
+  if (existsSync(target) && !opts.force) {
+    return { created: false, path: target, template: templateName };
+  }
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, content);
+  return { created: true, path: target, template: templateName };
+}
+
 export function registerConfigCommand(program: Command): void {
   const cmd = program
     .command("config")
@@ -103,9 +164,15 @@ export function registerConfigCommand(program: Command): void {
     .command("init")
     .description("Create .arkeon/agents.yaml from a template")
     .option("--force", "Overwrite an existing file", false)
-    .action(async (options: { force: boolean }) => {
+    .option(
+      "--template <name>",
+      `Named template to use (default: ${DEFAULT_AGENTS_TEMPLATE}). ` +
+        `Available: ${Object.keys(AGENTS_YAML_TEMPLATES).sort().join(", ")}.`,
+      DEFAULT_AGENTS_TEMPLATE,
+    )
+    .action(async (options: { force: boolean; template: string }) => {
       try {
-        await runInit(options.force);
+        await runInit(options.force, options.template);
       } catch (error) {
         output.error(error, { operation: "config init" });
         process.exitCode = 1;
@@ -150,27 +217,26 @@ async function runShow(): Promise<void> {
   }
 }
 
-async function runInit(force: boolean): Promise<void> {
+async function runInit(force: boolean, template: string): Promise<void> {
   const cwd = process.cwd();
-  const target = resolve(cwd, REPO_RELATIVE_PATH);
+  const result = writeAgentsYamlTemplate({ targetDir: cwd, template, force });
 
-  if (existsSync(target) && !force) {
+  if (!result.created) {
     output.result({
       operation: "config init",
       created: false,
-      path: target,
+      path: result.path,
+      template: result.template,
       hint: "File already exists. Use --force to overwrite, or edit it directly.",
     });
     return;
   }
 
-  mkdirSync(dirname(target), { recursive: true });
-  writeFileSync(target, TEMPLATE);
-
   output.result({
     operation: "config init",
     created: true,
-    path: target,
+    path: result.path,
+    template: result.template,
     hint:
       "Edit this file to set your provider/model and operator instructions. " +
       "Add API keys to .env (not this file).",

--- a/packages/arkeon/src/cli/commands/repo/init.ts
+++ b/packages/arkeon/src/cli/commands/repo/init.ts
@@ -4,8 +4,21 @@
 /**
  * `arkeon-wiki init [name]` — register the current directory as a space.
  *
- * Creates a space in the running Arkeon instance. The daemon automatically
- * starts watching the directory and syncs all files.
+ * First run: creates a space in the running Arkeon instance (POST
+ * /spaces), writes `.arkeon/state.json`, gitignores `.env` + state,
+ * creates `wiki/`, and lays down `.arkeon/agents.yaml` from a named
+ * template.
+ *
+ * Re-run (state.json already present): reconcile mode. Skips the API
+ * call, leaves state.json alone, but still ensures `.gitignore`,
+ * `wiki/`, and `.arkeon/agents.yaml` exist. All three helpers are
+ * idempotent (no clobber on existing files), so a user who deleted
+ * `.arkeon/agents.yaml` by hand or init'd with a pre-template version
+ * of the CLI can recover by re-running `init` — no need for a
+ * separate `config init` step.
+ *
+ * The `name` argument is ignored in reconcile mode; the existing
+ * space_name from state.json is canonical.
  */
 
 import type { Command } from "commander";
@@ -52,42 +65,55 @@ async function runInit(
   template: string,
 ): Promise<void> {
   const cwd = process.cwd();
-  const spaceName = name ?? basename(cwd);
   const apiUrl = process.env.ARKE_API_URL ?? `http://localhost:${DEFAULT_API_PORT}`;
 
-  // Check if already initialized
+  // Branch on whether the space is already known locally. Reconcile
+  // mode skips the API call and the state.json write but still runs
+  // the three idempotent fill-in-missing-pieces helpers below.
   const existing = loadRepoState();
+  let space: { name: string; watch_dir: string };
+  const reconciled = existing !== null;
+
   if (existing) {
-    console.log(`This directory is already initialized (space: ${existing.space_name}).`);
-    return;
+    space = { name: existing.space_name, watch_dir: resolve(cwd) };
+  } else {
+    const spaceName = name ?? basename(cwd);
+
+    // Create space via API — the server will automatically start watching
+    const res = await fetch(`${apiUrl}/spaces`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: spaceName, watch_dir: resolve(cwd) }),
+    });
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({})) as Record<string, unknown>;
+      throw new Error(
+        `Failed to create space: ${res.status} ${(body as { error?: { message?: string } }).error?.message ?? res.statusText}`,
+      );
+    }
+
+    space = (await res.json()) as { name: string; watch_dir: string };
+
+    // Write .arkeon/state.json
+    const arkeonDir = join(cwd, ".arkeon");
+    if (!existsSync(arkeonDir)) mkdirSync(arkeonDir, { recursive: true });
+
+    const state: RepoState = {
+      api_url: apiUrl,
+      space_name: space.name,
+      created_at: new Date().toISOString(),
+    };
+    writeFileSync(join(arkeonDir, "state.json"), JSON.stringify(state, null, 2));
   }
 
-  // Create space via API — the server will automatically start watching
-  const res = await fetch(`${apiUrl}/spaces`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ name: spaceName, watch_dir: resolve(cwd) }),
-  });
-
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({})) as Record<string, unknown>;
-    throw new Error(
-      `Failed to create space: ${res.status} ${(body as { error?: { message?: string } }).error?.message ?? res.statusText}`,
-    );
-  }
-
-  const space = (await res.json()) as { name: string; watch_dir: string };
-
-  // Write .arkeon/state.json
-  const arkeonDir = join(cwd, ".arkeon");
-  if (!existsSync(arkeonDir)) mkdirSync(arkeonDir, { recursive: true });
-
-  const state: RepoState = {
-    api_url: apiUrl,
-    space_name: space.name,
-    created_at: new Date().toISOString(),
-  };
-  writeFileSync(join(arkeonDir, "state.json"), JSON.stringify(state, null, 2));
+  // ── Reconcile pass (runs in both first-init and re-run) ────────
+  //
+  // All three helpers are idempotent: ensureGitignoreEntries skips
+  // already-present lines, mkdirSync `recursive` is a no-op on an
+  // existing dir, and writeAgentsYamlTemplate refuses to overwrite
+  // an existing file unless `force` is set. So a re-run repairs
+  // anything missing without clobbering hand-edits.
 
   // Gitignore the per-clone state file AND `.env` (where API keys
   // land). `.arkeon/agents.yaml` and any other configuration in the
@@ -104,29 +130,45 @@ async function runInit(
   const wikiDir = join(cwd, "wiki");
   if (!existsSync(wikiDir)) mkdirSync(wikiDir, { recursive: true });
 
-  // Lay down .arkeon/agents.yaml from a named template. Idempotent:
-  // if the file already exists we leave it alone so re-running `init`
-  // (or `init` after a manual edit) never clobbers operator config.
+  // Lay down .arkeon/agents.yaml from a named template.
   const agentsYaml = writeAgentsYamlTemplate({ targetDir: cwd, template });
 
   output.result({
     operation: "init",
     space_name: space.name,
     watch_dir: resolve(cwd),
+    reconciled,
     agents_yaml: {
       path: agentsYaml.path,
       created: agentsYaml.created,
       template: agentsYaml.template,
     },
     gitignore_updated: gitignoreChanged,
-    hint:
-      agentsYaml.created
-        ? "The daemon is now watching this directory. Edit .arkeon/agents.yaml " +
-          "to set your provider/model and operator instructions, then drop your " +
-          "API key in ~/.arkeon-wiki/.env or ./.env."
-        : "The daemon is now watching this directory. Any files you add will be " +
-          "synced automatically.",
+    hint: buildHint({ reconciled, agentsYamlCreated: agentsYaml.created, gitignoreChanged }),
   });
+}
+
+function buildHint(args: {
+  reconciled: boolean;
+  agentsYamlCreated: boolean;
+  gitignoreChanged: boolean;
+}): string {
+  if (!args.reconciled) {
+    // First init — point the user at config next.
+    return (
+      "The daemon is now watching this directory. Edit .arkeon/agents.yaml " +
+      "to set your provider/model and operator instructions, then drop your " +
+      "API key in ~/.arkeon-wiki/.env or ./.env."
+    );
+  }
+  // Re-run — be explicit about what (if anything) was filled in.
+  const filled: string[] = [];
+  if (args.agentsYamlCreated) filled.push(".arkeon/agents.yaml");
+  if (args.gitignoreChanged) filled.push(".gitignore");
+  if (filled.length === 0) {
+    return "Already initialized — nothing to reconcile.";
+  }
+  return `Already initialized — restored missing: ${filled.join(", ")}.`;
 }
 
 /**

--- a/packages/arkeon/src/cli/commands/repo/init.ts
+++ b/packages/arkeon/src/cli/commands/repo/init.ts
@@ -15,6 +15,11 @@ import { basename, join, resolve } from "node:path";
 import { DEFAULT_API_PORT } from "../../lib/local-runtime.js";
 import { output } from "../../lib/output.js";
 import { loadRepoState, type RepoState } from "../../lib/repo-state.js";
+import {
+  AGENTS_YAML_TEMPLATES,
+  DEFAULT_AGENTS_TEMPLATE,
+  writeAgentsYamlTemplate,
+} from "./config.js";
 
 // --api-url is declared on the root program (src/index.ts); the
 // preAction hook moves the value into ARKE_API_URL. Don't redeclare
@@ -26,9 +31,15 @@ export function registerInitCommand(program: Command): void {
     .command("init")
     .argument("[name]", "Space name (defaults to directory name)")
     .description("Register this directory as an Arkeon space")
-    .action(async (name: string | undefined) => {
+    .option(
+      "--template <name>",
+      `agents.yaml template to lay down (default: ${DEFAULT_AGENTS_TEMPLATE}). ` +
+        `Available: ${Object.keys(AGENTS_YAML_TEMPLATES).sort().join(", ")}.`,
+      DEFAULT_AGENTS_TEMPLATE,
+    )
+    .action(async (name: string | undefined, options: { template: string }) => {
       try {
-        await runInit(name);
+        await runInit(name, options.template);
       } catch (error) {
         output.error(error, { operation: "init" });
         process.exitCode = 1;
@@ -36,7 +47,10 @@ export function registerInitCommand(program: Command): void {
     });
 }
 
-async function runInit(name: string | undefined): Promise<void> {
+async function runInit(
+  name: string | undefined,
+  template: string,
+): Promise<void> {
   const cwd = process.cwd();
   const spaceName = name ?? basename(cwd);
   const apiUrl = process.env.ARKE_API_URL ?? `http://localhost:${DEFAULT_API_PORT}`;
@@ -75,42 +89,84 @@ async function runInit(name: string | undefined): Promise<void> {
   };
   writeFileSync(join(arkeonDir, "state.json"), JSON.stringify(state, null, 2));
 
-  // Gitignore only the per-clone state file. `.arkeon/agents.yaml` and
-  // any other configuration that lives in the .arkeon dir are intended
-  // to be committed so the team shares them.
-  const gitignorePath = join(cwd, ".gitignore");
-  if (existsSync(gitignorePath)) {
-    const gitignoreContent = readFileSync(gitignorePath, "utf-8");
-    const stale = ".arkeon/";
-    const target = ".arkeon/state.json";
-    let updated = gitignoreContent;
-    // Migrate any pre-existing `.arkeon/` (which would also hide
-    // committed config) to the narrower `.arkeon/state.json`.
-    if (
-      updated.split("\n").some((line) => line.trim() === stale) &&
-      !updated.includes(target)
-    ) {
-      updated = updated
-        .split("\n")
-        .map((line) => (line.trim() === stale ? target : line))
-        .join("\n");
-    }
-    if (!updated.includes(target)) {
-      updated = `${updated.trimEnd()}\n${target}\n`;
-    }
-    if (updated !== gitignoreContent) {
-      writeFileSync(gitignorePath, updated);
-    }
-  }
+  // Gitignore the per-clone state file AND `.env` (where API keys
+  // land). `.arkeon/agents.yaml` and any other configuration in the
+  // .arkeon dir are intended to be committed so the team shares them.
+  // If `.gitignore` doesn't exist yet we create it — leaking a
+  // provider key is a worse outcome than silently materializing a
+  // one-line file.
+  const gitignoreChanged = ensureGitignoreEntries(cwd, [
+    ".arkeon/state.json",
+    ".env",
+  ]);
 
   // Create wiki/ directory
   const wikiDir = join(cwd, "wiki");
   if (!existsSync(wikiDir)) mkdirSync(wikiDir, { recursive: true });
 
+  // Lay down .arkeon/agents.yaml from a named template. Idempotent:
+  // if the file already exists we leave it alone so re-running `init`
+  // (or `init` after a manual edit) never clobbers operator config.
+  const agentsYaml = writeAgentsYamlTemplate({ targetDir: cwd, template });
+
   output.result({
     operation: "init",
     space_name: space.name,
     watch_dir: resolve(cwd),
-    hint: "The daemon is now watching this directory. Any files you add will be synced automatically.",
+    agents_yaml: {
+      path: agentsYaml.path,
+      created: agentsYaml.created,
+      template: agentsYaml.template,
+    },
+    gitignore_updated: gitignoreChanged,
+    hint:
+      agentsYaml.created
+        ? "The daemon is now watching this directory. Edit .arkeon/agents.yaml " +
+          "to set your provider/model and operator instructions, then drop your " +
+          "API key in ~/.arkeon-wiki/.env or ./.env."
+        : "The daemon is now watching this directory. Any files you add will be " +
+          "synced automatically.",
   });
+}
+
+/**
+ * Ensure each entry exists in `<cwd>/.gitignore`, creating the file
+ * if it doesn't exist. Returns true if any write happened. Also
+ * migrates the legacy `.arkeon/` line (which would hide committed
+ * config) to the narrower `.arkeon/state.json` when the latter is
+ * one of the requested entries.
+ */
+function ensureGitignoreEntries(cwd: string, entries: string[]): boolean {
+  const gitignorePath = join(cwd, ".gitignore");
+  const existed = existsSync(gitignorePath);
+  const original = existed ? readFileSync(gitignorePath, "utf-8") : "";
+  let updated = original;
+
+  // Legacy `.arkeon/` → `.arkeon/state.json` migration. Only relevant
+  // when `.arkeon/state.json` is being ensured.
+  const stateEntry = ".arkeon/state.json";
+  if (entries.includes(stateEntry)) {
+    const stale = ".arkeon/";
+    const hasStale = updated.split("\n").some((line) => line.trim() === stale);
+    if (hasStale && !updated.includes(stateEntry)) {
+      updated = updated
+        .split("\n")
+        .map((line) => (line.trim() === stale ? stateEntry : line))
+        .join("\n");
+    }
+  }
+
+  // Per-line presence check — `.env` would match `.envrc` if we used
+  // `includes`, so compare trimmed lines exactly.
+  const presentLines = new Set(updated.split("\n").map((l) => l.trim()));
+  const toAdd = entries.filter((e) => !presentLines.has(e));
+  if (toAdd.length > 0) {
+    updated = `${updated.trimEnd()}\n${toAdd.join("\n")}\n`;
+    // If the file was empty/missing, drop the leading newline.
+    if (!existed) updated = updated.replace(/^\n/, "");
+  }
+
+  if (updated === original) return false;
+  writeFileSync(gitignorePath, updated);
+  return true;
 }

--- a/packages/arkeon/src/cli/commands/repo/init.ts
+++ b/packages/arkeon/src/cli/commands/repo/init.ts
@@ -135,8 +135,13 @@ async function runInit(
  * migrates the legacy `.arkeon/` line (which would hide committed
  * config) to the narrower `.arkeon/state.json` when the latter is
  * one of the requested entries.
+ *
+ * Exported for direct unit testing — the legacy-migration and
+ * empty/missing-file branches are non-trivial enough that exercising
+ * them only through `runInit` (which requires a live daemon) is too
+ * thin a coverage net.
  */
-function ensureGitignoreEntries(cwd: string, entries: string[]): boolean {
+export function ensureGitignoreEntries(cwd: string, entries: string[]): boolean {
   const gitignorePath = join(cwd, ".gitignore");
   const existed = existsSync(gitignorePath);
   const original = existed ? readFileSync(gitignorePath, "utf-8") : "";

--- a/packages/arkeon/test/unit/init-gitignore.test.ts
+++ b/packages/arkeon/test/unit/init-gitignore.test.ts
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ensureGitignoreEntries } from "../../src/cli/commands/repo/init.js";
+
+describe("ensureGitignoreEntries", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "arkeon-gitignore-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function gitignorePath(): string {
+    return join(dir, ".gitignore");
+  }
+
+  it("creates .gitignore with the requested entries when none exists", () => {
+    expect(existsSync(gitignorePath())).toBe(false);
+
+    const changed = ensureGitignoreEntries(dir, [".arkeon/state.json", ".env"]);
+    expect(changed).toBe(true);
+
+    const content = readFileSync(gitignorePath(), "utf-8");
+    expect(content).toBe(".arkeon/state.json\n.env\n");
+    // No leading newline before the first entry.
+    expect(content.startsWith("\n")).toBe(false);
+  });
+
+  it("migrates legacy `.arkeon/` to `.arkeon/state.json` and appends .env", () => {
+    writeFileSync(gitignorePath(), "node_modules/\n.arkeon/\n");
+
+    const changed = ensureGitignoreEntries(dir, [".arkeon/state.json", ".env"]);
+    expect(changed).toBe(true);
+
+    const content = readFileSync(gitignorePath(), "utf-8");
+    // Legacy .arkeon/ replaced in place, .env appended at end.
+    expect(content).toContain("node_modules/");
+    expect(content).toContain(".arkeon/state.json");
+    expect(content).toContain(".env");
+    expect(content).not.toMatch(/^\.arkeon\/$/m);
+  });
+
+  it("does not false-match .env against an existing .envrc line", () => {
+    writeFileSync(gitignorePath(), ".envrc\n");
+
+    const changed = ensureGitignoreEntries(dir, [".env"]);
+    expect(changed).toBe(true);
+
+    const content = readFileSync(gitignorePath(), "utf-8");
+    expect(content).toContain(".envrc");
+    // .env appears on its own line, not as a substring match of .envrc.
+    expect(content.split("\n").map((l) => l.trim())).toContain(".env");
+  });
+
+  it("returns false and doesn't write when all entries are already present", () => {
+    const initial = ".arkeon/state.json\n.env\nnode_modules/\n";
+    writeFileSync(gitignorePath(), initial);
+
+    const changed = ensureGitignoreEntries(dir, [".arkeon/state.json", ".env"]);
+    expect(changed).toBe(false);
+    expect(readFileSync(gitignorePath(), "utf-8")).toBe(initial);
+  });
+
+  it("appends only the missing entries, preserves existing content", () => {
+    writeFileSync(gitignorePath(), "node_modules/\n.arkeon/state.json\n");
+
+    const changed = ensureGitignoreEntries(dir, [".arkeon/state.json", ".env"]);
+    expect(changed).toBe(true);
+
+    const content = readFileSync(gitignorePath(), "utf-8");
+    expect(content).toBe("node_modules/\n.arkeon/state.json\n.env\n");
+  });
+
+  it("preserves trailing-newline-less files when appending", () => {
+    // Real-world .gitignores sometimes lack a final newline.
+    writeFileSync(gitignorePath(), "node_modules/");
+
+    ensureGitignoreEntries(dir, [".env"]);
+    const content = readFileSync(gitignorePath(), "utf-8");
+    expect(content).toBe("node_modules/\n.env\n");
+  });
+
+  it("legacy migration is skipped if state entry isn't among the requested set", () => {
+    writeFileSync(gitignorePath(), ".arkeon/\n");
+
+    // Only asking for .env — the legacy migration is gated on
+    // `.arkeon/state.json` being requested, so `.arkeon/` should stay.
+    ensureGitignoreEntries(dir, [".env"]);
+    const content = readFileSync(gitignorePath(), "utf-8");
+    expect(content).toContain(".arkeon/");
+    expect(content).not.toContain(".arkeon/state.json");
+    expect(content).toContain(".env");
+  });
+});

--- a/packages/arkeon/test/unit/init-template.test.ts
+++ b/packages/arkeon/test/unit/init-template.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  AGENTS_YAML_TEMPLATES,
+  DEFAULT_AGENTS_TEMPLATE,
+  writeAgentsYamlTemplate,
+} from "../../src/cli/commands/repo/config.js";
+
+describe("writeAgentsYamlTemplate", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "arkeon-init-tpl-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes the default template when none is named", () => {
+    const result = writeAgentsYamlTemplate({ targetDir: dir });
+    expect(result.created).toBe(true);
+    expect(result.template).toBe(DEFAULT_AGENTS_TEMPLATE);
+    expect(result.path).toBe(join(dir, ".arkeon", "agents.yaml"));
+    const written = readFileSync(result.path, "utf-8");
+    expect(written).toBe(AGENTS_YAML_TEMPLATES[DEFAULT_AGENTS_TEMPLATE]);
+  });
+
+  it("creates the .arkeon directory if missing", () => {
+    expect(existsSync(join(dir, ".arkeon"))).toBe(false);
+    writeAgentsYamlTemplate({ targetDir: dir });
+    expect(existsSync(join(dir, ".arkeon"))).toBe(true);
+  });
+
+  it("is idempotent — leaves an existing file untouched", () => {
+    const path = join(dir, ".arkeon", "agents.yaml");
+    writeAgentsYamlTemplate({ targetDir: dir });
+    writeFileSync(path, "# my edits\ndefaults: {}\n");
+
+    const result = writeAgentsYamlTemplate({ targetDir: dir });
+    expect(result.created).toBe(false);
+    expect(readFileSync(path, "utf-8")).toBe("# my edits\ndefaults: {}\n");
+  });
+
+  it("overwrites when force is set", () => {
+    const path = join(dir, ".arkeon", "agents.yaml");
+    writeAgentsYamlTemplate({ targetDir: dir });
+    writeFileSync(path, "# my edits\n");
+
+    const result = writeAgentsYamlTemplate({ targetDir: dir, force: true });
+    expect(result.created).toBe(true);
+    expect(readFileSync(path, "utf-8")).toBe(
+      AGENTS_YAML_TEMPLATES[DEFAULT_AGENTS_TEMPLATE],
+    );
+  });
+
+  it("throws on an unknown template name with the available list", () => {
+    expect(() =>
+      writeAgentsYamlTemplate({ targetDir: dir, template: "nope" }),
+    ).toThrow(/Unknown agents\.yaml template 'nope'.*Available: wiki/);
+  });
+});


### PR DESCRIPTION
## Summary

Three first-run UX gaps in `init`, batched because they all fall in the same code path:

- **`arkeon-wiki init` now writes `.arkeon/agents.yaml`** from a named template (default: `wiki`). Idempotent — re-running `init` or running it after a manual edit never clobbers the file. Adds `--template <name>` to both `init` and `config init`. Templates live in a registry (`AGENTS_YAML_TEMPLATES` in `config.ts`) so additional ones can land as new entries without changing the CLI surface; today only `wiki` ships.
- **`arkeon-wiki init` gitignores `.env`** alongside the existing `.arkeon/state.json` entry, and creates `.gitignore` if it doesn't exist. Per-line trimmed-set membership check so `.env` doesn't false-match `.envrc`. Justification for auto-creating the file inline in the code: leaking a provider key is worse than silently materializing a two-line `.gitignore`.
- **Reconcile mode**: re-running `init` in an already-initialized directory no longer bails early. It skips the API call + `state.json` write (state is canonical) but still runs the three idempotent helpers — gitignore, `wiki/`, `agents.yaml` — so a user who deleted `.arkeon/agents.yaml` by hand or init'd with a pre-template version of the CLI can recover by re-running `init`. No separate `config init` step needed. Output surfaces `reconciled: true` and the hint names what was restored (`Already initialized — restored missing: .arkeon/agents.yaml`) or `nothing to reconcile`. Bare `console.log` at the old early-return is gone; output is JSON-shaped end-to-end.

Together these remove three awkward steps from the setup story.

## Test plan

- [x] `npm run typecheck -w packages/arkeon` clean
- [x] `npm test -w packages/arkeon` — 165/165 (5 in `test/unit/init-template.test.ts`, 7 in `test/unit/init-gitignore.test.ts` covering: empty-file creation, legacy `.arkeon/` migration, `.env` vs `.envrc` false-match, all-present no-op, partial-missing append, no-trailing-newline preservation, gated legacy migration)
- [x] Manual smoke: fresh dir → `reconciled: false`, everything created
- [x] Manual smoke: re-run no-op → `reconciled: true`, "nothing to reconcile"
- [x] Manual smoke: delete `agents.yaml`, re-run → restored, hint names it
- [x] Manual smoke: hand-edit `agents.yaml`, re-run → edits preserved
- [x] Manual smoke: delete `.gitignore`, re-run → restored with both entries
- [x] Manual smoke: `arkeon-wiki init --template nope` returns a clear error listing available templates

Closes #141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
