### PR TITLE
docs: SETUP.md — first-time setup walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A knowledge graph that lives in your filesystem. Point it at a directory, and it watches for changes, indexes files into SQLite, and builds a connected graph from `<a href>` links between HTML articles.
 
+**First-time setup → [SETUP.md](./SETUP.md)** is a 15-minute walkthrough that takes you from install to a corpus the agents are actively writing into.
+
 ## Quick start
 
 **1. Install and start**

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,254 @@
+# Setting up an arkeon-wiki
+
+A walkthrough for going from zero to a corpus the agents are actively writing into. Works equally well if you're running the commands by hand or asking Claude Code (or any coding agent) to drive — every step is a concrete command.
+
+The README explains *what* arkeon-wiki is. This doc gets you to a wiki that's producing real articles. Budget: 15-20 minutes plus a few cents in LLM credit.
+
+## 1. Prerequisites
+
+- Node 18 or newer
+- An API key from one of: OpenAI (default), Anthropic, or any OpenAI-compatible backend (Ollama, OpenRouter, Groq, LM Studio, vLLM, …)
+
+If you don't have a global install yet:
+
+```bash
+npm install -g arkeon-wiki
+```
+
+## 2. Drop your API key in `.env`
+
+Write the key **before** you start the daemon. The daemon snapshots `process.env` at launch — adding `.env` after `arkeon-wiki up` requires a restart for the key to land.
+
+```bash
+mkdir -p ~/.arkeon-wiki
+echo "OPENAI_API_KEY=sk-..." > ~/.arkeon-wiki/.env
+chmod 600 ~/.arkeon-wiki/.env
+```
+
+(Substitute `ANTHROPIC_API_KEY` if that's what you're using. For OpenAI-compatible backends, also set the `base_url` in your per-repo `.arkeon/agents.yaml` later.)
+
+Shell `export OPENAI_API_KEY=...` works too and takes precedence over the file.
+
+## 3. Start the daemon
+
+```bash
+arkeon-wiki up
+```
+
+This forks a detached background process that runs SQLite + the API server on `http://localhost:8000`. It survives terminal close. Stop it with `arkeon-wiki down`. State (database, pidfile, log) lives in `~/.arkeon-wiki/`.
+
+Verify:
+
+```bash
+arkeon-wiki status
+curl http://localhost:8000/health
+```
+
+## 4. Initialize your directory
+
+`cd` to wherever your corpus will live, then:
+
+```bash
+arkeon-wiki init
+```
+
+One command, four effects:
+
+1. Registers the directory as a **space** with the daemon. The file watcher starts immediately.
+2. Writes `.arkeon/state.json` (per-clone, gitignored).
+3. Creates `wiki/` (where the agents will author).
+4. Lays down `.arkeon/agents.yaml` from the bundled `wiki` template, and adds both `.arkeon/state.json` and `.env` to `.gitignore` (creating `.gitignore` if missing).
+
+The output payload reports what was created or already in place. If you re-run `init` after editing the YAML by hand, it reconciles missing pieces (e.g. restores `agents.yaml` if you deleted it) without ever clobbering hand-edits.
+
+## 5. Opinionate the wiki
+
+This is the most consequential step. Without an `instructions:` block your agents will write a generic encyclopedia on whatever's in front of them; with it, the corpus develops a point of view.
+
+Open `.arkeon/agents.yaml`. Find the commented-out `instructions:` block in `defaults:`. Uncomment it and replace the placeholder text. The block is appended to every role's system prompt without disturbing the workflow.
+
+A strong `instructions:` answers four questions:
+
+- **What is the wiki about, and what is it *not* about?**
+- **What kinds of articles should be written?** (Surveys? Questions and answers? Polemics? Concept-by-concept reference?)
+- **What voice?** (Encyclopedia neutrality, primary-source-voice, opinionated, contrarian, etc.)
+- **Who's the audience?** (Practitioners, newcomers, you-six-months-from-now, etc.)
+
+Concrete example — a wiki built on Augustine and G. K. Chesterton, asking how their critique of pure reason applies to the modern world:
+
+```yaml
+defaults:
+  provider: openai
+  model: gpt-5-mini
+  instructions: |
+    This wiki develops a Christian critique of modern intellectual
+    prides — rationalism, scientism, and the unexamined faith in
+    pure reason. The corpus is Augustine and G. K. Chesterton,
+    primary texts only (Confessions, City of God, Orthodoxy,
+    Heretics).
+
+    The driving question: how would these authors apply their
+    Christian ideals to the modern world, and which of the modern
+    certainties they attacked still go unchallenged today?
+
+    What to write:
+    - Questions that surface when ancient/Christian thought meets
+      modern certainties.
+    - Articles that take a clear side. These authors had positions
+      — the wiki should not water them down into balanced
+      "perspectives" prose.
+    - Specific citations. Augustine by book + chapter
+      (Confessions VII.5; City of God I.1). Chesterton by chapter
+      title (Orthodoxy ch. III "The Suicide of Thought").
+
+    Tone:
+    - Direct, opinionated, occasionally polemical. Match the voice
+      of the sources. Chesterton paradoxes are fine; Augustine's
+      confessional personalism is fine. Don't flatten either into
+      encyclopedia voice.
+
+    Out of scope:
+    - "How modern Christians have responded to X." Secondary
+      commentary doesn't belong here.
+    - Apologetics primers for newcomers.
+    - Hedging. Sentences that begin "Some have argued..." defeat
+      the project.
+
+    Audience:
+    - Readers familiar with these authors or willing to chase a
+      citation.
+```
+
+Verify the parse + the merged config:
+
+```bash
+arkeon-wiki config validate
+arkeon-wiki config show
+```
+
+The `instructions:` text will appear under `defaults:` in the `config show` output.
+
+## 6. Add your sources
+
+Drop text files anywhere in the directory (any subfolder is fine — `sources/`, `notes/`, top-level, doesn't matter). The watcher picks them up automatically.
+
+**Supported extensions**: `.txt`, `.html` (outside `wiki/`), `.json`, `.csv`, `.xml`, `.rst`. Anything else is **silently ignored** — Markdown, PDFs, DOCX, images, binaries.
+
+Check what the watcher actually sees:
+
+```bash
+arkeon-wiki sources scan
+```
+
+The output partitions every file into supported / unsupported. Unsupported entries list up to 5 example paths per extension. Convert anything you wanted indexed:
+
+| Source | Recommended converter |
+|--------|----------------------|
+| PDF | `pdftotext file.pdf file.txt` (poppler-utils) |
+| DOCX | `pandoc file.docx -o file.txt` |
+| Markdown | `cp file.md file.txt`, or convert with `pandoc -o file.html` if you want HTML semantics |
+| HTML web pages | already supported as `.txt` if you save the page text; or use `pandoc` to clean |
+| EPUB | `pandoc file.epub -o file.txt` |
+
+A re-run of `sources scan` after conversion confirms zero unsupported files.
+
+## 7. First-cycle smoke test
+
+Three roles cooperate, in order:
+
+- **`editor`** reads one source per tick and adds citations / open-thread red links to *existing* articles. On a fresh corpus with no articles yet, it tags-and-skips. **0 edits is the expected first-tick outcome — don't panic.**
+- **`proposer`** picks up the source the editor just tagged, identifies questions no article covers yet, and emits them as red links in a per-source plan wiki at `wiki/_plans/<source-path>.html`.
+- **`writer`** drains the highest-demand red link, one article per tick. This is where the corpus starts to fill in.
+
+Drive one manual cycle to verify your `instructions:` produces what you want before letting cron loose:
+
+```bash
+arkeon-wiki agent run editor       # tags the first source. 0 edits expected.
+arkeon-wiki agent run proposer     # creates wiki/_plans/<source>.html with red links
+arkeon-wiki agent run writer       # produces the first article
+```
+
+Each call blocks until the run finishes (typically 5-60 seconds). The output payload includes `duration_ms`, `steps`, `edits`, and `usage.totalTokens` so you can size the cost.
+
+### Sanity-check the output
+
+```bash
+arkeon-wiki agent run writer --space <your-space>   # if not run inside the bound dir
+curl -s http://localhost:8000/<your-space>/redlinks | jq .   # see queued articles
+ls wiki/                                            # see what the writer produced
+```
+
+Open the result in a browser:
+
+```
+http://localhost:8000/<your-space>/
+```
+
+The reader page lists every article in the space; click through to see the writer's first output rendered with the article-relative links resolved.
+
+**Don't proceed if the article isn't what you wanted.** This is the moment to tune `instructions:`. The agents will produce articles in this voice/structure for as long as the config stands; later corrections require either rewriting articles by hand or rolling back. Re-run `agent run writer` (after deleting the article and tweaking `instructions:`) until the output is what you'd be happy to read every hour.
+
+## 8. Let cron carry it
+
+Bundled cron defaults:
+
+| Role | Cadence | Why |
+|------|---------|-----|
+| `editor` | hourly | Source-driven; new sources land slowly. |
+| `proposer` | hourly | Trails editor by data dependency (gates on `editor.processed_hash` tag). |
+| `writer` | every 15 min | Red-link queue-driven; the fastest mover. |
+
+For the first day or two, **slow the writer down** so you can observe before the corpus gets large. Override in `.arkeon/agents.yaml`:
+
+```yaml
+roles:
+  writer:
+    cron: "0 */1 * * *"     # every hour instead of every 15 minutes
+```
+
+The change takes effect on the next tick — no daemon restart needed.
+
+Read articles in the browser:
+
+```
+http://localhost:8000/<your-space>/
+```
+
+Red links show up in red; click through to see what the queue looks like. The `/<space>/redlinks` and `/<space>/recent` API routes give you the queue and the edit feed if you want to script alerts.
+
+## 9. Daily-use commands
+
+```bash
+arkeon-wiki status                  # is the daemon up?
+arkeon-wiki logs -f                 # tail the daemon log (includes agent runs)
+arkeon-wiki ls                      # list running instances (rare unless --name)
+arkeon-wiki search "shannon"        # ripgrep across the bound space
+arkeon-wiki sources scan            # re-inventory after adding sources
+arkeon-wiki config show             # what'll actually run
+arkeon-wiki agent run <role>        # fire a tick on demand
+arkeon-wiki down                    # stop the daemon
+```
+
+## Troubleshooting
+
+**`fetch failed` from `init`.** No daemon is running on the URL `init` is targeting. Run `arkeon-wiki status` to check, and `arkeon-wiki up` to start one.
+
+**Agents start spending money the moment the daemon is up.** True. The writer's default cron is every 15 min and will fire on any redlinks the proposer leaves behind. If you want to inspect before letting it loose, slow the writer to hourly (Step 8) before adding sources — the editor and proposer won't queue anything for the writer until they've each processed at least one source.
+
+**My API key isn't being picked up.** Check the order: `~/.arkeon-wiki/.env` is read at daemon launch. If you added the key after `arkeon-wiki up`, restart with `arkeon-wiki down && arkeon-wiki up`. Shell `export` always wins, so `OPENAI_API_KEY=sk-... arkeon-wiki up` is another option.
+
+**The editor logged "0 edits" — is it broken?** No. The editor only edits *existing* articles. On a corpus with zero or few articles, "0 edits" is the correct outcome. The proposer is the one that converts unprocessed sources into red links; the writer is the one that fills the queue. Run those two next.
+
+**The writer produced one article and stopped.** That's the design — one article per tick. The next writer tick (in 15 min by default, or `arkeon-wiki agent run writer` immediately) drains the next red link.
+
+**The voice is wrong / the structure is wrong / the articles are bland.** Tune `instructions:`. The single biggest lever in the system. If you want a fundamentally different article structure (different section names, different layout), override `roles.writer.system:` wholesale instead — `instructions:` layers onto the bundled prompt, it doesn't replace it.
+
+**A source I want indexed isn't showing up.** Run `arkeon-wiki sources scan`. If it's in the `unsupported` bucket, convert it (see Step 6). If it's not in either bucket, it's probably under a hidden directory (anything starting with `.`) or inside `node_modules`, `.git`, etc. — the watcher skips those by design.
+
+**Multiple daemons running confused things.** `arkeon-wiki ls` lists them. The default-port daemon (started by plain `up`) takes precedence; if you also have named instances (`up --name foo`), pass `--api-url http://localhost:<port>` to target a specific one.
+
+## What's next
+
+- **Customize the role pipeline**: add a custom role in `.arkeon/agents.yaml` (e.g., a `curator` that prunes stale articles, or a `synthesizer` that connects articles across themes). See [docs/user/AGENT_RUNTIME.md](./docs/user/AGENT_RUNTIME.md).
+- **Run multiple wikis side by side**: register more directories with `arkeon-wiki init`. The daemon watches as many spaces as you point at.
+- **Read the corpus a different way**: the `/<space>/search`, `/<space>/redlinks`, and `/<space>/recent` API endpoints expose the index. The reader UI in v0 is intentionally minimal — articles render as plain HTML pages.

--- a/SETUP.md
+++ b/SETUP.md
@@ -86,7 +86,7 @@ roles:
     model: gpt-5-mini
 ```
 
-`defaults.model` does apply to any *custom* role you define (that has no bundled template). Operator-defaults vs. bundled-template precedence is something the project may fix; track [#TBD](https://github.com/Arkeon-Technologies/arkeon-wiki/issues) if you care.
+`defaults.model` does apply to any *custom* role you define (that has no bundled template). Operator-defaults vs. bundled-template precedence is tracked in [#148](https://github.com/Arkeon-Technologies/arkeon-wiki/issues/148).
 
 Concrete worked example — a wiki built on Augustine and G. K. Chesterton, attacking specific modern phenomena (transhumanism, AI companionship, productivity culture, etc.) through their critique of pure reason. The biggest lever is **insisting articles name a modern target by name** and refusing generic concept-exposition:
 
@@ -221,6 +221,8 @@ The output partitions every file into supported / unsupported. Unsupported entri
 | HTML web pages | already supported as `.txt` if you save the page text; or use `pandoc` to clean |
 | EPUB | `pandoc file.epub -o file.txt` |
 
+Install the converters if you don't have them: `brew install pandoc poppler` on macOS, `apt install pandoc poppler-utils` on Debian/Ubuntu, or equivalents for your package manager.
+
 A re-run of `sources scan` after conversion confirms zero unsupported files.
 
 ## 7. First-cycle smoke test
@@ -338,7 +340,7 @@ arkeon-wiki down                    # stop the daemon
 
 **The proposer created an empty plan wiki (no red links inside).** That's correct, not broken. The proposer refuses to emit red links that duplicate themes already covered by existing articles or queued red links. On the next editor tick, the same source will be integrated as citations into existing articles instead. Empty plans tend to appear on the 2nd, 3rd, etc. source of a thematically-cohesive corpus.
 
-**Multiple daemons running confused things.** `arkeon-wiki ls` lists them. The default-port daemon (started by plain `up`) takes precedence; if you also have named instances (`up --name foo`), pass `--api-url http://localhost:<port>` to target a specific one.
+**Multiple daemons running confused things.** `arkeon-wiki ls` lists them. To target a specific one, pass `--api-url http://localhost:<port>` (the port for a named daemon is printed by `arkeon-wiki up --name <name>` and visible in `ls`). If `init` is hitting the wrong daemon — see [#144](https://github.com/Arkeon-Technologies/arkeon-wiki/pull/144) for auto-discovery, after which plain `arkeon-wiki up` (no `--name`) is preferred and `init` will find it automatically.
 
 ## What's next
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -74,50 +74,90 @@ A strong `instructions:` answers four questions:
 - **What voice?** (Encyclopedia neutrality, primary-source-voice, opinionated, contrarian, etc.)
 - **Who's the audience?** (Practitioners, newcomers, you-six-months-from-now, etc.)
 
-Concrete example — a wiki built on Augustine and G. K. Chesterton, asking how their critique of pure reason applies to the modern world:
+**A trap worth flagging up front**: `defaults.model` is silently ignored for the bundled `editor`, `proposer`, and `writer` roles, because each bundled template has its own `model:` field that takes precedence in the resolution chain. To actually change the model for a bundled role, override it per role:
+
+```yaml
+roles:
+  editor:
+    model: gpt-5-mini
+  proposer:
+    model: gpt-5-mini
+  writer:
+    model: gpt-5-mini
+```
+
+`defaults.model` does apply to any *custom* role you define (that has no bundled template). Operator-defaults vs. bundled-template precedence is something the project may fix; track [#TBD](https://github.com/Arkeon-Technologies/arkeon-wiki/issues) if you care.
+
+Concrete worked example — a wiki built on Augustine and G. K. Chesterton, attacking specific modern phenomena (transhumanism, AI companionship, productivity culture, etc.) through their critique of pure reason. The biggest lever is **insisting articles name a modern target by name** and refusing generic concept-exposition:
 
 ```yaml
 defaults:
   provider: openai
-  model: gpt-5-mini
   instructions: |
-    This wiki develops a Christian critique of modern intellectual
-    prides — rationalism, scientism, and the unexamined faith in
-    pure reason. The corpus is Augustine and G. K. Chesterton,
-    primary texts only (Confessions, City of God, Orthodoxy,
-    Heretics).
+    This wiki uses Augustine and G. K. Chesterton as weapons
+    against specific 21st-century anxieties, technologies, and
+    prides. It is not a wiki *about* Augustine and Chesterton —
+    generic exposition of their concepts is out of scope.
 
-    The driving question: how would these authors apply their
-    Christian ideals to the modern world, and which of the modern
-    certainties they attacked still go unchallenged today?
+    Every article names a modern target by name and submits it to
+    the authors' diagnosis. Anchor on the things that actually
+    shape contemporary life: dating apps, AI companions,
+    doomscrolling, hustle culture, parasocial relationships,
+    secular mindfulness, optimization culture, longtermism,
+    "follow your passion," the loneliness epidemic, productivity
+    theology, scientism, AI doomerism, "live your truth."
 
-    What to write:
-    - Questions that surface when ancient/Christian thought meets
-      modern certainties.
-    - Articles that take a clear side. These authors had positions
-      — the wiki should not water them down into balanced
-      "perspectives" prose.
-    - Specific citations. Augustine by book + chapter
-      (Confessions VII.5; City of God I.1). Chesterton by chapter
-      title (Orthodoxy ch. III "The Suicide of Thought").
+    Slug shape: name the target by name.
+
+      GOOD:  is-ai-companionship-the-new-manichaeism.html
+      GOOD:  what-would-chesterton-say-about-tinder.html
+      GOOD:  how-augustine-explains-doomscrolling.html
+      GOOD:  why-self-actualization-is-cain-not-abel.html
+
+      BAD:   why-is-orthodoxy-revolutionary.html
+      BAD:   how-do-paradoxes-save-ethics.html
+      BAD:   why-must-god-be-transcendent.html
+
+    The BAD examples are generic concept articles. They explain
+    what the authors thought; they do not deploy it against
+    anything. Do not write them.
+
+    Article shape (Question / Current answer / Evidence / Open
+    threads — unchanged):
+      Question: name the modern thing. State the unspoken modern
+        assumption about it. Frame the question as "what does
+        this assumption conceal?"
+      Current answer: the authors' diagnosis, tied directly to
+        the named modern thing. No generic theory.
+      Evidence: inline citations to the sources (book + section
+        where possible). Each quote should be connected to the
+        modern target by name in the same paragraph — not just
+        paraphrased into encyclopedia voice.
+      Open threads: two or three OTHER modern phenomena the same
+        diagnosis would touch, as red links.
 
     Tone:
-    - Direct, opinionated, occasionally polemical. Match the voice
-      of the sources. Chesterton paradoxes are fine; Augustine's
-      confessional personalism is fine. Don't flatten either into
-      encyclopedia voice.
+      Polemical, sharp, partial. The reader should finish each
+      article with the feeling that something they assumed is
+      now in question. Hedging is forbidden — no "some have
+      argued" or "on the other hand."
 
     Out of scope:
-    - "How modern Christians have responded to X." Secondary
-      commentary doesn't belong here.
-    - Apologetics primers for newcomers.
-    - Hedging. Sentences that begin "Some have argued..." defeat
-      the project.
+      Generic exposition of the authors' concepts.
+      Apologetics primers — assume the reader knows the basics.
+      Both-sides framing.
 
     Audience:
-    - Readers familiar with these authors or willing to chase a
-      citation.
+      Practitioners of contrarian thought who use these authors
+      as weapons against modern certainties. Not students.
+
+roles:
+  editor:    { model: gpt-5-mini }
+  proposer:  { model: gpt-5-mini }
+  writer:    { model: gpt-5-mini }
 ```
+
+The `GOOD/BAD` slug examples are the single most useful lever — they shape the proposer's red-link slugs, which then constrain the writer's article titles, which constrains the writer's voice. Get this right and the wiki develops a point of view from the first article on.
 
 Verify the parse + the merged config:
 
@@ -133,6 +173,37 @@ The `instructions:` text will appear under `defaults:` in the `config show` outp
 Drop text files anywhere in the directory (any subfolder is fine — `sources/`, `notes/`, top-level, doesn't matter). The watcher picks them up automatically.
 
 **Supported extensions**: `.txt`, `.html` (outside `wiki/`), `.json`, `.csv`, `.xml`, `.rst`. Anything else is **silently ignored** — Markdown, PDFs, DOCX, images, binaries.
+
+### Prefer chapters / sections over whole books
+
+One source file = one editor tick = one proposer tick. Two practical consequences:
+
+- **Size**: every tick reads the source in full. A 1 MB+ file can overflow the model's effective context (we hit this with a full Augustine *City of God* volume on `gpt-5-mini`). Aim for under ~150 KB per source — most chapters or essay-length pieces fit easily.
+- **Granularity**: chapters give the proposer focused thematic territory to mine. A whole book covering 20 themes yields one plan wiki with 5 red links (most of the book's questions get compressed away); the same book split into 20 chapters yields 20 plan wikis, each surfacing the specific questions of that chapter.
+
+So if you've grabbed a book, split it by chapter or by argument-section before letting the agents see it. A typical layout:
+
+```
+sources/
+  augustine/
+    confessions/
+      book-01.txt
+      book-02.txt
+      ...
+    city-of-god/
+      book-01.txt
+      ...
+  chesterton/
+    orthodoxy/
+      ch-01-introduction.txt
+      ch-02-the-maniac.txt
+      ch-03-the-suicide-of-thought.txt
+      ...
+```
+
+A simple `pandoc` or Python regex splitter on chapter headings is usually enough. Each chapter file ends up 10-100 KB, well within context limits.
+
+### Convert binaries to text
 
 Check what the watcher actually sees:
 
@@ -157,7 +228,7 @@ A re-run of `sources scan` after conversion confirms zero unsupported files.
 Three roles cooperate, in order:
 
 - **`editor`** reads one source per tick and adds citations / open-thread red links to *existing* articles. On a fresh corpus with no articles yet, it tags-and-skips. **0 edits is the expected first-tick outcome — don't panic.**
-- **`proposer`** picks up the source the editor just tagged, identifies questions no article covers yet, and emits them as red links in a per-source plan wiki at `wiki/_plans/<source-path>.html`.
+- **`proposer`** picks up the source the editor just tagged, identifies questions no article covers yet, and emits them as red links in a per-source plan wiki at `wiki/_plans/<source-path>.html`. **An empty plan is also expected behavior**: when a new source's themes overlap with red links the queue already has, the proposer correctly refuses to duplicate them and emits an empty `<ul>`. That means the editor will instead integrate this source as citations into existing articles on subsequent ticks.
 - **`writer`** drains the highest-demand red link, one article per tick. This is where the corpus starts to fill in.
 
 Drive one manual cycle to verify your `instructions:` produces what you want before letting cron loose:
@@ -198,15 +269,27 @@ Bundled cron defaults:
 | `proposer` | hourly | Trails editor by data dependency (gates on `editor.processed_hash` tag). |
 | `writer` | every 15 min | Red-link queue-driven; the fastest mover. |
 
-For the first day or two, **slow the writer down** so you can observe before the corpus gets large. Override in `.arkeon/agents.yaml`:
+For the first day or two, **slow the writer down** so you can observe before the corpus gets large. Or for a fresh-corpus burst, speed all three up so you can watch the system fill in. Override in `.arkeon/agents.yaml`:
 
 ```yaml
 roles:
   writer:
     cron: "0 */1 * * *"     # every hour instead of every 15 minutes
+
+  # Or, for the initial-burst case:
+  editor:
+    cron: "*/3 * * * *"     # every 3 minutes
+  proposer:
+    cron: "*/3 * * * *"     # every 3 minutes
 ```
 
-The change takes effect on the next tick — no daemon restart needed.
+**Cron changes require a daemon restart** (`arkeon-wiki down && arkeon-wiki up`). The scheduler captures cron values at startup. Most other config — `instructions:`, `system:`, `tools:`, `model:` — hot-reloads on every tick, so edits to those land in seconds.
+
+**Editor source-order**: with `sort: updated_at`, the editor picks whichever source was most recently updated (synced or touched). If you bulk-imported and the editor keeps grinding through the same corner of the corpus, give a specific file a nudge to jump the queue:
+
+```bash
+printf "\n" >> sources/path/to/the/one/you-want-next.txt
+```
 
 Read articles in the browser:
 
@@ -243,7 +326,17 @@ arkeon-wiki down                    # stop the daemon
 
 **The voice is wrong / the structure is wrong / the articles are bland.** Tune `instructions:`. The single biggest lever in the system. If you want a fundamentally different article structure (different section names, different layout), override `roles.writer.system:` wholesale instead — `instructions:` layers onto the bundled prompt, it doesn't replace it.
 
+**Articles are too abstract — they explain concepts instead of attacking modern things.** Your `instructions:` need explicit GOOD/BAD slug examples and a "every article must name a 21st-century target by name" rule. The proposer follows the slug-shape patterns you give it; the writer follows the titles the proposer emits. See the worked example in Step 5.
+
 **A source I want indexed isn't showing up.** Run `arkeon-wiki sources scan`. If it's in the `unsupported` bucket, convert it (see Step 6). If it's not in either bucket, it's probably under a hidden directory (anything starting with `.`) or inside `node_modules`, `.git`, etc. — the watcher skips those by design.
+
+**`context_length_exceeded` 500 from `agent run`.** The source the agent picked is too big for the model's effective context. Split that source into chapters (see Step 6 — "Prefer chapters / sections over whole books"). If you can't split it for some reason, switch the affected role to a model with a larger context window (`roles.editor.model: ...`, etc. — and remember to restart the daemon if you also changed cron values).
+
+**The editor keeps picking the same corner of my corpus.** `sort: updated_at` means whichever sources were touched most recently get picked first. After a bulk import, the order is deterministic but often unintuitive. Bump a specific file with `printf "\n" >> sources/.../that-one.txt` to jump it to the front of the queue.
+
+**My `model:` change isn't taking effect.** `defaults.model` is silently ignored for the bundled `editor`, `proposer`, and `writer` roles — each bundled template has its own `model:` that wins. Override per-role under `roles:` (see Step 5).
+
+**The proposer created an empty plan wiki (no red links inside).** That's correct, not broken. The proposer refuses to emit red links that duplicate themes already covered by existing articles or queued red links. On the next editor tick, the same source will be integrated as citations into existing articles instead. Empty plans tend to appear on the 2nd, 3rd, etc. source of a thematically-cohesive corpus.
 
 **Multiple daemons running confused things.** `arkeon-wiki ls` lists them. The default-port daemon (started by plain `up`) takes precedence; if you also have named instances (`up --name foo`), pass `--api-url http://localhost:<port>` to target a specific one.
 


### PR DESCRIPTION
## Summary

A 9-step setup walkthrough that takes a user from install to a corpus the agents are actively writing into. Worked example uses the Augustine/Chesterton "Christian critique of modern reason" wiki we built during the v0-setup rehearsal — concrete enough that the \`instructions:\` block shows what good operator framing looks like.

Each step is a copy-pasteable command with no ambiguity, so the doc works equally well for a human reading it or a coding agent (Claude Code, etc.) driving on the user's behalf.

## What it covers

1. Prereqs
2. API key in \`~/.arkeon-wiki/.env\` — emphasizes "before \`up\`, not after"
3. \`arkeon-wiki up\`
4. \`arkeon-wiki init\` — what the four effects are
5. **Opinionate** — uncomment \`instructions:\`, full worked example
6. Add sources, run \`sources scan\`, convert binaries
7. First-cycle smoke test (editor → proposer → writer) with bound expectations ("0 edits is the expected first-tick outcome")
8. Tune cron, let it run
9. Daily-use command reference

Plus a troubleshooting section with the seven most likely failure modes from the walkthrough.

## Frictions surfaced during the rehearsal that this doc addresses

- Env sequencing: daemon snapshots env at launch.
- Editor logs "0 edits" on first tick → users will think it's broken without context.
- The role dependency order (editor → proposer → writer) isn't visible from the CLI alone.
- The bundled \`agents.yaml\` ships with \`instructions:\` commented out — easy to miss.
- Sources scan surfaces unsupported binaries the watcher silently skips.

## Test plan

- [x] Walked the doc against the live daemon end-to-end (Augustine/Chesterton wiki, produced real articles)
- [x] Verified every command in the doc resolves correctly against the merged main (#138/#139/#140 landed)
- [ ] Manual: drop a fresh checkout into a tmp dir and run the doc start-to-finish to spot anything I missed

🤖 Generated with [Claude Code](https://claude.com/claude-code)