### PR TITLE
agent run: fire one role on demand via CLI + API

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ arkeon-wiki logs [-f]          # print/tail the daemon log
 arkeon-wiki init [name]        # register current directory as a space
 arkeon-wiki search <query>     # keyword search (ripgrep, defaults to bound space)
 arkeon-wiki sources scan       # list files by extension (supported vs unsupported)
+arkeon-wiki agent run <role>   # fire one role on demand (writer/editor/proposer/custom)
 arkeon-wiki config init        # write .arkeon/agents.yaml from a template
 arkeon-wiki config show        # print merged effective agent config
 arkeon-wiki config validate    # schema-check the YAML

--- a/packages/arkeon/src/cli/commands/repo/agent.ts
+++ b/packages/arkeon/src/cli/commands/repo/agent.ts
@@ -88,13 +88,26 @@ async function runAgentCmd(
   );
   if (!res.ok) {
     const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
-    const errShape = (body as { error?: { message?: string; code?: string } }).error;
+    const errShape = (body as {
+      error?: {
+        message?: string;
+        code?: string;
+        details?: Record<string, unknown>;
+      };
+    }).error;
     const message = errShape?.message ?? res.statusText;
+    // Attach structured fields the daemon returned (code, status,
+    // details) onto the Error — `output.error` reads them back to
+    // emit a JSON payload that scripts can branch on. Without this,
+    // a 409 `space_busy` and a 400 `validation_error` would collapse
+    // to the same human string.
     const err = new Error(`agent run failed: ${res.status} ${message}`) as Error & {
       code?: string;
       statusCode?: number;
+      details?: Record<string, unknown>;
     };
     if (errShape?.code) err.code = errShape.code;
+    if (errShape?.details) err.details = errShape.details;
     err.statusCode = res.status;
     throw err;
   }

--- a/packages/arkeon/src/cli/commands/repo/agent.ts
+++ b/packages/arkeon/src/cli/commands/repo/agent.ts
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `arkeon-wiki agent <subcommand>` — agent operations.
+ *
+ * Subcommands:
+ *   run <role>    fire one role on demand (POST /:space/agents/:role/run)
+ *
+ * The subcommand layout exists so additional verbs (list, watch, ...)
+ * can land without re-shaping the CLI surface.
+ *
+ * `agent run` is the smoke-test entrypoint for the setup flow: change
+ * `instructions:` in agents.yaml, then trigger one writer tick to see
+ * what the corpus actually produces before letting cron roll. Without
+ * this command, the user has to wait for the next cron firing or
+ * temporarily edit the cron expression.
+ */
+
+import type { Command } from "commander";
+
+import { DEFAULT_API_PORT } from "../../lib/local-runtime.js";
+import { output } from "../../lib/output.js";
+import { loadRepoState } from "../../lib/repo-state.js";
+
+interface AgentRunOptions {
+  space?: string;
+}
+
+interface AgentRunResponse {
+  space: string;
+  role: string;
+  duration_ms: number;
+  steps: number;
+  edits: { path: string; kind: string }[];
+  skipped: boolean;
+  reason?: string;
+  usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number };
+  text: string;
+}
+
+export function registerAgentCommand(program: Command): void {
+  const cmd = program
+    .command("agent")
+    .description("Agent operations (run, ...)");
+
+  cmd
+    .command("run")
+    .argument("<role>", "Role name (editor, proposer, writer, or a custom role)")
+    .description("Fire one role on demand and block until it finishes")
+    .option("--space <name>", "Space name (default: bound space)")
+    .action(async (role: string, options: AgentRunOptions) => {
+      try {
+        await runAgentCmd(role, options);
+      } catch (error) {
+        output.error(error, { operation: "agent run" });
+        process.exitCode = 1;
+      }
+    });
+}
+
+async function runAgentCmd(
+  role: string,
+  options: AgentRunOptions,
+): Promise<void> {
+  const repoState = loadRepoState();
+  const apiUrl =
+    process.env.ARKE_API_URL ??
+    repoState?.api_url ??
+    `http://localhost:${DEFAULT_API_PORT}`;
+
+  const space = options.space ?? repoState?.space_name;
+  if (!space) {
+    throw new Error(
+      "agent run: --space is required when not run inside an arkeon-wiki space (no .arkeon/state.json found).",
+    );
+  }
+
+  // No body needed today — the runtime picks its own work from
+  // list_entities / list_redlinks. Future: { trigger_path }.
+  const res = await fetch(
+    `${apiUrl}/${encodeURIComponent(space)}/agents/${encodeURIComponent(role)}/run`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    },
+  );
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    const errShape = (body as { error?: { message?: string; code?: string } }).error;
+    const message = errShape?.message ?? res.statusText;
+    const err = new Error(`agent run failed: ${res.status} ${message}`) as Error & {
+      code?: string;
+      statusCode?: number;
+    };
+    if (errShape?.code) err.code = errShape.code;
+    err.statusCode = res.status;
+    throw err;
+  }
+
+  const result = (await res.json()) as AgentRunResponse;
+  output.result({
+    operation: "agent run",
+    space: result.space,
+    role: result.role,
+    duration_ms: result.duration_ms,
+    steps: result.steps,
+    edit_count: result.edits.length,
+    edits: result.edits,
+    skipped: result.skipped,
+    reason: result.reason,
+    usage: result.usage,
+  });
+}

