### PR TITLE
init: auto-discover the running daemon

### DIFF
--- a/packages/arkeon/src/cli/commands/repo/init.ts
+++ b/packages/arkeon/src/cli/commands/repo/init.ts
@@ -27,7 +27,6 @@ import { basename, join, resolve } from "node:path";
 
 import {
   DEFAULT_INSTANCE_NAME,
-  findInstance,
   listInstances,
   type Instance,
 } from "../../lib/instances.js";
@@ -194,30 +193,32 @@ function buildHint(args: {
  *      message that names the running instances and tells the user
  *      to pass `--api-url`.
  *
+ * Both lookups go through `listInstances()`, which prunes stale
+ * registry entries (dead PIDs) before returning. A crashed daemon's
+ * leftover `default.json` therefore can't fool us into returning a
+ * dead api_url and producing the exact `fetch failed` UX this helper
+ * exists to eliminate.
+ *
  * The `deps` argument exists for unit tests — production callers omit
- * it and the registry lookups go through the real filesystem.
+ * it and the registry lookup goes through the real filesystem.
  */
 export interface ResolveApiUrlDeps {
   env?: NodeJS.ProcessEnv;
-  findInstance?: (name: string) => Instance | null;
   listInstances?: () => Instance[];
 }
 
 export function resolveApiUrl(deps: ResolveApiUrlDeps = {}): string {
   const env = deps.env ?? process.env;
-  const findInst = deps.findInstance ?? findInstance;
   const listInst = deps.listInstances ?? listInstances;
 
   // (1) Explicit override.
   const fromEnv = env.ARKE_API_URL;
   if (fromEnv) return fromEnv;
 
-  // (2) Default unnamed daemon.
-  const defaultInst = findInst(DEFAULT_INSTANCE_NAME);
-  if (defaultInst) return defaultInst.api_url;
-
-  // (3) Unique named instance.
+  // (2)+(3) live-pid-filtered registry.
   const running = listInst();
+  const defaultInst = running.find((i) => i.name === DEFAULT_INSTANCE_NAME);
+  if (defaultInst) return defaultInst.api_url;
   if (running.length === 1) return running[0].api_url;
 
   // (4) Error path — describe what we found so the user can choose.

--- a/packages/arkeon/src/cli/commands/repo/init.ts
+++ b/packages/arkeon/src/cli/commands/repo/init.ts
@@ -25,7 +25,12 @@ import type { Command } from "commander";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
 
-import { DEFAULT_API_PORT } from "../../lib/local-runtime.js";
+import {
+  DEFAULT_INSTANCE_NAME,
+  findInstance,
+  listInstances,
+  type Instance,
+} from "../../lib/instances.js";
 import { output } from "../../lib/output.js";
 import { loadRepoState, type RepoState } from "../../lib/repo-state.js";
 import {
@@ -65,7 +70,7 @@ async function runInit(
   template: string,
 ): Promise<void> {
   const cwd = process.cwd();
-  const apiUrl = process.env.ARKE_API_URL ?? `http://localhost:${DEFAULT_API_PORT}`;
+  const apiUrl = resolveApiUrl();
 
   // Branch on whether the space is already known locally. Reconcile
   // mode skips the API call and the state.json write but still runs
@@ -169,6 +174,66 @@ function buildHint(args: {
     return "Already initialized — nothing to reconcile.";
   }
   return `Already initialized — restored missing: ${filled.join(", ")}.`;
+}
+
+/**
+ * Decide which daemon `init` should talk to. Every other CLI command
+ * gets the api_url from `.arkeon/state.json`, but `init` runs before
+ * state.json exists — it has to discover the daemon some other way.
+ *
+ * Priority chain (most specific wins):
+ *
+ *   1. `ARKE_API_URL` env var or `--api-url` flag (moved into the env
+ *      var by the root preAction hook). Explicit override.
+ *   2. The "default" instance — i.e. a daemon started by plain
+ *      `arkeon-wiki up` (no `--name`). This is the 99% case and the
+ *      port is :8000.
+ *   3. Exactly one named instance running. If the user has a single
+ *      `--name foo` daemon and no default, init talks to it.
+ *   4. Nothing running, or multiple named with no default → throw a
+ *      message that names the running instances and tells the user
+ *      to pass `--api-url`.
+ *
+ * The `deps` argument exists for unit tests — production callers omit
+ * it and the registry lookups go through the real filesystem.
+ */
+export interface ResolveApiUrlDeps {
+  env?: NodeJS.ProcessEnv;
+  findInstance?: (name: string) => Instance | null;
+  listInstances?: () => Instance[];
+}
+
+export function resolveApiUrl(deps: ResolveApiUrlDeps = {}): string {
+  const env = deps.env ?? process.env;
+  const findInst = deps.findInstance ?? findInstance;
+  const listInst = deps.listInstances ?? listInstances;
+
+  // (1) Explicit override.
+  const fromEnv = env.ARKE_API_URL;
+  if (fromEnv) return fromEnv;
+
+  // (2) Default unnamed daemon.
+  const defaultInst = findInst(DEFAULT_INSTANCE_NAME);
+  if (defaultInst) return defaultInst.api_url;
+
+  // (3) Unique named instance.
+  const running = listInst();
+  if (running.length === 1) return running[0].api_url;
+
+  // (4) Error path — describe what we found so the user can choose.
+  if (running.length === 0) {
+    throw new Error(
+      "No arkeon-wiki daemon is running. Start one with `arkeon-wiki up` " +
+        "(or pass `--api-url <url>` to point at a daemon elsewhere).",
+    );
+  }
+  const list = running
+    .map((i: Instance) => `  - ${i.name} (${i.api_url})`)
+    .join("\n");
+  throw new Error(
+    `Multiple arkeon-wiki daemons are running and none of them is the default. ` +
+      `Pick one with --api-url <url>:\n${list}`,
+  );
 }
 
 /**

--- a/packages/arkeon/test/unit/init-resolve-api-url.test.ts
+++ b/packages/arkeon/test/unit/init-resolve-api-url.test.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { resolveApiUrl } from "../../src/cli/commands/repo/init.js";
+import type { Instance } from "../../src/cli/lib/instances.js";
+
+function mkInst(name: string, port: number): Instance {
+  return {
+    name,
+    api_url: `http://localhost:${port}`,
+    api_port: port,
+    home: `/tmp/${name}`,
+    pid: 1234,
+    started_at: "2026-05-14T00:00:00.000Z",
+  };
+}
+
+describe("resolveApiUrl", () => {
+  it("returns ARKE_API_URL when set, regardless of running daemons", () => {
+    const url = resolveApiUrl({
+      env: { ARKE_API_URL: "http://elsewhere:9999" },
+      findInstance: () => mkInst("default", 8000),
+      listInstances: () => [mkInst("default", 8000)],
+    });
+    expect(url).toBe("http://elsewhere:9999");
+  });
+
+  it("returns the default instance's api_url when one is running", () => {
+    const url = resolveApiUrl({
+      env: {},
+      findInstance: (name) => (name === "default" ? mkInst("default", 8000) : null),
+      listInstances: () => [mkInst("default", 8000), mkInst("dev", 8123)],
+    });
+    expect(url).toBe("http://localhost:8000");
+  });
+
+  it("falls back to a sole named instance when no default is running", () => {
+    const url = resolveApiUrl({
+      env: {},
+      findInstance: () => null,
+      listInstances: () => [mkInst("dev", 8123)],
+    });
+    expect(url).toBe("http://localhost:8123");
+  });
+
+  it("throws a friendly error when no daemon is running", () => {
+    expect(() =>
+      resolveApiUrl({
+        env: {},
+        findInstance: () => null,
+        listInstances: () => [],
+      }),
+    ).toThrow(/No arkeon-wiki daemon is running/);
+  });
+
+  it("throws and lists candidates when multiple named instances run with no default", () => {
+    let err: Error | null = null;
+    try {
+      resolveApiUrl({
+        env: {},
+        findInstance: () => null,
+        listInstances: () => [mkInst("dev-a", 8101), mkInst("dev-b", 8102)],
+      });
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err).not.toBeNull();
+    expect(err!.message).toMatch(/Multiple arkeon-wiki daemons/);
+    expect(err!.message).toContain("dev-a");
+    expect(err!.message).toContain("dev-b");
+    expect(err!.message).toContain("http://localhost:8101");
+    expect(err!.message).toContain("http://localhost:8102");
+  });
+
+  it("env override beats default and named (priority 1 highest)", () => {
+    const url = resolveApiUrl({
+      env: { ARKE_API_URL: "http://override:9000" },
+      findInstance: () => mkInst("default", 8000),
+      listInstances: () => [mkInst("default", 8000), mkInst("dev", 8123)],
+    });
+    expect(url).toBe("http://override:9000");
+  });
+});

--- a/packages/arkeon/test/unit/init-resolve-api-url.test.ts
+++ b/packages/arkeon/test/unit/init-resolve-api-url.test.ts
@@ -21,7 +21,6 @@ describe("resolveApiUrl", () => {
   it("returns ARKE_API_URL when set, regardless of running daemons", () => {
     const url = resolveApiUrl({
       env: { ARKE_API_URL: "http://elsewhere:9999" },
-      findInstance: () => mkInst("default", 8000),
       listInstances: () => [mkInst("default", 8000)],
     });
     expect(url).toBe("http://elsewhere:9999");
@@ -30,7 +29,6 @@ describe("resolveApiUrl", () => {
   it("returns the default instance's api_url when one is running", () => {
     const url = resolveApiUrl({
       env: {},
-      findInstance: (name) => (name === "default" ? mkInst("default", 8000) : null),
       listInstances: () => [mkInst("default", 8000), mkInst("dev", 8123)],
     });
     expect(url).toBe("http://localhost:8000");
@@ -39,7 +37,6 @@ describe("resolveApiUrl", () => {
   it("falls back to a sole named instance when no default is running", () => {
     const url = resolveApiUrl({
       env: {},
-      findInstance: () => null,
       listInstances: () => [mkInst("dev", 8123)],
     });
     expect(url).toBe("http://localhost:8123");
@@ -49,7 +46,6 @@ describe("resolveApiUrl", () => {
     expect(() =>
       resolveApiUrl({
         env: {},
-        findInstance: () => null,
         listInstances: () => [],
       }),
     ).toThrow(/No arkeon-wiki daemon is running/);
@@ -60,7 +56,6 @@ describe("resolveApiUrl", () => {
     try {
       resolveApiUrl({
         env: {},
-        findInstance: () => null,
         listInstances: () => [mkInst("dev-a", 8101), mkInst("dev-b", 8102)],
       });
     } catch (e) {
@@ -77,9 +72,26 @@ describe("resolveApiUrl", () => {
   it("env override beats default and named (priority 1 highest)", () => {
     const url = resolveApiUrl({
       env: { ARKE_API_URL: "http://override:9000" },
-      findInstance: () => mkInst("default", 8000),
       listInstances: () => [mkInst("default", 8000), mkInst("dev", 8123)],
     });
     expect(url).toBe("http://override:9000");
+  });
+
+  // Encodes the invariant that fixed the back-door the original PR
+  // review caught: `listInstances` is responsible for pruning stale
+  // (dead-pid) registry entries, so a crashed daemon's leftover
+  // `default.json` is already gone by the time we look. From
+  // resolveApiUrl's perspective this is indistinguishable from
+  // "no daemon was ever running" — which is exactly the contract
+  // we want.
+  it("treats a pruned-stale registry as 'no daemon running'", () => {
+    expect(() =>
+      resolveApiUrl({
+        env: {},
+        // listInstances returns [] because the stale default.json
+        // had a dead pid and was pruned at lookup time.
+        listInstances: () => [],
+      }),
+    ).toThrow(/No arkeon-wiki daemon is running/);
   });
 });


### PR DESCRIPTION
## Summary

Surfaced during the SETUP.md walkthrough rehearsal: every other CLI command picks up the api_url from `.arkeon/state.json`, but `init` runs *before* state.json exists — and used to hard-default to `http://localhost:8000` with no fallback. A user running `arkeon-wiki up --name foo` (whose port is derived from the name) would see `init` silently target `:8000`, hit nothing, and fail with `"fetch failed"`.

New priority chain in `resolveApiUrl`:

1. `ARKE_API_URL` env / `--api-url` flag (explicit override) — kept
2. The `"default"` instance — daemon started by plain `arkeon-wiki up` (no `--name`). 99% case, port `:8000`.
3. Exactly one named instance running — fall back to it.
4. Nothing running, or multiple named with no default → throw a clear error that lists the running instances and points at `--api-url`.

The helper takes its registry lookups via optional deps so unit tests can pass fakes; the production caller omits them.

## Test plan

- [x] `npm run typecheck -w packages/arkeon` clean
- [x] `npm test -w packages/arkeon` — 183/183 (7 new in `init-resolve-api-url.test.ts` covering all four branches + env-override-precedence)
- [x] Manual smoke A: default daemon on :8000 → `init` auto-discovers, succeeds
- [x] Manual smoke B: only a named daemon running (no default), other unrelated named daemon also present → `init` errors listing both candidates and asking for `--api-url`
- [x] Manual smoke C: zero daemons → friendly "no arkeon-wiki daemon is running" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)