### PR TITLE
sources scan: report indexable vs ignored files by extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ arkeon-wiki ls                 # list running instances
 arkeon-wiki logs [-f]          # print/tail the daemon log
 arkeon-wiki init [name]        # register current directory as a space
 arkeon-wiki search <query>     # keyword search (ripgrep, defaults to bound space)
+arkeon-wiki sources scan       # list files by extension (supported vs unsupported)
 arkeon-wiki config init        # write .arkeon/agents.yaml from a template
 arkeon-wiki config show        # print merged effective agent config
 arkeon-wiki config validate    # schema-check the YAML

--- a/packages/arkeon/src/cli/commands/repo/sources.ts
+++ b/packages/arkeon/src/cli/commands/repo/sources.ts
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `arkeon-wiki sources scan` — file inventory by extension.
+ *
+ * Calls the daemon's GET /{space}/sources/scan and prints the
+ * supported / unsupported partition. Useful as the first step in
+ * setup — surfaces every binary or unknown-extension file the
+ * watcher will silently ignore, so the operator can convert them to
+ * a supported text format before letting agents run.
+ *
+ * Defaults to the space bound to the current directory (via
+ * .arkeon/state.json); `--space <name>` overrides.
+ */
+
+import type { Command } from "commander";
+
+import { DEFAULT_API_PORT } from "../../lib/local-runtime.js";
+import { output } from "../../lib/output.js";
+import { loadRepoState } from "../../lib/repo-state.js";
+
+interface SourcesScanOptions {
+  space?: string;
+}
+
+interface ScanResponse {
+  space: string;
+  watch_dir: string;
+  total: number;
+  supported: { count: number; by_ext: Record<string, number> };
+  unsupported: {
+    count: number;
+    by_ext: Record<string, number>;
+    examples: Record<string, string[]>;
+  };
+}
+
+export function registerSourcesCommand(program: Command): void {
+  const cmd = program
+    .command("sources")
+    .description("Inspect the watch directory's source files");
+
+  cmd
+    .command("scan")
+    .description(
+      "Partition every file by extension into supported vs unsupported. " +
+        "Unsupported files are silently ignored by the watcher.",
+    )
+    .option("--space <name>", "Space name (default: bound space)")
+    .action(async (options: SourcesScanOptions) => {
+      try {
+        await runScan(options);
+      } catch (error) {
+        output.error(error, { operation: "sources scan" });
+        process.exitCode = 1;
+      }
+    });
+}
+
+async function runScan(options: SourcesScanOptions): Promise<void> {
+  const repoState = loadRepoState();
+  const apiUrl =
+    process.env.ARKE_API_URL ??
+    repoState?.api_url ??
+    `http://localhost:${DEFAULT_API_PORT}`;
+
+  const space = options.space ?? repoState?.space_name;
+  if (!space) {
+    throw new Error(
+      "sources scan: --space is required when not run inside an arkeon-wiki space (no .arkeon/state.json found).",
+    );
+  }
+
+  const res = await fetch(
+    `${apiUrl}/${encodeURIComponent(space)}/sources/scan`,
+  );
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    const message =
+      (body as { error?: { message?: string } }).error?.message ?? res.statusText;
+    throw new Error(`sources scan failed: ${res.status} ${message}`);
+  }
+
+  const result = (await res.json()) as ScanResponse;
+  output.result({
+    operation: "sources scan",
+    space: result.space,
+    watch_dir: result.watch_dir,
+    total: result.total,
+    supported: result.supported,
+    unsupported: result.unsupported,
+  });
+}

--- a/packages/arkeon/src/index.ts
+++ b/packages/arkeon/src/index.ts
@@ -11,6 +11,7 @@ import { registerLocalCommands } from "./cli/commands/local/index.js";
 import { registerConfigCommand } from "./cli/commands/repo/config.js";
 import { registerInitCommand } from "./cli/commands/repo/init.js";
 import { registerSearchCommand } from "./cli/commands/repo/search.js";