--- a/packages/arkeon/src/index.ts
+++ b/packages/arkeon/src/index.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 import { Command } from "commander";
 
 import { registerLocalCommands } from "./cli/commands/local/index.js";
+import { registerAgentCommand } from "./cli/commands/repo/agent.js";
 import { registerConfigCommand } from "./cli/commands/repo/config.js";
 import { registerInitCommand } from "./cli/commands/repo/init.js";
 import { registerSearchCommand } from "./cli/commands/repo/search.js";
@@ -45,6 +46,7 @@ registerLocalCommands(program);
 registerInitCommand(program);
 registerSearchCommand(program);
 registerSourcesCommand(program);
+registerAgentCommand(program);
 registerConfigCommand(program);
 
 program.parse();

--- a/packages/arkeon/src/server/agents/scheduler.ts
+++ b/packages/arkeon/src/server/agents/scheduler.ts
@@ -45,6 +45,11 @@ import { loadAgentConfig, type AgentConfig } from "./config.js";
 import { buildAgentRole } from "./role-builder.js";
 import { loadBundledTemplates } from "./templates.js";
 import { runAgent as defaultRunAgent } from "./runtime.js";
+import {
+  SpaceBusyError,
+  inFlightRole,
+  withSpaceMutex,
+} from "./space-mutex.js";
 import type { Space } from "../lib/sync.js";
 
 import { ALL_TOOLS } from "./tools.js";
@@ -148,9 +153,10 @@ export async function startScheduler(
     return { stop: async () => {} };
   }
 
-  // Per-space mutex. Held by an in-flight run; ticks that find it held
-  // log "skip (busy)" and reschedule from now.
-  let busy = false;
+  // The per-space mutex lives in space-mutex.ts so the manual
+  // `POST /:space/agents/:role/run` route obeys the same serialization
+  // as cron-fired ticks. `inFlight` here tracks our own most-recent
+  // run promise so stop() can wait for it bounded by gracePeriodMs.
   let inFlight: Promise<unknown> | null = null;
 
   let stopped = false;
@@ -180,14 +186,15 @@ export async function startScheduler(
   }
 
   async function fireTick(role: string, cron: string): Promise<void> {
-    if (busy) {
+    const holder = inFlightRole(opts.space.name);
+    if (holder) {
       console.log(
-        `[agent/scheduler] role=${role} space="${opts.space.name}" skip (busy)`,
+        `[agent/scheduler] role=${role} space="${opts.space.name}" skip (busy with ${holder})`,
       );
       scheduleNext(role, cron);
       return;
     }
-    busy = true;
+
     const built = (() => {
       try {
         return buildAgentRole(role, loadAgentConfig({ spaceDir: opts.space.watch_dir }));
@@ -199,12 +206,11 @@ export async function startScheduler(
       }
     })();
     if (!built) {
-      busy = false;
       scheduleNext(role, cron);
       return;
     }
 
-    const runPromise = (async () => {
+    const runPromise = withSpaceMutex(opts.space.name, role, async () => {
       try {
         await runAgent(
           built,
@@ -219,13 +225,24 @@ export async function startScheduler(
         );
         if (opts.rethrow) throw err;
       }
-    })();
+    }).catch((err) => {
+      // The pre-flight inFlightRole check should rule this out, but a
+      // race between two roles firing in the same JS tick is in theory
+      // possible if either's setTimeout callback contains an early
+      // await. Treat it the same as the explicit busy branch.
+      if (err instanceof SpaceBusyError) {
+        console.log(
+          `[agent/scheduler] role=${role} space="${opts.space.name}" skip (busy with ${err.inFlightRole})`,
+        );
+        return;
+      }
+      throw err;
+    });
     inFlight = runPromise;
 
     try {
       await runPromise;
     } finally {
-      busy = false;
       inFlight = null;
       scheduleNext(role, cron);
     }

--- a/packages/arkeon/src/server/agents/scheduler.ts
+++ b/packages/arkeon/src/server/agents/scheduler.ts
@@ -47,7 +47,6 @@ import { loadBundledTemplates } from "./templates.js";
 import { runAgent as defaultRunAgent } from "./runtime.js";
 import {
   SpaceBusyError,
-  inFlightRole,
   withSpaceMutex,
 } from "./space-mutex.js";
 import type { Space } from "../lib/sync.js";
@@ -186,15 +185,6 @@ export async function startScheduler(
   }
 
   async function fireTick(role: string, cron: string): Promise<void> {
-    const holder = inFlightRole(opts.space.name);
-    if (holder) {
-      console.log(
-        `[agent/scheduler] role=${role} space="${opts.space.name}" skip (busy with ${holder})`,
-      );
-      scheduleNext(role, cron);
-      return;
-    }
-
     const built = (() => {
       try {
         return buildAgentRole(role, loadAgentConfig({ spaceDir: opts.space.watch_dir }));
@@ -210,6 +200,15 @@ export async function startScheduler(
       return;
     }
 
+    // `withSpaceMutex` is the single acquisition point. The route
+    // handler (`POST /:space/agents/:role/run`) uses the same mutex,
+    // so a manual run holding it surfaces here as SpaceBusyError —
+    // we treat it the same as a same-process cron contention: log
+    // skip and reschedule. Two cron timers firing in the same JS
+    // tick can't actually race in Node's single-threaded model
+    // because withSpaceMutex sets inFlight synchronously before any
+    // await, but treating busy as a normal observable outcome means
+    // the scheduler doesn't have to reason about that proof.
     const runPromise = withSpaceMutex(opts.space.name, role, async () => {
       try {
         await runAgent(
@@ -226,10 +225,6 @@ export async function startScheduler(
         if (opts.rethrow) throw err;
       }
     }).catch((err) => {
-      // The pre-flight inFlightRole check should rule this out, but a
-      // race between two roles firing in the same JS tick is in theory
-      // possible if either's setTimeout callback contains an early
-      // await. Treat it the same as the explicit busy branch.
       if (err instanceof SpaceBusyError) {
         console.log(
           `[agent/scheduler] role=${role} space="${opts.space.name}" skip (busy with ${err.inFlightRole})`,

--- a/packages/arkeon/src/server/agents/space-mutex.ts
+++ b/packages/arkeon/src/server/agents/space-mutex.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Per-space agent mutex, shared between the cron scheduler and any
+ * other caller that needs to run a role in a space (today: the manual
+ * `POST /:space/agents/:role/run` endpoint).
+ *
+ * Process-global Map keyed by space name. At most one role runs per
+ * space at a time. Callers race-free in the single-threaded Node
+ * model: `inFlight.set` happens synchronously before any await, so
+ * two timers firing in the same JS tick are serialized correctly.
+ *
+ * Behavior is non-blocking: `withSpaceMutex` throws `SpaceBusyError`
+ * if another role is already running in the space. The cron scheduler
+ * uses this to log skip-and-reschedule; the HTTP route uses it to
+ * return 409. Neither caller queues — queueing is intentionally not
+ * a primitive here.
+ */
+
+export class SpaceBusyError extends Error {
+  /** Name of the role currently holding the mutex for this space. */
+  inFlightRole: string;
+  spaceName: string;
+
+  constructor(spaceName: string, inFlightRole: string) {
+    super(
+      `space '${spaceName}' is busy running role '${inFlightRole}'`,
+    );
+    this.name = "SpaceBusyError";
+    this.spaceName = spaceName;
+    this.inFlightRole = inFlightRole;
+  }
+}
+
+const inFlight = new Map<string, { role: string; startedAt: number }>();
+
+/** The role currently holding the mutex for `spaceName`, or null. */
+export function inFlightRole(spaceName: string): string | null {
+  return inFlight.get(spaceName)?.role ?? null;
+}
+
+/**
+ * Run `fn` while holding the per-space mutex. Throws
+ * `SpaceBusyError` synchronously (before invoking fn) if another
+ * role is already running in the space.
+ */
+export async function withSpaceMutex<T>(
+  spaceName: string,
+  role: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const existing = inFlight.get(spaceName);
+  if (existing) {
+    throw new SpaceBusyError(spaceName, existing.role);
+  }
+  inFlight.set(spaceName, { role, startedAt: Date.now() });
+  try {
+    return await fn();
+  } finally {
+    inFlight.delete(spaceName);
+  }
+}
+
+/**
+ * Test-only: drop all mutex state. Each test that exercises the
+ * scheduler or the run route should call this in afterEach so leaked
+ * state from one case doesn't bleed into the next.
+ */
+export function resetSpaceMutexForTests(): void {
+  inFlight.clear();
+}

--- a/packages/arkeon/src/server/routes/space-scoped.ts
+++ b/packages/arkeon/src/server/routes/space-scoped.ts
@@ -251,6 +251,13 @@ spaceScopedRouter.post("/:space/agents/:role/run", async (c) => {
 
   const startedAt = Date.now();
   try {
+    // Args match `scheduler.fireTick`'s invocation shape: same
+    // AgentInput (`{ space, meta: {} }`), same registry (ALL_TOOLS —
+    // the scheduler exposes a `toolRegistry` injection seam for
+    // tests, but in production both call sites resolve to ALL_TOOLS),
+    // same empty `RunAgentOptions`. Keeping them aligned by hand for
+    // now; if a third call site lands, fold both into a shared
+    // `invokeRole(space, role)` helper.
     const result = await withSpaceMutex(space, role, () =>
       runAgent(built, { space: spaceRow, meta: {} }, ALL_TOOLS, {}),
     );

--- a/packages/arkeon/src/server/routes/space-scoped.ts
+++ b/packages/arkeon/src/server/routes/space-scoped.ts
@@ -10,6 +10,7 @@
  *   GET    /:space/recent                    entity_edits feed
  *   GET    /:space/search?q=...              keyword search
  *   GET    /:space/sources/scan              file inventory by extension
+ *   POST   /:space/agents/:role/run          fire one role on demand
  *   POST   /:space/chat                      Phase 3 stub (501)
  *   GET    /:space/chat/:conversation_id     Phase 3 stub (501)
  *   DELETE /:space/chat/:conversation_id     Phase 3 stub (501)
@@ -37,6 +38,14 @@ import {
   type KeywordSearchResult,
 } from "../lib/search.js";
 import { scanSources } from "../lib/sources-scan.js";
+import { loadAgentConfig } from "../agents/config.js";
+import { buildAgentRole, listAvailableRoles } from "../agents/role-builder.js";
+import { runAgent } from "../agents/runtime.js";
+import {
+  SpaceBusyError,
+  withSpaceMutex,
+} from "../agents/space-mutex.js";
+import { ALL_TOOLS } from "../agents/tools.js";
 
 export const spaceScopedRouter = new Hono<AppBindings>();
 
@@ -47,6 +56,15 @@ async function spaceWatchDir(spaceName: string): Promise<string> {
     throw new ApiError(404, "not_found", `Space '${spaceName}' not found`);
   }
   return rows[0].watch_dir as string;
+}
+
+async function loadSpace(spaceName: string): Promise<{ name: string; watch_dir: string }> {
+  const sql = createSql();
+  const rows = await sql`SELECT name, watch_dir FROM spaces WHERE name = ${spaceName}`;
+  if (rows.length === 0) {
+    throw new ApiError(404, "not_found", `Space '${spaceName}' not found`);
+  }
+  return rows[0] as { name: string; watch_dir: string };
 }
 
 // ── /:space/entities ──────────────────────────────────────────────
@@ -192,6 +210,72 @@ spaceScopedRouter.get("/:space/recent", async (c) => {
   }
 
   return c.json({ space, edits: rows });
+});
+
+// ── POST /:space/agents/:role/run ─────────────────────────────────
+//
+// Fire one role on demand. Synchronous: blocks until the run finishes
+// or errors, then returns a summary. The per-space mutex applies — if
+// another role (cron-fired or manual) is in flight, we return 409.
+//
+// Body is currently ignored. A future iteration may accept
+// { trigger_path: string } to force a specific target; today's roles
+// pick their own work from list_entities / list_redlinks.
+
+spaceScopedRouter.post("/:space/agents/:role/run", async (c) => {
+  const space = c.req.param("space");
+  const role = c.req.param("role");
+  const spaceRow = await loadSpace(space);
+
+  const config = loadAgentConfig({ spaceDir: spaceRow.watch_dir });
+  // Validate the role exists in the merged config (bundled templates +
+  // YAML). Catches typos before we try to build the role.
+  if (!listAvailableRoles(config).includes(role)) {
+    throw new ApiError(
+      404,
+      "not_found",
+      `Role '${role}' not found. Available: ${listAvailableRoles(config).join(", ") || "(none)"}.`,
+    );
+  }
+
+  let built;
+  try {
+    built = buildAgentRole(role, config);
+  } catch (err) {
+    throw new ApiError(
+      400,
+      "validation_error",
+      `Failed to build role '${role}': ${(err as Error).message}`,
+    );
+  }
+
+  const startedAt = Date.now();
+  try {
+    const result = await withSpaceMutex(space, role, () =>
+      runAgent(built, { space: spaceRow, meta: {} }, ALL_TOOLS, {}),
+    );
+    return c.json({
+      space,
+      role,
+      duration_ms: Date.now() - startedAt,
+      steps: result.steps,
+      edits: result.edits.map((e) => ({ path: e.path, kind: e.kind })),
+      skipped: result.skipped,
+      reason: result.reason,
+      usage: result.usage,
+      text: result.text,
+    });
+  } catch (err) {
+    if (err instanceof SpaceBusyError) {
+      throw new ApiError(
+        409,
+        "space_busy",
+        `Space '${space}' is busy running role '${err.inFlightRole}'.`,
+        { in_flight_role: err.inFlightRole },
+      );
+    }
+    throw err;
+  }
 });
 
 // ── /:space/search ────────────────────────────────────────────────

--- a/packages/arkeon/test/unit/space-mutex.test.ts
+++ b/packages/arkeon/test/unit/space-mutex.test.ts
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  SpaceBusyError,
+  inFlightRole,
+  resetSpaceMutexForTests,
+  withSpaceMutex,
+} from "../../src/server/agents/space-mutex.js";
+
+describe("space-mutex", () => {
+  afterEach(() => {
+    resetSpaceMutexForTests();
+  });
+
+  it("runs the function and returns its result", async () => {
+    const result = await withSpaceMutex("alpha", "writer", async () => "ok");
+    expect(result).toBe("ok");
+    expect(inFlightRole("alpha")).toBeNull();
+  });
+
+  it("blocks a concurrent run in the same space", async () => {
+    let release: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+
+    const first = withSpaceMutex("alpha", "writer", () => gate);
+    // Drain the microtask queue so the first call has set inFlight.
+    await Promise.resolve();
+    expect(inFlightRole("alpha")).toBe("writer");
+
+    await expect(
+      withSpaceMutex("alpha", "editor", async () => "second"),
+    ).rejects.toBeInstanceOf(SpaceBusyError);
+
+    release!();
+    await first;
+    expect(inFlightRole("alpha")).toBeNull();
+  });
+
+  it("allows concurrent runs across different spaces", async () => {
+    let releaseA: () => void;
+    const gateA = new Promise<void>((r) => {
+      releaseA = r;
+    });
+
+    const a = withSpaceMutex("alpha", "writer", () => gateA);
+    await Promise.resolve();
+    expect(inFlightRole("alpha")).toBe("writer");
+
+    // Different space should not throw.
+    const b = await withSpaceMutex("beta", "writer", async () => "b-ok");
+    expect(b).toBe("b-ok");
+
+    releaseA!();
+    await a;
+  });
+
+  it("releases the mutex when the function throws", async () => {
+    await expect(
+      withSpaceMutex("alpha", "writer", async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(inFlightRole("alpha")).toBeNull();
+
+    const second = await withSpaceMutex("alpha", "editor", async () => "ok");
+    expect(second).toBe("ok");
+  });
+
+  it("SpaceBusyError carries the in-flight role name", async () => {
+    let release: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+
+    const first = withSpaceMutex("alpha", "writer", () => gate);
+    await Promise.resolve();
+
+    try {
+      await withSpaceMutex("alpha", "proposer", async () => "second");
+      expect.fail("expected SpaceBusyError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SpaceBusyError);
+      expect((err as SpaceBusyError).inFlightRole).toBe("writer");
+      expect((err as SpaceBusyError).spaceName).toBe("alpha");
+    }
+
+    release!();
+    await first;
+  });
+});


### PR DESCRIPTION
## Summary

Removes the last UX hole in the setup flow: smoke-testing a role tick without waiting for cron or temporarily editing the cron expression.

- **New endpoint** \`POST /:space/agents/:role/run\` — synchronous, blocks until the run finishes. Returns the run summary on completion: \`{ space, role, duration_ms, steps, edits, skipped, reason, usage, text }\`. Status codes: 404 on unknown space or unknown role, 400 if the role won't build (missing API key, bad config), 409 if the per-space mutex is held by another in-flight role (response carries \`details.in_flight_role\`).
- **New CLI** \`arkeon-wiki agent run <role>\` — wraps the endpoint, defaults to the bound space, \`--space <name>\` overrides. Subcommand layout (\`arkeon-wiki agent <verb>\`) leaves room for \`agent list\` / \`agent watch\` later without re-shaping the surface.
- **Mutex refactor**: moved the per-space mutex from \`let busy = false\` inside \`startScheduler\` into a shared module \`agents/space-mutex.ts\` so the manual route and the scheduler share serialization. Without this, a cron-fired tick could race a manual \`agent run\` in the same space. Scheduler behavior is preserved (skip-if-busy, log + reschedule from now).
- Works for roles **without** \`cron:\` set, too — manual run lets operators test template-only or draft roles before promoting them to scheduled. The route gates on \`listAvailableRoles(config)\` (templates + YAML roles), not on cron presence.

## Design notes

- **Synchronous response, not async with run_id.** A writer tick is on the order of 30-90s; HTTP can handle that comfortably. An async \`POST + GET run_id\` flow would be more machinery for no v0 benefit. Easy to layer later if dashboard / scheduling UIs need it.
- **No queue on 409.** The user retries. Matches the existing scheduler's skip-if-busy semantic.
- **Body is currently empty / ignored.** Today's roles pick their own work from \`list_entities\` / \`list_redlinks\`. A future iteration may accept \`{ trigger_path }\` to force a specific target.

## Test plan

- [x] \`npm run typecheck -w packages/arkeon\` clean
- [x] \`npm test -w packages/arkeon\` — 158/158 (5 new in \`test/unit/space-mutex.test.ts\` covering: happy path, busy throws, cross-space concurrency, release on exception, SpaceBusyError carries role name)
- [x] \`npm run test:e2e -w packages/arkeon\` — 51/51 (existing scheduler e2e covers the cron path through the refactored mutex)
- [ ] Manual smoke: \`arkeon-wiki up\` → \`arkeon-wiki init\` → \`OPENAI_API_KEY=... arkeon-wiki agent run writer\` — verify it fires, produces a summary, an article appears
- [ ] Manual smoke: fire two \`agent run\` calls concurrently — verify the second returns 409 with the in-flight role name
- [ ] Manual smoke: \`arkeon-wiki agent run nonexistent\` — verify 404 with available-roles list

🤖 Generated with [Claude Code](https://claude.com/claude-code)