+import { registerSourcesCommand } from "./cli/commands/repo/sources.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf-8")) as { version: string };
@@ -43,6 +44,7 @@ program.hook("preAction", (command) => {
 registerLocalCommands(program);
 registerInitCommand(program);
 registerSearchCommand(program);
+registerSourcesCommand(program);
 registerConfigCommand(program);
 
 program.parse();

--- a/packages/arkeon/src/server/lib/fs-watcher.ts
+++ b/packages/arkeon/src/server/lib/fs-watcher.ts
@@ -25,7 +25,10 @@ type SchedulerHandle = Awaited<ReturnType<typeof startScheduler>>;
 const IGNORE_DIRS = new Set([".arkeon", ".git", "node_modules", ".claude", "__pycache__", ".venv"]);
 
 // File extensions we index. Anything else is invisible to the system.
-const INDEX_EXTENSIONS = new Set([".txt", ".json", ".csv", ".xml", ".html", ".rst"]);
+// Exported so callers like the sources-scan endpoint can partition a
+// directory listing against the same set the watcher applies — keeps
+// "what's indexable" defined in exactly one place.
+export const INDEX_EXTENSIONS = new Set([".txt", ".json", ".csv", ".xml", ".html", ".rst"]);
 
 const watchers = new Map<string, FSWatcher>();
 const schedulers = new Map<string, SchedulerHandle>();

--- a/packages/arkeon/src/server/lib/sources-scan.ts
+++ b/packages/arkeon/src/server/lib/sources-scan.ts
@@ -44,7 +44,13 @@ const EXAMPLES_PER_EXT = 5;
  * skipped — same rule the watcher applies.
  *
  * Synchronous fs is fine here: this runs once on operator demand, not
- * in a hot path.
+ * in a hot path. Cost is O(N) over every file in the watch tree —
+ * a corpus of tens of thousands of files blocks the event loop for
+ * the duration of the walk. Acceptable for v0 because the endpoint
+ * is operator-triggered (one shot, not a request you fan out). If
+ * usage outgrows that, the natural next step is async readdir + a
+ * max-files truncation signal, or serving from a count the watcher
+ * maintains.
  */
 export function scanSources(watchDir: string): ScanResult {
   const supportedByExt: Record<string, number> = {};
@@ -105,6 +111,10 @@ function walk(
     } else if (entry.isFile()) {
       visit(relativePath);
     }
+    // Symlinks fall through both branches (isDirectory and isFile
+    // are false for them) and are silently skipped — matches the
+    // watcher's behavior in fs-watcher.ts so the inventory stays
+    // consistent with what gets indexed.
   }
 }
 

--- a/packages/arkeon/src/server/lib/sources-scan.ts
+++ b/packages/arkeon/src/server/lib/sources-scan.ts
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Source inventory for a space's watch directory.
+ *
+ * Walks the directory once, partitions every regular file by
+ * extension against the indexable set (INDEX_EXTENSIONS), and reports
+ * counts plus a handful of example paths per unsupported extension so
+ * the operator (or an LLM agent) can decide what to convert.
+ *
+ * The walk reuses the ignore rules from fs-watcher (shouldIgnorePath)
+ * so what the scan reports lines up exactly with what the watcher
+ * will or won't index.
+ */
+
+import { readdirSync } from "node:fs";
+import { extname, join } from "node:path";
+
+import { INDEX_EXTENSIONS, shouldIgnorePath } from "./fs-watcher.js";
+
+/** Per-extension counts, sorted descending by count. */
+export interface ExtensionBucket {
+  count: number;
+  by_ext: Record<string, number>;
+}
+
+export interface UnsupportedBucket extends ExtensionBucket {
+  /** Up to EXAMPLES_PER_EXT paths per extension, space-relative. */
+  examples: Record<string, string[]>;
+}
+
+export interface ScanResult {
+  total: number;
+  supported: ExtensionBucket;
+  unsupported: UnsupportedBucket;
+}
+
+const EXAMPLES_PER_EXT = 5;
+
+/**
+ * Walk `watchDir` and partition every file by extension. Hidden dirs
+ * and well-known ignore dirs (.git, node_modules, .arkeon, ...) are
+ * skipped — same rule the watcher applies.
+ *
+ * Synchronous fs is fine here: this runs once on operator demand, not
+ * in a hot path.
+ */
+export function scanSources(watchDir: string): ScanResult {
+  const supportedByExt: Record<string, number> = {};
+  const unsupportedByExt: Record<string, number> = {};
+  const unsupportedExamples: Record<string, string[]> = {};
+  let total = 0;
+
+  walk(watchDir, "", (relativePath) => {
+    total += 1;
+    const ext = extname(relativePath).toLowerCase();
+    // Files with no extension live under the "(none)" bucket so the
+    // operator sees them — many sources arrive as `README` or `LICENSE`
+    // with no suffix, and silently lumping them with `.xyz` would hide
+    // them from the conversion plan.
+    const bucketKey = ext === "" ? "(none)" : ext;
+    if (ext !== "" && INDEX_EXTENSIONS.has(ext)) {
+      supportedByExt[bucketKey] = (supportedByExt[bucketKey] ?? 0) + 1;
+    } else {
+      unsupportedByExt[bucketKey] = (unsupportedByExt[bucketKey] ?? 0) + 1;
+      const examples = unsupportedExamples[bucketKey] ?? [];
+      if (examples.length < EXAMPLES_PER_EXT) {
+        examples.push(relativePath);
+      }
+      unsupportedExamples[bucketKey] = examples;
+    }
+  });
+
+  return {
+    total,
+    supported: {
+      count: sumValues(supportedByExt),
+      by_ext: sortByCountDesc(supportedByExt),
+    },
+    unsupported: {
+      count: sumValues(unsupportedByExt),
+      by_ext: sortByCountDesc(unsupportedByExt),
+      examples: unsupportedExamples,
+    },
+  };
+}
+
+function walk(
+  root: string,
+  prefix: string,
+  visit: (relativePath: string) => void,
+): void {
+  let entries;
+  try {
+    entries = readdirSync(join(root, prefix), { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (shouldIgnorePath(relativePath)) continue;
+    if (entry.isDirectory()) {
+      walk(root, relativePath, visit);
+    } else if (entry.isFile()) {
+      visit(relativePath);
+    }
+  }
+}
+
+function sumValues(record: Record<string, number>): number {
+  let sum = 0;
+  for (const v of Object.values(record)) sum += v;
+  return sum;
+}
+
+function sortByCountDesc(record: Record<string, number>): Record<string, number> {
+  const entries = Object.entries(record).sort(([, a], [, b]) => b - a);
+  return Object.fromEntries(entries);
+}

--- a/packages/arkeon/src/server/routes/space-scoped.ts
+++ b/packages/arkeon/src/server/routes/space-scoped.ts
@@ -9,6 +9,7 @@
  *   GET    /:space/redlinks                  red-link queue
  *   GET    /:space/recent                    entity_edits feed
  *   GET    /:space/search?q=...              keyword search
+ *   GET    /:space/sources/scan              file inventory by extension
  *   POST   /:space/chat                      Phase 3 stub (501)
  *   GET    /:space/chat/:conversation_id     Phase 3 stub (501)
  *   DELETE /:space/chat/:conversation_id     Phase 3 stub (501)
@@ -35,6 +36,7 @@ import {
   searchKeyword,
   type KeywordSearchResult,
 } from "../lib/search.js";
+import { scanSources } from "../lib/sources-scan.js";
 
 export const spaceScopedRouter = new Hono<AppBindings>();
 
@@ -121,6 +123,20 @@ spaceScopedRouter.get("/:space/redlinks", async (c) => {
     offset: parseNumQuery(c.req.query("offset"), "offset"),
   });
   return c.json(result);
+});
+
+// ── /:space/sources/scan ──────────────────────────────────────────
+// File inventory by extension. Partitions every file in the watch
+// directory into supported (the watcher indexes it) vs unsupported
+// (silently ignored) — the operator's signal to convert binary
+// sources to text before letting the agents loose. Cheap synchronous
+// walk; not paginated.
+
+spaceScopedRouter.get("/:space/sources/scan", async (c) => {
+  const space = c.req.param("space");
+  const watchDir = await spaceWatchDir(space);
+  const result = scanSources(watchDir);
+  return c.json({ space, watch_dir: watchDir, ...result });
 });
 
 // ── /:space/recent ────────────────────────────────────────────────

--- a/packages/arkeon/test/unit/sources-scan.test.ts
+++ b/packages/arkeon/test/unit/sources-scan.test.ts
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { scanSources } from "../../src/server/lib/sources-scan.js";
+
+describe("scanSources", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "arkeon-scan-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function touch(rel: string, content = ""): void {
+    const full = join(dir, rel);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, content);
+  }
+
+  it("returns empty buckets on an empty directory", () => {
+    const result = scanSources(dir);
+    expect(result.total).toBe(0);
+    expect(result.supported.count).toBe(0);
+    expect(result.unsupported.count).toBe(0);
+    expect(result.supported.by_ext).toEqual({});
+    expect(result.unsupported.by_ext).toEqual({});
+  });
+
+  it("partitions supported and unsupported by extension", () => {
+    touch("a.txt");
+    touch("b.txt");
+    touch("c.json");
+    touch("notes/d.html");
+    touch("binary.pdf");
+    touch("photo.png");
+    touch("photo2.png");
+
+    const result = scanSources(dir);
+    expect(result.total).toBe(7);
+    expect(result.supported.count).toBe(4);
+    expect(result.supported.by_ext).toEqual({ ".txt": 2, ".json": 1, ".html": 1 });
+    expect(result.unsupported.count).toBe(3);
+    expect(result.unsupported.by_ext).toEqual({ ".png": 2, ".pdf": 1 });
+  });
+
+  it("buckets extensionless files under (none)", () => {
+    touch("README");
+    touch("LICENSE");
+    touch("a.txt");
+
+    const result = scanSources(dir);
+    expect(result.supported.by_ext).toEqual({ ".txt": 1 });
+    expect(result.unsupported.by_ext).toEqual({ "(none)": 2 });
+  });
+
+  it("skips ignored directories (.git, node_modules, .arkeon, hidden)", () => {
+    touch(".git/config");
+    touch("node_modules/foo/package.json");
+    touch(".arkeon/state.json");
+    touch(".hidden/secret.txt");
+    touch("real.txt");
+
+    const result = scanSources(dir);
+    expect(result.total).toBe(1);
+    expect(result.supported.by_ext).toEqual({ ".txt": 1 });
+  });
+
+  it("limits unsupported examples to 5 per extension", () => {
+    for (let i = 0; i < 7; i++) touch(`doc-${i}.pdf`);
+    const result = scanSources(dir);
+    expect(result.unsupported.by_ext[".pdf"]).toBe(7);
+    expect(result.unsupported.examples[".pdf"]).toHaveLength(5);
+  });
+
+  it("sorts by_ext by count descending", () => {
+    touch("a.png");
+    touch("b.pdf");
+    touch("c.pdf");
+    touch("d.pdf");
+    touch("e.docx");
+    touch("f.docx");
+
+    const result = scanSources(dir);
+    expect(Object.keys(result.unsupported.by_ext)).toEqual([".pdf", ".docx", ".png"]);
+  });
+
+  it("normalizes extensions to lowercase", () => {
+    touch("a.PDF");
+    touch("b.pdf");
+    touch("c.TXT");
+    const result = scanSources(dir);
+    // INDEX_EXTENSIONS only has lowercase entries; uppercased .TXT
+    // becomes ".txt" via the lowercase normalization and lands in
+    // supported.
+    expect(result.supported.by_ext).toEqual({ ".txt": 1 });
+    expect(result.unsupported.by_ext).toEqual({ ".pdf": 2 });
+  });
+});


### PR DESCRIPTION
## Summary

The first-run setup flow needs a way to surface binary or unknown-extension files the watcher silently skips, so the operator can convert them before letting agents loose. This PR adds that.

- **New endpoint** \`GET /:space/sources/scan\` — single synchronous walk of the watch directory, partitions every file by extension into supported / unsupported, with up to 5 example paths per unsupported extension. Reuses \`shouldIgnorePath\` + \`INDEX_EXTENSIONS\` from the watcher (now exported) so the scan's view of "indexable" lines up exactly with what the watcher does.
- **New CLI** \`arkeon-wiki sources scan [--space <name>]\` — wraps the endpoint, defaults to the space bound to cwd.
- Extensionless files (\`README\`, \`LICENSE\`) bucket under \`(none)\` so they're visible in the unsupported list instead of silently lumped together.
- Extensions normalize to lowercase (\`.PDF\` → \`.pdf\`).

The endpoint is intentionally a thin wrapper around \`scanSources\` (one resolve, one call) — all the interesting logic + tests live in \`src/server/lib/sources-scan.ts\`.

## Test plan

- [x] \`npm run typecheck -w packages/arkeon\` clean
- [x] \`npm test -w packages/arkeon\` — 160/160 (7 new in \`test/unit/sources-scan.test.ts\` covering empty dir, partition, extensionless bucket, ignored dirs, example cap, count-desc sort, lowercase normalization)
- [x] \`npm run test:e2e -w packages/arkeon\` — 51/51 (no e2e for the new route; thin wrapper, fully covered by unit tests)
- [ ] Manual smoke: \`curl http://localhost:8000/<space>/sources/scan\` in a directory with PDFs and TXTs — verify partition + examples
- [ ] Manual smoke: \`arkeon-wiki sources scan\` from within a bound space

🤖 Generated with [Claude Code](https://claude.com/claude-code)