### PR TITLE
install-service: persistent daemon via macOS launchd

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,8 @@ arkeon-wiki logs [-f]                # print/tail the daemon log
 arkeon-wiki init [name]              # register cwd as a space (default name = basename)
 arkeon-wiki search <query> [--space <name>]
 arkeon-wiki start                    # foreground (pm2/launchd/etc.)
+arkeon-wiki install                  # persistent service: starts at login, restarts on crash
+arkeon-wiki uninstall                # remove the service
 ```
 
 Run multiple instances side by side with `--name`:
@@ -213,6 +215,23 @@ arkeon-wiki up --name dev-b          # independent daemon, different port
 ```
 
 The port for a named instance is `8000 + sha256(name) mod 999 + 1`.
+
+## Persistent service (macOS launchd / Linux systemd)
+
+`arkeon-wiki up` spawns a detached child that survives shell exit but not reboot. `arkeon-wiki install` registers the daemon with the platform's service supervisor so it starts at login and restarts on crash.
+
+- **macOS:** writes `~/Library/LaunchAgents/tech.arkeon.wiki[.<name>].plist` and bootstraps it into the user's launchd domain (`gui/$UID`). No sudo. `KeepAlive: { SuccessfulExit: false, Crashed: true }` means a clean `arkeon-wiki down` stays down, but a crashed daemon comes back within `ThrottleInterval` (10s).
+- **Linux:** systemd user unit (`arkeon-wiki[@<name>].service`), `loginctl enable-linger $USER` so it survives logout on headless servers. *Planned for PR2; tracked in [#146](https://github.com/Arkeon-Technologies/arkeon-wiki/issues/146).*
+
+`OPENAI_API_KEY` / `ANTHROPIC_API_KEY` are not stored in the plist (plists are world-readable on multi-user Macs). Install captures them into `~/.arkeon-wiki/.env`, where the existing env-loader (`server/agents/env-loader.ts:42`) reads them at startup. Idempotent: never overwrites an existing value.
+
+When a service is installed, `up` / `down` / `status` automatically coordinate with the supervisor instead of fighting it:
+
+- `up` detects the installed plist and delegates to `launchctl kickstart -k` instead of spawning a detached child (which would create an orphan launchd doesn't track). Reports `managed_by: "service"` in the result.
+- `down` uses `SIGTERM`, the daemon exits cleanly (exit code 0), and launchd respects `SuccessfulExit: false` — does not auto-restart. The daemon stays down until next `up` or login.
+- `status` reports a `service` field (`installed`, `running`, `pid`, `unit_path`) so consumers see service state independently of pidfile state.
+
+Manual e2e: `packages/arkeon/scripts/test-service.sh` runs the full install → kill -9 → down → up → uninstall lifecycle with `--name service-smoke-test`, asserting state at each step. ~30s. PR authors run this on their Mac before merging. (Linux variant arrives with PR2.)
 
 ## Testing
 
@@ -232,6 +251,8 @@ E2e tests start a real stack in-process — no running daemon needed.
 - `~/.arkeon-wiki/<home>/arkeon.pid` — pidfile for the daemon
 - `~/.arkeon-wiki/<home>/arkeon.log` — daemon stdout/stderr
 - `~/.arkeon-wiki/instances/<name>.json` — registry of running instances
+- `~/.arkeon-wiki/.env` — user-global env file. `install` writes API keys here; the agent runtime reads them at startup. Never overwritten — values rotate by editing the file.
+- `~/Library/LaunchAgents/tech.arkeon.wiki[.<name>].plist` — service plist when `install` has been run on macOS. Owned by the user; survives reboot.
 - `.arkeon/state.json` — per-directory space binding (`{api_url, space_name, created_at}`). The old `space_id` field is gone — names are PKs now.
 
 Override the state dir with `ARKEON_WIKI_HOME` env var or `--data-dir`.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ arkeon-wiki up
 
 This starts the daemon as a detached background process — it survives your terminal closing. Stop it with `arkeon-wiki down`. State (SQLite database, pidfile, log) lives in `~/.arkeon-wiki/`.
 
+For a daemon that also survives reboot and restarts on crash, run `arkeon-wiki install` (macOS launchd today; Linux systemd planned). See [§Persistent service](#persistent-service).
+
 **2. Register a directory**
 
 ```bash
@@ -100,7 +102,27 @@ arkeon-wiki config init        # write .arkeon/agents.yaml from a template
 arkeon-wiki config show        # print merged effective agent config
 arkeon-wiki config validate    # schema-check the YAML
 arkeon-wiki start              # foreground (for use under pm2/launchd/etc.)
+arkeon-wiki install            # persistent service: starts at login, restarts on crash
+arkeon-wiki uninstall          # remove the service
 ```
+
+## Persistent service
+
+`arkeon-wiki up` runs as a detached child — survives your shell, but not a reboot. For a daemon that comes back automatically at login and restarts on crash, install it as a service:
+
+```bash
+arkeon-wiki install                  # default instance
+arkeon-wiki install --name dev-a     # a specific --name instance
+arkeon-wiki uninstall                # remove the service (leaves data dir intact)
+```
+
+**macOS** writes `~/Library/LaunchAgents/tech.arkeon.wiki[.<name>].plist` and bootstraps it into the user's launchd domain. No sudo. The plist's `KeepAlive: { SuccessfulExit: false, Crashed: true }` contract means `arkeon-wiki down` stays down (clean exit), but a crashed daemon comes back within ~10s.
+
+**Linux** (systemd user unit + `loginctl enable-linger`) is planned for PR2 — tracked in [#146](https://github.com/Arkeon-Technologies/arkeon-wiki/issues/146).
+
+API keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`) live in `~/.arkeon-wiki/.env`, *not* in the plist (plists are world-readable). `install` captures keys from your shell if they're set there but not in the file yet — it never overwrites existing values. Rotate keys by editing the file.
+
+When a service is installed, `up`/`down`/`status` coordinate with the supervisor automatically: `up` delegates to `launchctl kickstart` instead of spawning an orphan; `down` produces a clean exit the supervisor respects; `status` surfaces a `service` field with installed/running/pid.
 
 ## Agents (LLM-powered)
 

--- a/packages/arkeon/scripts/test-service.sh
+++ b/packages/arkeon/scripts/test-service.sh
@@ -93,6 +93,17 @@ require "install running=true" echo "$INSTALL_OUT" | grep -q '"running": true'
 require "plist exists" test -f "$PLIST"
 require "launchctl knows label" launchctl print "gui/$UID/$LABEL" 2>/dev/null
 
+# Install returns when launchctl reports state=running. The daemon's
+# own pidfile is written by start.ts a few hundred ms later, after the
+# API binds the port. Real users hit this delay invisibly between
+# commands; the harness runs back-to-back and would race. Poll for the
+# pidfile so the rest of the script can lean on `status` consistently.
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  [[ -f "$DATA_DIR/arkeon.pid" ]] && break
+  sleep 0.5
+done
+require "pidfile present after install" test -f "$DATA_DIR/arkeon.pid"
+
 # --- 2. status (running) ---
 
 step "2. status --name $NAME (expect state=running, service.installed=true)"

--- a/packages/arkeon/scripts/test-service.sh
+++ b/packages/arkeon/scripts/test-service.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Arkeon Technologies, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Manual end-to-end smoke test for `arkeon-wiki install / uninstall`.
+#
+# Runs the full lifecycle (install → status → up → down → kickstart
+# resumes → uninstall) against an isolated `--name service-smoke-test`
+# instance, asserting expected state at each step. Cleans up on any
+# failure via a trap. ~30s wall-clock end-to-end.
+#
+# Not a CI test — it mutates ~/Library/LaunchAgents (Mac) /
+# ~/.config/systemd/user (Linux), so the PR author runs it once on
+# their machine before merging.
+#
+# Usage:
+#   packages/arkeon/scripts/test-service.sh
+#
+# Requirements:
+#   - built CLI at packages/arkeon/dist/index.js
+#   - macOS (launchd) for now; Linux (systemd) lands with PR2
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+CLI="$REPO_ROOT/packages/arkeon/dist/index.js"
+NAME="service-smoke-test"
+LABEL="tech.arkeon.wiki.$NAME"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+DATA_DIR="$HOME/.arkeon-wiki/$NAME"
+
+# Per nameToPortSlot() in local-runtime.ts: 8000 + (sha256(name) bytes
+# 0-1 mod 999) + 1. We don't recompute here — discover at runtime.
+PORT=""
+
+cleanup() {
+  local exit_code=$?
+  echo
+  echo "== cleanup =="
+  # Best-effort — none of these should fail the script.
+  node "$CLI" uninstall --name "$NAME" >/dev/null 2>&1 || true
+  rm -f "$PLIST"
+  rm -rf "$DATA_DIR"
+  if [[ $exit_code -ne 0 ]]; then
+    echo "FAILED at line $LINENO (exit $exit_code)" >&2
+  else
+    echo "OK"
+  fi
+  exit $exit_code
+}
+trap cleanup EXIT
+
+step() {
+  echo
+  echo "== $* =="
+}
+
+require() {
+  local label="$1"; shift
+  if ! "$@"; then
+    echo "ASSERTION FAILED: $label" >&2
+    exit 1
+  fi
+}
+
+# Resolve PORT by parsing the running supervisor's args after install.
+discover_port() {
+  PORT=$(curl -sf "http://localhost:0/health" >/dev/null 2>&1; \
+    for p in $(seq 8001 8999); do
+      if curl -sf "http://localhost:$p/health" 2>/dev/null | grep -q "ok"; then
+        # Confirm it's *our* instance, not the user's other daemon
+        if launchctl print "gui/$UID/$LABEL" 2>/dev/null | grep -q "$NAME"; then
+          echo "$p"; return 0
+        fi
+      fi
+    done; echo "")
+}
+
+# --- Preconditions ---
+
+[[ -f "$CLI" ]] || { echo "Built CLI not found at $CLI. Run 'npm run build' first." >&2; exit 1; }
+[[ "$OSTYPE" == "darwin"* ]] || { echo "test-service.sh: only macOS supported in this build (Linux arrives in PR2)." >&2; exit 1; }
+
+[[ ! -e "$PLIST" ]] || { echo "Stale plist at $PLIST — manual cleanup needed before running." >&2; exit 1; }
+
+# --- 1. install ---
+
+step "1. install --name $NAME --no-env"
+INSTALL_OUT=$(node "$CLI" install --name "$NAME" --no-env 2>&1)
+echo "$INSTALL_OUT"
+require "install ok=true" echo "$INSTALL_OUT" | grep -q '"ok": true'
+require "install running=true" echo "$INSTALL_OUT" | grep -q '"running": true'
+require "plist exists" test -f "$PLIST"
+require "launchctl knows label" launchctl print "gui/$UID/$LABEL" 2>/dev/null
+
+# --- 2. status (running) ---
+
+step "2. status --name $NAME (expect state=running, service.installed=true)"
+STATUS_OUT=$(node "$CLI" status --name "$NAME" 2>&1)
+echo "$STATUS_OUT"
+require "status state=running" echo "$STATUS_OUT" | grep -q '"state": "running"'
+require "status service.installed=true" echo "$STATUS_OUT" | grep -q '"installed": true'
+
+# --- 3. /health via discovered port ---
+
+step "3. /health probe"
+PID_FROM_LAUNCHD=$(launchctl print "gui/$UID/$LABEL" 2>&1 | awk '/^\tpid = /{print $3; exit}')
+echo "supervisor pid: $PID_FROM_LAUNCHD"
+require "pid is alive" kill -0 "$PID_FROM_LAUNCHD"
+
+# --- 4. crash recovery ---
+
+step "4. kill -9 $PID_FROM_LAUNCHD; wait 12s; supervisor should restart"
+kill -9 "$PID_FROM_LAUNCHD"
+sleep 12  # ThrottleInterval is 10s
+NEW_PID=$(launchctl print "gui/$UID/$LABEL" 2>&1 | awk '/^\tpid = /{print $3; exit}')
+echo "new pid: $NEW_PID"
+require "new pid differs from killed one" test "$NEW_PID" != "$PID_FROM_LAUNCHD"
+require "new pid is alive" kill -0 "$NEW_PID"
+require "supervisor reports running" launchctl print "gui/$UID/$LABEL" 2>&1 | grep -E "^\sstate = running"
+
+# --- 5. down: clean exit, supervisor respects ---
+
+step "5. down --name $NAME (clean exit; supervisor must NOT auto-restart)"
+node "$CLI" down --name "$NAME" 2>&1 | tail -5
+sleep 15  # well past ThrottleInterval
+require "after down, NOT running" \
+  bash -c 'launchctl print "gui/$UID/'"$LABEL"'" 2>&1 | grep -qE "^\\sstate = not running"'
+require "process is gone" bash -c "! kill -0 $NEW_PID 2>/dev/null"
+
+# --- 6. up resumes via supervisor (no orphan spawn) ---
+
+step "6. up --name $NAME (should kickstart via supervisor)"
+UP_OUT=$(node "$CLI" up --name "$NAME" 2>&1)
+echo "$UP_OUT"
+require "up reports managed_by=service" echo "$UP_OUT" | grep -q '"managed_by": "service"'
+UP_PID=$(echo "$UP_OUT" | awk -F': ' '/"pid":/{gsub(/[, ]/, "", $2); print $2; exit}')
+LAUNCHCTL_PID=$(launchctl print "gui/$UID/$LABEL" 2>&1 | awk '/^\tpid = /{print $3; exit}')
+require "up's pid matches supervisor's pid" test "$UP_PID" = "$LAUNCHCTL_PID"
+
+# --- 7. uninstall ---
+
+step "7. uninstall --name $NAME"
+UNINSTALL_OUT=$(node "$CLI" uninstall --name "$NAME" 2>&1)
+echo "$UNINSTALL_OUT"
+require "uninstall removed=true" echo "$UNINSTALL_OUT" | grep -q '"removed": true'
+require "plist gone" bash -c "! test -e $PLIST"
+require "launchctl no longer knows label" \
+  bash -c '! launchctl print "gui/$UID/'"$LABEL"'" >/dev/null 2>&1'
+
+# --- 8. data dir preserved (uninstall must not touch user data) ---
+
+step "8. data dir preserved"
+require "data dir still exists" test -d "$DATA_DIR"
+require "database file still exists" test -f "$DATA_DIR/data/arke.db"
+
+echo
+echo "== all assertions passed =="

--- a/packages/arkeon/src/cli/commands/local/index.ts
+++ b/packages/arkeon/src/cli/commands/local/index.ts
@@ -4,11 +4,13 @@
 import { Command } from "commander";
 
 import { registerDownCommand } from "./down.js";
+import { registerInstallCommand } from "./install.js";
 import { registerLogsCommand } from "./logs.js";
 import { registerLsCommand } from "./ls.js";
 import { registerStartCommand } from "./start.js";
 import { registerStatusCommand } from "./status.js";
 import { registerStopCommand } from "./stop.js";
+import { registerUninstallCommand } from "./uninstall.js";
 import { registerUpCommand } from "./up.js";
 
 export function registerLocalCommands(program: Command): void {
@@ -19,4 +21,6 @@ export function registerLocalCommands(program: Command): void {
   registerStatusCommand(program);
   registerLsCommand(program);
   registerLogsCommand(program);
+  registerInstallCommand(program);
+  registerUninstallCommand(program);
 }

--- a/packages/arkeon/src/cli/commands/local/install.ts
+++ b/packages/arkeon/src/cli/commands/local/install.ts
@@ -37,7 +37,8 @@ import {
 interface InstallCliOptions {
   name?: string;
   envKey?: string[];
-  noEnv?: boolean;
+  // Commander's `--no-env` flag flips this to false; default is true.
+  env?: boolean;
 }
 
 const DEFAULT_ENV_KEYS = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"];
@@ -108,7 +109,7 @@ async function runInstall(opts: InstallCliOptions): Promise<void> {
   // Capture API keys from the current shell into ~/.arkeon-wiki/.env
   // so the service can authenticate after a reboot when there's no
   // shell session. Idempotent: never overwrites existing values.
-  const envKeys = opts.noEnv
+  const envKeys = opts.env === false
     ? []
     : Array.from(new Set([...DEFAULT_ENV_KEYS, ...(opts.envKey ?? [])]));
   const envResult = envKeys.length > 0

--- a/packages/arkeon/src/cli/commands/local/install.ts
+++ b/packages/arkeon/src/cli/commands/local/install.ts
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `arkeon-wiki install` — register the daemon with the platform's
+ * service supervisor so it survives reboot and restarts on crash.
+ *
+ * On macOS: writes a LaunchAgent plist under ~/Library/LaunchAgents
+ * and bootstraps it into the user's launchd domain. On Linux: writes
+ * a user-scope systemd unit (PR2). User-scope on both — no sudo.
+ *
+ * Refuses to run while a `up`-spawned daemon already holds the port.
+ * Installation includes starting the service; we want a clean handoff,
+ * not a port-collision crash inside the supervisor's first launch.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { Command } from "commander";
+
+import {
+  applyName,
+  arkeonDir,
+  isProcessAlive,
+  readPidfile,
+  removePidfile,
+} from "../../lib/local-runtime.js";
+import { DEFAULT_INSTANCE_NAME } from "../../lib/instances.js";
+import { output } from "../../lib/output.js";
+import {
+  detectPlatform,
+  getServiceManager,
+  snapshotEnv,
+  snapshotPaths,
+} from "../../lib/service/index.js";
+
+interface InstallCliOptions {
+  name?: string;
+  envKey?: string[];
+  noEnv?: boolean;
+}
+
+const DEFAULT_ENV_KEYS = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"];
+
+export function registerInstallCommand(program: Command): void {
+  program
+    .command("install")
+    .description(
+      "Install the daemon as a system service (starts at login + restarts on crash)",
+    )
+    .option(
+      "--name <name>",
+      "Install a named instance — independent of any other --name install",
+    )
+    .option(
+      "--env-key <key>",
+      "Capture this env var from the current shell into ~/.arkeon-wiki/.env if it isn't already there. Repeatable.",
+      collectRepeatable,
+      [] as string[],
+    )
+    .option("--no-env", "Skip the env-snapshot step entirely")
+    .action(async (opts: InstallCliOptions) => {
+      try {
+        await runInstall(opts);
+      } catch (err) {
+        output.error(err, { operation: "install" });
+        process.exitCode = 1;
+      }
+    });
+}
+
+function collectRepeatable(value: string, prev: string[]): string[] {
+  return [...prev, value];
+}
+
+async function runInstall(opts: InstallCliOptions): Promise<void> {
+  const platform = detectPlatform();
+  if (platform === "unsupported") {
+    throw new Error(
+      `service install is not supported on this platform. ` +
+        `Currently: macOS (launchd), Linux (systemd, planned).`,
+    );
+  }
+
+  const instanceName = opts.name ?? DEFAULT_INSTANCE_NAME;
+  if (opts.name) applyName(opts.name);
+  const home = arkeonDir();
+
+  // Refuse to install while a `up`-spawned daemon is running on the
+  // same instance. The supervisor's first start would race the
+  // existing daemon for the port and crash. Asking the user to `down`
+  // first is clearer than a confused half-installed state.
+  const pid = readPidfile();
+  if (pid && isProcessAlive(pid)) {
+    throw new Error(
+      `Daemon is already running (pid ${pid}). Run \`arkeon-wiki down${opts.name ? ` --name ${opts.name}` : ""}\` first, then re-run install.`,
+    );
+  }
+  if (pid && !isProcessAlive(pid)) {
+    removePidfile();
+  }
+
+  // Resolve absolute node + CLI entry paths. Throws if invoked from a
+  // dev checkout without a built CLI — install needs absolute paths
+  // because launchd/systemd don't inherit the user's shell PATH.
+  const paths = snapshotPaths();
+
+  // Capture API keys from the current shell into ~/.arkeon-wiki/.env
+  // so the service can authenticate after a reboot when there's no
+  // shell session. Idempotent: never overwrites existing values.
+  const envKeys = opts.noEnv
+    ? []
+    : Array.from(new Set([...DEFAULT_ENV_KEYS, ...(opts.envKey ?? [])]));
+  const envResult = envKeys.length > 0
+    ? snapshotEnv({
+        keys: envKeys,
+        envFilePath: join(homedir(), ".arkeon-wiki", ".env"),
+      })
+    : { written: [], preserved: [], missing: [], envFilePath: "" };
+
+  output.progress(`[arkeon-wiki] platform: ${platform === "launchd" ? "macOS (launchd)" : "Linux (systemd)"}`);
+
+  const manager = await getServiceManager(platform);
+  const result = await manager.install({
+    name: instanceName,
+    home,
+    paths,
+  });
+
+  output.result({
+    operation: "install",
+    name: instanceName,
+    platform,
+    unit_path: result.unitPath,
+    label: result.label,
+    running: result.running,
+    pid: result.pid,
+    env: envResult.envFilePath
+      ? {
+          file: envResult.envFilePath,
+          written: envResult.written,
+          preserved: envResult.preserved,
+          missing: envResult.missing,
+        }
+      : { skipped: true },
+    next_steps:
+      envResult.missing.length > 0
+        ? [
+            `Missing keys: ${envResult.missing.join(", ")}. Add them to ${envResult.envFilePath} or set them in the shell where you ran install before retrying.`,
+          ]
+        : undefined,
+  });
+}

--- a/packages/arkeon/src/cli/commands/local/status.ts
+++ b/packages/arkeon/src/cli/commands/local/status.ts
@@ -11,7 +11,9 @@ import {
   readPidfile,
   removePidfile,
 } from "../../lib/local-runtime.js";
+import { DEFAULT_INSTANCE_NAME } from "../../lib/instances.js";
 import { output } from "../../lib/output.js";
+import { findInstalledService } from "../../lib/service/index.js";
 
 interface StatusOptions {
   name?: string;
@@ -39,13 +41,29 @@ async function runStatus(opts: StatusOptions): Promise<void> {
   const port = Number(opts.port ?? named?.port ?? DEFAULT_API_PORT);
   const apiUrl = `http://localhost:${port}`;
   const pid = readPidfile();
+  const instanceName = opts.name ?? DEFAULT_INSTANCE_NAME;
+
+  // Look up service status independently — the daemon can be running
+  // (pidfile alive) while no service is installed, or vice versa.
+  const service = await findInstalledService(instanceName);
+  const serviceField = service
+    ? {
+        installed: true,
+        running: service.status.running,
+        pid: service.status.pid,
+        unit_path: service.status.unitPath,
+      }
+    : { installed: false };
 
   if (!pid) {
     output.result({
       operation: "status",
       state: "not_running",
       state_dir: arkeonDir(),
-      hint: "Run `arkeon-wiki start` to start the stack.",
+      service: serviceField,
+      hint: service
+        ? `Service is installed but no pidfile. Run \`arkeon-wiki up${opts.name ? ` --name ${opts.name}` : ""}\` to start via the supervisor.`
+        : "Run `arkeon-wiki up` to start the stack, or `arkeon-wiki install` for a persistent service.",
     });
     process.exit(2);
   }
@@ -58,6 +76,7 @@ async function runStatus(opts: StatusOptions): Promise<void> {
       reason: "stale_pidfile",
       stale_pid: pid,
       state_dir: arkeonDir(),
+      service: serviceField,
     });
     process.exit(2);
   }
@@ -72,6 +91,7 @@ async function runStatus(opts: StatusOptions): Promise<void> {
       api_url: apiUrl,
       health: false,
       state_dir: arkeonDir(),
+      service: serviceField,
     });
     process.exit(1);
   }
@@ -83,6 +103,7 @@ async function runStatus(opts: StatusOptions): Promise<void> {
     api_url: apiUrl,
     health: true,
     state_dir: arkeonDir(),
+    service: serviceField,
   });
   process.exit(0);
 }

--- a/packages/arkeon/src/cli/commands/local/uninstall.ts
+++ b/packages/arkeon/src/cli/commands/local/uninstall.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `arkeon-wiki uninstall` — stop the supervisor-managed daemon and
+ * remove the plist/unit from disk.
+ *
+ * Idempotent: missing plist returns removed=false and exits 0.
+ * Never touches ~/.arkeon-wiki/<name>/ data — that's the user's
+ * knowledge graph, not a service artifact.
+ */
+
+import type { Command } from "commander";
+
+import { applyName } from "../../lib/local-runtime.js";
+import { DEFAULT_INSTANCE_NAME } from "../../lib/instances.js";
+import { output } from "../../lib/output.js";
+import { detectPlatform, getServiceManager } from "../../lib/service/index.js";
+
+interface UninstallCliOptions {
+  name?: string;
+}
+
+export function registerUninstallCommand(program: Command): void {
+  program
+    .command("uninstall")
+    .description("Remove a previously installed service")
+    .option("--name <name>", "Uninstall a specific named-instance service")
+    .action(async (opts: UninstallCliOptions) => {
+      try {
+        await runUninstall(opts);
+      } catch (err) {
+        output.error(err, { operation: "uninstall" });
+        process.exitCode = 1;
+      }
+    });
+}
+
+async function runUninstall(opts: UninstallCliOptions): Promise<void> {
+  const platform = detectPlatform();
+  if (platform === "unsupported") {
+    throw new Error(
+      `service uninstall is not supported on this platform. ` +
+        `Currently: macOS (launchd), Linux (systemd, planned).`,
+    );
+  }
+
+  const instanceName = opts.name ?? DEFAULT_INSTANCE_NAME;
+  if (opts.name) applyName(opts.name);
+
+  const manager = await getServiceManager(platform);
+  const result = await manager.uninstall({ name: instanceName });
+
+  output.result({
+    operation: "uninstall",
+    name: instanceName,
+    platform,
+    removed: result.removed,
+    unit_path: result.unitPath,
+  });
+}

--- a/packages/arkeon/src/cli/commands/local/up.ts
+++ b/packages/arkeon/src/cli/commands/local/up.ts
@@ -29,6 +29,7 @@ import {
 } from "../../lib/local-runtime.js";
 import { DEFAULT_INSTANCE_NAME, findInstance, findInstanceByPort } from "../../lib/instances.js";
 import { output } from "../../lib/output.js";
+import { findInstalledService } from "../../lib/service/index.js";
 
 interface UpOptions {
   name?: string;
@@ -60,6 +61,28 @@ async function runUp(options: UpOptions): Promise<void> {
   const named = options.name ? applyName(options.name) : null;
   const apiPort = Number(options.port ?? named?.port ?? DEFAULT_API_PORT);
   const timeoutMs = Number(options.timeout ?? "60") * 1000;
+  const instanceName = options.name ?? DEFAULT_INSTANCE_NAME;
+
+  // If a service is installed for this instance, delegate to the
+  // supervisor instead of spawning a detached child. Spawning would
+  // create an orphan the supervisor doesn't track — pid in pidfile,
+  // launchctl reporting state=not running, and no auto-restart.
+  const service = await findInstalledService(instanceName);
+  if (service) {
+    if (options.port) {
+      output.progress(
+        `[arkeon-wiki] --port is ignored when the service is installed — the supervisor uses the port baked into the plist at install time.`,
+      );
+    }
+    await runServiceManagedUp({
+      service,
+      instanceName,
+      apiPort,
+      timeoutMs,
+      options,
+    });
+    return;
+  }
 
   // Refuse if a live daemon already owns the pidfile for this home.
   const existingPid = readPidfile();
@@ -155,17 +178,102 @@ async function runUp(options: UpOptions): Promise<void> {
 
   // The spawn() child.pid may be a wrapper (e.g. npx in dev mode); the
   // daemon registers its own pid once /health passes. Prefer that.
-  const registered = findInstance(options.name ?? DEFAULT_INSTANCE_NAME);
+  const registered = findInstance(instanceName);
 
   output.result({
     operation: "up",
-    name: options.name ?? DEFAULT_INSTANCE_NAME,
+    name: instanceName,
     pid: registered?.pid ?? child.pid,
     api_url: `http://localhost:${apiPort}`,
     health_url: `http://localhost:${apiPort}/health`,
     state_dir: arkeonDir(),
     log: logPath,
+    managed_by: "spawn",
   });
+
+  // One-line nudge after the first successful detached spawn. Goes to
+  // stderr so it doesn't pollute the JSON result on stdout — scripts
+  // parsing the result aren't disturbed.
+  output.progress(
+    `[arkeon-wiki] Tip: run \`arkeon-wiki install${options.name ? ` --name ${options.name}` : ""}\` to start automatically at login + survive crashes.`,
+  );
+}
+
+/**
+ * Bring up the daemon via the platform's service supervisor.
+ *
+ * Idempotent: if the supervisor already reports the service running,
+ * we just confirm /health and return. Otherwise we delegate to
+ * `manager.start()` (which does `launchctl kickstart -k`), then poll
+ * /health to confirm the API is actually reachable.
+ *
+ * Polling here is plain /health — no log tail, no orphan-cleanup. The
+ * supervisor owns the process; if it crashes during boot the
+ * supervisor handles the restart, not us.
+ */
+async function runServiceManagedUp(params: {
+  service: NonNullable<Awaited<ReturnType<typeof findInstalledService>>>;
+  instanceName: string;
+  apiPort: number;
+  timeoutMs: number;
+  options: UpOptions;
+}): Promise<void> {
+  const { service, instanceName, apiPort, timeoutMs, options } = params;
+  const healthUrl = `http://localhost:${apiPort}/health`;
+
+  if (service.status.running) {
+    const ready = await pollHealth(healthUrl, 5000);
+    output.result({
+      operation: "up",
+      name: instanceName,
+      pid: service.status.pid,
+      api_url: `http://localhost:${apiPort}`,
+      health_url: healthUrl,
+      state_dir: arkeonDir(),
+      managed_by: "service",
+      state: ready ? "running" : "running_unhealthy",
+      unit_path: service.status.unitPath,
+    });
+    return;
+  }
+
+  output.progress(
+    `[arkeon-wiki] Service is installed; starting via supervisor...`,
+  );
+
+  const startResult = await service.manager.start({ name: instanceName });
+
+  const ready = await pollHealth(healthUrl, timeoutMs);
+  if (!ready) {
+    throw new Error(
+      `Service started via supervisor (pid ${startResult.pid ?? "?"}) but /health did not come up within ${timeoutMs / 1000}s. ` +
+        `See logs: arkeon-wiki logs${options.name ? ` --name ${options.name}` : ""}`,
+    );
+  }
+
+  output.result({
+    operation: "up",
+    name: instanceName,
+    pid: startResult.pid,
+    api_url: `http://localhost:${apiPort}`,
+    health_url: healthUrl,
+    state_dir: arkeonDir(),
+    managed_by: "service",
+    state: "running",
+    unit_path: startResult.unitPath,
+  });
+}
+
+async function pollHealth(url: string, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return true;
+    } catch { /* still coming up */ }
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  return false;
 }
 
 /**

--- a/packages/arkeon/src/cli/lib/service/env-snapshot.ts
+++ b/packages/arkeon/src/cli/lib/service/env-snapshot.ts
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Manage ~/.arkeon-wiki/.env on behalf of `install`.
+ *
+ * The supervisor (launchd / systemd) does not inherit the user's shell
+ * environment. Without a persisted .env file, the daemon would start
+ * after reboot but agents couldn't authenticate (no OPENAI_API_KEY).
+ *
+ * The runtime already loads `~/.arkeon-wiki/.env` via
+ * `server/agents/env-loader.ts:42` — we don't need to invent a loader.
+ * Install's job is to ensure the file exists and contains the keys the
+ * user expects, *without ever overwriting an existing value*.
+ *
+ * Idempotent and non-destructive:
+ *
+ *   - If a key already lives in the file (any value, including empty),
+ *     leave it alone. We don't know if the user has rotated it.
+ *   - If a key isn't in the file but is set in the shell, append it.
+ *   - If a key is neither in the file nor in the shell, record it as
+ *     `missing` so the install command can warn but proceed.
+ *
+ * Format: standard dotenv — `KEY=value` per line, `#` line comments,
+ * blank lines preserved. We never reformat existing lines.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+
+export interface SnapshotEnvOptions {
+  /** Keys to consider, in user-visible order. e.g. ["OPENAI_API_KEY"]. */
+  keys: string[];
+  /** Path to the .env file we manage. */
+  envFilePath: string;
+  /** Source of values. Defaults to `process.env`. */
+  shellEnv?: NodeJS.ProcessEnv;
+  /** If false, compute the plan but don't write anything. */
+  apply?: boolean;
+}
+
+export interface SnapshotEnvResult {
+  /** Keys we appended this call. */
+  written: string[];
+  /** Keys already present in the file — left untouched. */
+  preserved: string[];
+  /** Keys not in the file and not in the shell — neither writable nor preserved. */
+  missing: string[];
+  /** Filesystem path we read/wrote. */
+  envFilePath: string;
+}
+
+/**
+ * Read an env file into a `{key: value}` record. Returns an empty map
+ * if the file doesn't exist. Preserves *which keys are defined*; we
+ * don't use the values, only their presence, so the parser is
+ * intentionally permissive — anything that looks like `KEY=` at the
+ * start of a non-comment line counts.
+ */
+export function readEnvKeys(path: string): Set<string> {
+  if (!existsSync(path)) return new Set();
+  const keys = new Set<string>();
+  const text = readFileSync(path, "utf-8");
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    // Strip optional `export ` prefix common in shell-style dotenvs.
+    const cleaned = key.startsWith("export ") ? key.slice("export ".length).trim() : key;
+    if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(cleaned)) keys.add(cleaned);
+  }
+  return keys;
+}
+
+/**
+ * Compute and (optionally) apply the snapshot. Pure when `apply:false`
+ * — exposes the plan for the install command to print before touching
+ * disk.
+ */
+export function snapshotEnv(opts: SnapshotEnvOptions): SnapshotEnvResult {
+  const shell = opts.shellEnv ?? process.env;
+  const apply = opts.apply ?? true;
+
+  const existing = readEnvKeys(opts.envFilePath);
+  const written: string[] = [];
+  const preserved: string[] = [];
+  const missing: string[] = [];
+
+  const toAppend: Array<[string, string]> = [];
+  for (const key of opts.keys) {
+    if (existing.has(key)) {
+      preserved.push(key);
+      continue;
+    }
+    const value = shell[key];
+    if (value === undefined || value === "") {
+      missing.push(key);
+      continue;
+    }
+    toAppend.push([key, value]);
+    written.push(key);
+  }
+
+  if (apply && toAppend.length > 0) {
+    ensureDir(opts.envFilePath);
+    const lines = toAppend.map(([k, v]) => `${k}=${quoteIfNeeded(v)}`).join("\n");
+    const prefix = existsSync(opts.envFilePath)
+      ? needsLeadingNewline(opts.envFilePath) ? "\n" : ""
+      : "";
+    appendFileSync(opts.envFilePath, `${prefix}${lines}\n`, "utf-8");
+  } else if (apply && !existsSync(opts.envFilePath)) {
+    // Create an empty file so the env-loader's existsSync check
+    // doesn't keep returning false — purely cosmetic but matches the
+    // user's mental model of "the file is there".
+    ensureDir(opts.envFilePath);
+    writeFileSync(opts.envFilePath, "", "utf-8");
+  }
+
+  return {
+    written,
+    preserved,
+    missing,
+    envFilePath: opts.envFilePath,
+  };
+}
+
+function ensureDir(filePath: string): void {
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+function needsLeadingNewline(path: string): boolean {
+  try {
+    const text = readFileSync(path, "utf-8");
+    return text.length > 0 && !text.endsWith("\n");
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Quote a value when it contains characters dotenv parsers interpret
+ * specially. Conservative: any whitespace, `#`, `=`, `'`, `"`, or
+ * shell-meta gets double-quoted with embedded `"` and `\` escaped.
+ */
+function quoteIfNeeded(value: string): string {
+  if (value === "") return "";
+  if (/^[A-Za-z0-9_./:@+\-]+$/.test(value)) return value;
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}

--- a/packages/arkeon/src/cli/lib/service/env-snapshot.ts
+++ b/packages/arkeon/src/cli/lib/service/env-snapshot.ts
@@ -27,12 +27,21 @@
 
 import {
   appendFileSync,
+  chmodSync,
   existsSync,
   mkdirSync,
   readFileSync,
   writeFileSync,
 } from "node:fs";
 import { dirname } from "node:path";
+
+/**
+ * Mode bits for the user-global env file. 0600 = owner read/write
+ * only; other users on the machine cannot read it. The plist
+ * deliberately omits secrets (multi-user Macs make plists
+ * world-readable); the redirect target must apply the same standard.
+ */
+const ENV_FILE_MODE = 0o600;
 
 export interface SnapshotEnvOptions {
   /** Keys to consider, in user-visible order. e.g. ["OPENAI_API_KEY"]. */
@@ -122,6 +131,15 @@ export function snapshotEnv(opts: SnapshotEnvOptions): SnapshotEnvResult {
     // user's mental model of "the file is there".
     ensureDir(opts.envFilePath);
     writeFileSync(opts.envFilePath, "", "utf-8");
+  }
+
+  // Always tighten perms on a real run, even when no new keys were
+  // written and the file existed already. The reviewer's framing: if
+  // a user populated this file by hand with permissive defaults
+  // (0644), install should bring it to the standard 0600. Re-running
+  // install is idempotent — chmod to the same mode is a no-op.
+  if (apply && existsSync(opts.envFilePath)) {
+    chmodSync(opts.envFilePath, ENV_FILE_MODE);
   }
 
   return {

--- a/packages/arkeon/src/cli/lib/service/index.ts
+++ b/packages/arkeon/src/cli/lib/service/index.ts
@@ -21,6 +21,13 @@ import type { Platform, ServiceManager } from "./types.js";
 export * from "./types.js";
 export { snapshotPaths } from "./path-snapshot.js";
 export { snapshotEnv, readEnvKeys } from "./env-snapshot.js";
+export {
+  DEFAULT_LAUNCHD_LABEL,
+  launchdLabel,
+  launchdPlistPath,
+  renderLaunchdPlist,
+  validateInstanceName,
+} from "./launchd-plist.js";
 
 /**
  * Detect which service supervisor we should target. Pure: only reads

--- a/packages/arkeon/src/cli/lib/service/index.ts
+++ b/packages/arkeon/src/cli/lib/service/index.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Service install/uninstall facade.
+ *
+ * Picks the right supervisor for the current platform (launchd on
+ * macOS, systemd on Linux). Both implement the same {@link
+ * ServiceManager} interface so the install/uninstall CLI commands stay
+ * platform-agnostic.
+ *
+ * `ARKEON_WIKI_FORCE_PLATFORM=launchd|systemd|unsupported` overrides
+ * the auto-detect — used by unit tests to drive the macOS code path
+ * from Linux CI runners (and vice versa) without faking process.platform.
+ */
+
+import { platform as osPlatform } from "node:os";
+
+import type { Platform, ServiceManager } from "./types.js";
+
+export * from "./types.js";
+export { snapshotPaths } from "./path-snapshot.js";
+export { snapshotEnv, readEnvKeys } from "./env-snapshot.js";
+
+/**
+ * Detect which service supervisor we should target. Pure: only reads
+ * `process.platform` and the override env var.
+ */
+export function detectPlatform(): Platform {
+  const override = process.env.ARKEON_WIKI_FORCE_PLATFORM;
+  if (override === "launchd" || override === "systemd" || override === "unsupported") {
+    return override;
+  }
+  const p = osPlatform();
+  if (p === "darwin") return "launchd";
+  if (p === "linux") return "systemd";
+  return "unsupported";
+}
+
+/**
+ * Get the platform's {@link ServiceManager}. Throws on `unsupported` —
+ * the install command catches and prints a friendly message.
+ *
+ * Implementations are loaded lazily via dynamic import so the launchd
+ * module never executes on Linux (it's pure rendering today, but as
+ * soon as we add `execFile("launchctl", ...)` we want that import to
+ * stay off the Linux path entirely).
+ */
+export async function getServiceManager(p: Platform = detectPlatform()): Promise<ServiceManager> {
+  if (p === "launchd") {
+    // Phase C wires this up; until then the module exports a
+    // not-yet-implemented stub that throws on use.
+    const mod = await import("./launchd.js");
+    return mod.manager;
+  }
+  if (p === "systemd") {
+    // PR2 wires this up.
+    throw new Error(
+      "systemd integration is not implemented in this build. " +
+        "See https://github.com/Arkeon-Technologies/arkeon-wiki/issues/146",
+    );
+  }
+  throw new Error(
+    `Service install is not supported on this platform (${osPlatform()}). ` +
+      "Currently supported: macOS (launchd), Linux (systemd, planned).",
+  );
+}

--- a/packages/arkeon/src/cli/lib/service/index.ts
+++ b/packages/arkeon/src/cli/lib/service/index.ts
@@ -16,7 +16,7 @@
 
 import { platform as osPlatform } from "node:os";
 
-import type { Platform, ServiceManager } from "./types.js";
+import type { Platform, ServiceManager, ServiceStatus } from "./types.js";
 
 export * from "./types.js";
 export { snapshotPaths } from "./path-snapshot.js";
@@ -42,6 +42,38 @@ export function detectPlatform(): Platform {
   if (p === "darwin") return "launchd";
   if (p === "linux") return "systemd";
   return "unsupported";
+}
+
+/**
+ * If a service is installed for the given instance, return its status
+ * + the platform's manager. Returns null on unsupported platforms,
+ * when no service is registered for this name, or when status query
+ * fails for any reason.
+ *
+ * Used by `up`, `down`, and `status` to coordinate with the
+ * supervisor: if a service exists, the supervisor owns the daemon's
+ * lifecycle and the CLI delegates to it instead of spawning a
+ * detached child the supervisor doesn't track.
+ *
+ * Failing closed (return null on any error) is deliberate. The
+ * fallback in callers is "behave like there's no service" — the
+ * pre-install behavior. We never want a transient launchctl glitch to
+ * make `up` refuse to start.
+ */
+export async function findInstalledService(name: string): Promise<{
+  manager: ServiceManager;
+  status: ServiceStatus;
+} | null> {
+  const platform = detectPlatform();
+  if (platform === "unsupported") return null;
+  try {
+    const manager = await getServiceManager(platform);
+    const status = await manager.status({ name });
+    if (!status.installed) return null;
+    return { manager, status };
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/packages/arkeon/src/cli/lib/service/launchctl.ts
+++ b/packages/arkeon/src/cli/lib/service/launchctl.ts
@@ -76,18 +76,30 @@ export function parseLaunchctlPrint(stdout: string): LaunchctlPrintFields {
   let state: LaunchctlPrintFields["state"] = "unknown";
   let pid: number | null = null;
 
+  // `launchctl print` repeats the substring `state = ...` inside nested
+  // blocks for `resource coalition` and `jetsam coalition` (their state
+  // is the literal string "active"). The service's own `state = ` line
+  // appears before any nested block, so the FIRST match wins and we
+  // never overwrite. Same defensive policy for `pid = ` — the
+  // top-level pid line appears before any nested process listings.
   for (const line of stdout.split("\n")) {
     const trimmed = line.trim();
-    const stateMatch = trimmed.match(/^state\s*=\s*(.+)$/);
-    if (stateMatch) {
-      const v = stateMatch[1]!.trim();
-      if (v === "running") state = "running";
-      else if (v === "not running") state = "not running";
-      else state = "unknown";
-      continue;
+    if (state === "unknown") {
+      const stateMatch = trimmed.match(/^state\s*=\s*(.+)$/);
+      if (stateMatch) {
+        const v = stateMatch[1]!.trim();
+        if (v === "running") state = "running";
+        else if (v === "not running") state = "not running";
+        // Any other value (e.g. "active" from nested coalition blocks)
+        // we leave as "unknown" — but only on the first match. Subsequent
+        // state lines never overwrite a real running/not-running answer.
+        continue;
+      }
     }
-    const pidMatch = trimmed.match(/^pid\s*=\s*(\d+)$/);
-    if (pidMatch) pid = Number(pidMatch[1]);
+    if (pid === null) {
+      const pidMatch = trimmed.match(/^pid\s*=\s*(\d+)$/);
+      if (pidMatch) pid = Number(pidMatch[1]);
+    }
   }
 
   return { state, pid };

--- a/packages/arkeon/src/cli/lib/service/launchctl.ts
+++ b/packages/arkeon/src/cli/lib/service/launchctl.ts
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Thin wrapper around `execFile("launchctl", ...)`.
+ *
+ * Surfaces stdout/stderr/exitCode together so callers can decide
+ * what's "success" — launchctl has dozens of exit codes that aren't
+ * uniformly "0 = good, anything else = bad" (e.g., 17 = "service
+ * already loaded" which we usually want to ignore-and-retry, 113 =
+ * "service not found" which is the expected state during uninstall).
+ *
+ * Exposed as a function type so the manager can be constructed with a
+ * fake runner in tests — no real launchctl invocation outside an
+ * actual `arkeon-wiki install` run.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export interface LaunchctlResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export type LaunchctlRunner = (args: string[]) => Promise<LaunchctlResult>;
+
+/**
+ * Production runner. Resolves the result regardless of exit code so the
+ * caller can branch on it.
+ */
+export const realLaunchctl: LaunchctlRunner = async (args) => {
+  try {
+    const { stdout, stderr } = await execFileAsync("launchctl", args, {
+      // Generous buffer for `launchctl print`, which can dump a few KB
+      // of service metadata in verbose form.
+      maxBuffer: 4 * 1024 * 1024,
+    });
+    return { stdout, stderr, exitCode: 0 };
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & {
+      stdout?: string;
+      stderr?: string;
+      code?: number | string;
+    };
+    return {
+      stdout: e.stdout ?? "",
+      stderr: e.stderr ?? e.message,
+      // execFile sets `code` to the exit code; type is `number | string`
+      // (ENOENT-style errors expose a string code). Coerce defensively.
+      exitCode: typeof e.code === "number" ? e.code : -1,
+    };
+  }
+};
+
+/**
+ * Parse the output of `launchctl print gui/$UID/<label>` into the
+ * fields we care about. The output is multi-line freeform; we look for
+ * lines matching `state = ...` and `pid = ...`. Indentation and
+ * whitespace vary across macOS releases — we strip leading whitespace
+ * before matching.
+ *
+ * When the service isn't loaded at all, `print` returns a non-zero
+ * exit code and a message like "Could not find service". Callers
+ * should treat that as `{loaded: false}` before invoking this parser.
+ */
+export interface LaunchctlPrintFields {
+  state: "running" | "not running" | "unknown";
+  pid: number | null;
+}
+
+export function parseLaunchctlPrint(stdout: string): LaunchctlPrintFields {
+  let state: LaunchctlPrintFields["state"] = "unknown";
+  let pid: number | null = null;
+
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    const stateMatch = trimmed.match(/^state\s*=\s*(.+)$/);
+    if (stateMatch) {
+      const v = stateMatch[1]!.trim();
+      if (v === "running") state = "running";
+      else if (v === "not running") state = "not running";
+      else state = "unknown";
+      continue;
+    }
+    const pidMatch = trimmed.match(/^pid\s*=\s*(\d+)$/);
+    if (pidMatch) pid = Number(pidMatch[1]);
+  }
+
+  return { state, pid };
+}

--- a/packages/arkeon/src/cli/lib/service/launchd-plist.ts
+++ b/packages/arkeon/src/cli/lib/service/launchd-plist.ts
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pure renderer for the launchd LaunchAgent plist.
+ *
+ * The plist is the persistent state launchd reads at login. Once it
+ * exists under ~/Library/LaunchAgents/ and has been bootstrapped, the
+ * OS picks it up across reboots without any further action — so this
+ * renderer is the *whole* persistence story for the macOS case.
+ *
+ * Kept separate from `launchd.ts` (the ServiceManager implementation,
+ * Phase C) so the rendering surface is independently testable without
+ * any launchctl involvement.
+ *
+ * Label scheme: `tech.arkeon.wiki` for the default instance, and
+ * `tech.arkeon.wiki.<name>` for a `--name`-scoped instance. Apple's
+ * convention is reverse-DNS-style; periods inside the name are fine
+ * because Apple itself uses multi-segment labels like
+ * `com.apple.cfprefsd.xpc.daemon`.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import type { InstallOptions } from "./types.js";
+
+export const DEFAULT_LAUNCHD_LABEL = "tech.arkeon.wiki";
+export const DEFAULT_INSTANCE_NAME = "default";
+
+/**
+ * `default` is the sentinel for "the unnamed install" used across the
+ * CLI (`instances.ts`). Everything else is a real `--name` instance.
+ */
+function isDefaultName(name: string): boolean {
+  return name === DEFAULT_INSTANCE_NAME;
+}
+
+/**
+ * Allow only filesystem-safe characters in instance names. Anything
+ * outside this set would either break filename construction or risk
+ * shell interpretation inside the plist's `ProgramArguments` — easier
+ * to reject up front than guard every escape boundary.
+ */
+const NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+export function validateInstanceName(name: string): void {
+  if (!name) {
+    throw new Error("instance name must be non-empty");
+  }
+  if (!NAME_PATTERN.test(name)) {
+    throw new Error(
+      `instance name "${name}" contains characters outside [A-Za-z0-9._-]. ` +
+        "Pick a name made of letters, digits, dot, underscore, or hyphen.",
+    );
+  }
+}
+
+/**
+ * Derive the launchd label for a given instance name. Stable across
+ * runs — used to look up the existing service via
+ * `launchctl print gui/$UID/<label>` in Phase C.
+ */
+export function launchdLabel(name: string): string {
+  validateInstanceName(name);
+  return isDefaultName(name) ? DEFAULT_LAUNCHD_LABEL : `${DEFAULT_LAUNCHD_LABEL}.${name}`;
+}
+
+/**
+ * Canonical install path for a launchd label. User-scoped — no sudo,
+ * runs in the user's GUI session, survives login.
+ */
+export function launchdPlistPath(label: string, home: string = homedir()): string {
+  return join(home, "Library", "LaunchAgents", `${label}.plist`);
+}
+
+/**
+ * Render the plist body. Pure — no I/O. Caller writes the result to
+ * the path returned by {@link launchdPlistPath}.
+ *
+ * The contract embedded in this template (see scoping doc §macOS for
+ * the why behind each key):
+ *
+ *   - `RunAtLoad` + the LaunchAgents directory location together
+ *     guarantee the daemon comes up at every login.
+ *   - `KeepAlive` is the *dict* form, not the boolean form, so the
+ *     supervisor restarts on crash but respects a clean `arkeon-wiki
+ *     down` (clean exit → stays down until next `up`/login).
+ *   - `EnvironmentVariables.PATH` is set explicitly because launchd's
+ *     default PATH is the bare minimum and won't find homebrew binaries.
+ *   - Secrets (OPENAI_API_KEY etc.) deliberately do *not* live here.
+ *     They go in ~/.arkeon-wiki/.env via env-snapshot.ts; the agent
+ *     runtime loads them at startup. Plists are world-readable on
+ *     multi-user Macs — we don't want keys there.
+ */
+export function renderLaunchdPlist(opts: InstallOptions): string {
+  const { name, home, paths } = opts;
+  validateInstanceName(name);
+
+  const label = launchdLabel(name);
+  const args = isDefaultName(name)
+    ? [paths.nodeBin, paths.cliEntry, "start"]
+    : [paths.nodeBin, paths.cliEntry, "start", "--name", name];
+
+  const argsXml = args.map((a) => `    <string>${xmlEscape(a)}</string>`).join("\n");
+  const logPath = join(home, "arkeon.log");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${xmlEscape(label)}</string>
+  <key>ProgramArguments</key>
+  <array>
+${argsXml}
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+    <key>Crashed</key>
+    <true/>
+  </dict>
+  <key>WorkingDirectory</key>
+  <string>${xmlEscape(home)}</string>
+  <key>StandardOutPath</key>
+  <string>${xmlEscape(logPath)}</string>
+  <key>StandardErrorPath</key>
+  <string>${xmlEscape(logPath)}</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+    <key>ARKEON_WIKI_HOME</key>
+    <string>${xmlEscape(home)}</string>
+  </dict>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+</dict>
+</plist>
+`;
+}
+
+/**
+ * Standard XML escaping for content nested inside `<string>...</string>`.
+ * Apple's plist parser is strict — an unescaped `&` in a file path
+ * produces a parse error and launchctl refuses to load it. Realistic
+ * filenames rarely contain these chars, but unit-test fixtures and
+ * users with `&` in their home dir name do exist, so we escape.
+ */
+function xmlEscape(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}

--- a/packages/arkeon/src/cli/lib/service/launchd.ts
+++ b/packages/arkeon/src/cli/lib/service/launchd.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Phase A stub. Phase B replaces the body with the plist renderer;
+ * Phase C wires bootstrap / bootout / kickstart against launchctl.
+ *
+ * Exporting the stub here keeps the dynamic import in `index.ts`
+ * typecheck-clean before the real implementation lands, and surfaces a
+ * clear "not yet implemented" error if someone tries to call it.
+ */
+
+import type {
+  InstallOptions,
+  InstallResult,
+  ServiceManager,
+  ServiceStatus,
+  UninstallOptions,
+  UninstallResult,
+} from "./types.js";
+
+function notYetImplemented(name: string): never {
+  throw new Error(
+    `service.launchd.${name}: not yet implemented in this build ` +
+      "(arrives in Phase B/C of the install-service feature).",
+  );
+}
+
+export const manager: ServiceManager = {
+  install(_opts: InstallOptions): Promise<InstallResult> {
+    notYetImplemented("install");
+  },
+  uninstall(_opts: UninstallOptions): Promise<UninstallResult> {
+    notYetImplemented("uninstall");
+  },
+  status(_opts: { name: string }): Promise<ServiceStatus> {
+    notYetImplemented("status");
+  },
+};

--- a/packages/arkeon/src/cli/lib/service/launchd.ts
+++ b/packages/arkeon/src/cli/lib/service/launchd.ts
@@ -2,14 +2,43 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Phase A stub. Phase B replaces the body with the plist renderer;
- * Phase C wires bootstrap / bootout / kickstart against launchctl.
+ * macOS launchd ServiceManager.
  *
- * Exporting the stub here keeps the dynamic import in `index.ts`
- * typecheck-clean before the real implementation lands, and surfaces a
- * clear "not yet implemented" error if someone tries to call it.
+ * Wires the pure plist renderer (launchd-plist.ts) and the launchctl
+ * exec wrapper (launchctl.ts) into the {@link ServiceManager}
+ * contract.
+ *
+ * Constructed via {@link createLaunchdManager} so tests can supply a
+ * fake launchctl + a tmp `home` directory. The exported `manager`
+ * uses the real launchctl and the user's `$HOME`.
+ *
+ * Lifecycle commands we exercise:
+ *
+ *   - `bootstrap gui/$UID <plist>`   load + start (boot-time + login)
+ *   - `bootout    gui/$UID/<label>`  stop + unload (clean shutdown)
+ *   - `kickstart  -k gui/$UID/<label>`  hard-restart (used to ensure
+ *                                       a freshly-bootstrapped service
+ *                                       is actually running)
+ *   - `print      gui/$UID/<label>`  inspect state (running/pid)
+ *
+ * The `gui/$UID` domain is the modern (macOS 10.10+) replacement for
+ * `launchctl load -w`. User-scope; no sudo.
  */
 
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname } from "node:path";
+
+import {
+  launchdLabel,
+  launchdPlistPath,
+  renderLaunchdPlist,
+} from "./launchd-plist.js";
+import {
+  parseLaunchctlPrint,
+  realLaunchctl,
+  type LaunchctlRunner,
+} from "./launchctl.js";
 import type {
   InstallOptions,
   InstallResult,
@@ -19,21 +48,150 @@ import type {
   UninstallResult,
 } from "./types.js";
 
-function notYetImplemented(name: string): never {
-  throw new Error(
-    `service.launchd.${name}: not yet implemented in this build ` +
-      "(arrives in Phase B/C of the install-service feature).",
-  );
+export interface CreateLaunchdManagerOptions {
+  /** Override the launchctl executor — used in tests. */
+  runLaunchctl?: LaunchctlRunner;
+  /** Override `$HOME` used to locate the LaunchAgents directory. */
+  home?: string;
+  /** Override UID. Defaults to `process.getuid()`. */
+  uid?: number;
+  /** Poll interval + budget after bootstrap, in ms. */
+  bootWaitMs?: number;
+  bootIntervalMs?: number;
+  /** Sleep used during the post-bootstrap wait. Override for tests. */
+  sleep?: (ms: number) => Promise<void>;
 }
 
-export const manager: ServiceManager = {
-  install(_opts: InstallOptions): Promise<InstallResult> {
-    notYetImplemented("install");
-  },
-  uninstall(_opts: UninstallOptions): Promise<UninstallResult> {
-    notYetImplemented("uninstall");
-  },
-  status(_opts: { name: string }): Promise<ServiceStatus> {
-    notYetImplemented("status");
-  },
-};
+const DEFAULT_BOOT_WAIT_MS = 5000;
+const DEFAULT_BOOT_INTERVAL_MS = 200;
+
+export function createLaunchdManager(
+  opts: CreateLaunchdManagerOptions = {},
+): ServiceManager {
+  const run = opts.runLaunchctl ?? realLaunchctl;
+  const home = opts.home ?? homedir();
+  const uid = opts.uid ?? process.getuid?.() ?? -1;
+  const bootWaitMs = opts.bootWaitMs ?? DEFAULT_BOOT_WAIT_MS;
+  const bootIntervalMs = opts.bootIntervalMs ?? DEFAULT_BOOT_INTERVAL_MS;
+  const sleep = opts.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+
+  function domain(label: string): string {
+    return `gui/${uid}/${label}`;
+  }
+
+  function plistPathFor(name: string): string {
+    return launchdPlistPath(launchdLabel(name), home);
+  }
+
+  async function readStatus(name: string): Promise<ServiceStatus> {
+    const label = launchdLabel(name);
+    const unitPath = plistPathFor(name);
+    const installed = existsSync(unitPath);
+
+    if (!installed) {
+      return { installed: false, running: false, pid: null, unitPath: null };
+    }
+
+    const printed = await run(["print", domain(label)]);
+    if (printed.exitCode !== 0) {
+      // Plist on disk but not loaded — common between `bootout` and
+      // the next bootstrap. Report installed-but-not-running.
+      return { installed: true, running: false, pid: null, unitPath };
+    }
+
+    const fields = parseLaunchctlPrint(printed.stdout);
+    return {
+      installed: true,
+      running: fields.state === "running",
+      pid: fields.pid,
+      unitPath,
+    };
+  }
+
+  async function install(installOpts: InstallOptions): Promise<InstallResult> {
+    const label = launchdLabel(installOpts.name);
+    const unitPath = plistPathFor(installOpts.name);
+    const plistBody = renderLaunchdPlist(installOpts);
+
+    // Make sure ~/Library/LaunchAgents/ exists — fresh-user Macs may
+    // not have it yet if no third-party tool ever wrote a LaunchAgent.
+    const launchAgentsDir = dirname(unitPath);
+    if (!existsSync(launchAgentsDir)) {
+      mkdirSync(launchAgentsDir, { recursive: true });
+    }
+
+    // If the service is already loaded (re-install, or a stale entry
+    // from a previous build), bootout first so bootstrap can take a
+    // fresh plist. Ignore failures — bootout returns non-zero if the
+    // service wasn't loaded, which is fine.
+    await run(["bootout", domain(label)]);
+
+    writeFileSync(unitPath, plistBody, "utf-8");
+
+    const bootstrap = await run(["bootstrap", `gui/${uid}`, unitPath]);
+    if (bootstrap.exitCode !== 0) {
+      throw new Error(
+        `launchctl bootstrap failed (exit ${bootstrap.exitCode}): ` +
+          `${bootstrap.stderr.trim() || bootstrap.stdout.trim()}`,
+      );
+    }
+
+    // Some macOS releases bootstrap-then-skip-Run-At-Load if the
+    // service was loaded earlier in the session. `kickstart -k` is the
+    // belt-and-braces way to guarantee an actual running process; the
+    // -k flag means "kill any existing instance first" which is safe
+    // because we just bootstrapped fresh.
+    await run(["kickstart", "-k", domain(label)]);
+
+    // Poll for `state = running`. Bootstrap is synchronous in name
+    // only — the child process spawns asynchronously, and on a cold
+    // box the daemon needs a moment to bind the API port. We give it
+    // bootWaitMs; if we time out, we still return — the caller can
+    // call `arkeon-wiki status` later to confirm.
+    const deadline = Date.now() + bootWaitMs;
+    let last = await readStatus(installOpts.name);
+    while (!last.running && Date.now() < deadline) {
+      await sleep(bootIntervalMs);
+      last = await readStatus(installOpts.name);
+    }
+
+    return {
+      unitPath,
+      label,
+      running: last.running,
+      pid: last.pid,
+    };
+  }
+
+  async function uninstall(
+    uninstallOpts: UninstallOptions,
+  ): Promise<UninstallResult> {
+    const label = launchdLabel(uninstallOpts.name);
+    const unitPath = plistPathFor(uninstallOpts.name);
+    const existed = existsSync(unitPath);
+
+    // bootout is best-effort — if the service wasn't loaded, it
+    // returns non-zero, which is fine for the uninstall path. We just
+    // want to ensure nothing is running under this label after we
+    // delete the file.
+    await run(["bootout", domain(label)]);
+
+    if (existed) {
+      rmSync(unitPath);
+    }
+
+    return {
+      removed: existed,
+      unitPath: existed ? unitPath : null,
+    };
+  }
+
+  return {
+    install,
+    uninstall,
+    status: ({ name }) => readStatus(name),
+  };
+}
+
+/** Production manager — uses real launchctl + `$HOME`. */
+export const manager: ServiceManager = createLaunchdManager();

--- a/packages/arkeon/src/cli/lib/service/launchd.ts
+++ b/packages/arkeon/src/cli/lib/service/launchd.ts
@@ -121,13 +121,19 @@ export function createLaunchdManager(
       mkdirSync(launchAgentsDir, { recursive: true });
     }
 
-    // If the service is already loaded (re-install, or a stale entry
-    // from a previous build), bootout first so bootstrap can take a
-    // fresh plist. Ignore failures — bootout returns non-zero if the
-    // service wasn't loaded, which is fine.
-    await run(["bootout", domain(label)]);
-
+    // Write the new plist *before* tearing down the previous load.
+    // If writeFileSync throws (disk full, EACCES, etc.) the user's
+    // previous service is left running — a re-runnable failure.
+    // If we bootout'd first and then failed to write, the user would
+    // be left with a stopped service and no new plist to retry from.
     writeFileSync(unitPath, plistBody, "utf-8");
+
+    // If the service is already loaded (re-install with new plist
+    // contents, or a stale entry from a previous build), bootout
+    // first so bootstrap can take the fresh plist. Ignore failures —
+    // bootout returns non-zero when the service wasn't loaded, which
+    // is the happy path on a first install.
+    await run(["bootout", domain(label)]);
 
     const bootstrap = await run(["bootstrap", `gui/${uid}`, unitPath]);
     if (bootstrap.exitCode !== 0) {

--- a/packages/arkeon/src/cli/lib/service/launchd.ts
+++ b/packages/arkeon/src/cli/lib/service/launchd.ts
@@ -44,6 +44,7 @@ import type {
   InstallResult,
   ServiceManager,
   ServiceStatus,
+  StartResult,
   UninstallOptions,
   UninstallResult,
 } from "./types.js";
@@ -186,10 +187,40 @@ export function createLaunchdManager(
     };
   }
 
+  async function start({ name }: { name: string }): Promise<StartResult> {
+    const label = launchdLabel(name);
+    const unitPath = plistPathFor(name);
+    if (!existsSync(unitPath)) {
+      throw new Error(
+        `service is not installed for ${name === "default" ? "the default instance" : `instance "${name}"`}. ` +
+          `Run \`arkeon-wiki install${name === "default" ? "" : ` --name ${name}`}\` first.`,
+      );
+    }
+
+    // kickstart -k = "kill any existing process, then start". Safe
+    // because we only call start() when the supervisor's view of state
+    // is "not running", and harmless when it's actually running.
+    await run(["kickstart", "-k", domain(label)]);
+
+    const deadline = Date.now() + bootWaitMs;
+    let last = await readStatus(name);
+    while (!last.running && Date.now() < deadline) {
+      await sleep(bootIntervalMs);
+      last = await readStatus(name);
+    }
+
+    return {
+      running: last.running,
+      pid: last.pid,
+      unitPath,
+    };
+  }
+
   return {
     install,
     uninstall,
     status: ({ name }) => readStatus(name),
+    start,
   };
 }
 

--- a/packages/arkeon/src/cli/lib/service/path-snapshot.ts
+++ b/packages/arkeon/src/cli/lib/service/path-snapshot.ts
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Resolve absolute paths to the node binary and CLI entry script for
+ * use in a launchd plist or systemd unit.
+ *
+ * The supervisor's PATH is *not* the user's interactive shell PATH —
+ * launchd's default is `/usr/bin:/bin:/usr/sbin:/sbin`, and systemd
+ * user units inherit the session manager's environment, not the
+ * login shell's. nvm/fnm/asdf-managed nodes are reachable only via
+ * shell init scripts, so a unit that says `ExecStart=node ...` will
+ * fail to find node under launchd/systemd on most developer machines.
+ *
+ * We pin the absolute path at install time. If the user later
+ * uninstalls that node version, the service fails fast with a clear
+ * ENOENT in the log — better than silently picking up a different
+ * node from somewhere on PATH.
+ */
+
+import { resolve } from "node:path";
+
+import { findCliEntry } from "../local-runtime.js";
+
+import type { PathSnapshot } from "./types.js";
+
+/**
+ * Resolve absolute paths for the supervisor to invoke.
+ *
+ * Production (npm-installed): consumes the bundled `dist/index.js`
+ * that `findCliEntry()` already finds; the `cmd` it returns is
+ * `process.execPath` (absolute), and the entry is an absolute path
+ * within the package's install dir. Both are stable for the lifetime
+ * of the install.
+ *
+ * Dev mode (tsx running .ts directly): `findCliEntry()` returns `npx
+ * tsx <path>`, which won't work under a service supervisor that
+ * doesn't share the user's shell PATH. We refuse rather than guess —
+ * install is a production action, and asking the user to run `npm run
+ * build` first is clearer than silently shipping a broken plist.
+ */
+export function snapshotPaths(): PathSnapshot {
+  const entry = findCliEntry();
+
+  if (entry.cmd === "npx" || entry.cmd === "arkeon-wiki") {
+    throw new Error(
+      "service install requires a built CLI. " +
+        "Run `npm run build` from a source checkout, or install via `npm install -g arkeon-wiki`.",
+    );
+  }
+
+  const cliEntry = entry.args[0];
+  if (!cliEntry) {
+    throw new Error(
+      "service install: could not resolve absolute CLI entry path from findCliEntry().",
+    );
+  }
+
+  return {
+    nodeBin: resolve(entry.cmd),
+    cliEntry: resolve(cliEntry),
+  };
+}

--- a/packages/arkeon/src/cli/lib/service/types.ts
+++ b/packages/arkeon/src/cli/lib/service/types.ts
@@ -68,14 +68,29 @@ export interface ServiceStatus {
   unitPath: string | null;
 }
 
+export interface StartResult {
+  /** True if the supervisor reports the service running after the call. */
+  running: boolean;
+  /** PID per the supervisor, if any. */
+  pid: number | null;
+  /** Path of the unit/plist the supervisor is managing. */
+  unitPath: string;
+}
+
 /**
  * Per-platform surface. `launchd.ts` and `systemd.ts` each export a
  * `manager: ServiceManager` that satisfies this interface.
+ *
+ * `start()` is the "bring an already-installed service up" operation
+ * — distinct from `install()` which also writes the plist/unit. Used
+ * by `arkeon-wiki up` to delegate to the supervisor instead of
+ * spawning a detached child that the supervisor doesn't track.
  */
 export interface ServiceManager {
   install(opts: InstallOptions): Promise<InstallResult>;
   uninstall(opts: UninstallOptions): Promise<UninstallResult>;
   status(opts: { name: string }): Promise<ServiceStatus>;
+  start(opts: { name: string }): Promise<StartResult>;
 }
 
 export type Platform = "launchd" | "systemd" | "unsupported";

--- a/packages/arkeon/src/cli/lib/service/types.ts
+++ b/packages/arkeon/src/cli/lib/service/types.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared types for the service install/uninstall surface. Platforms
+ * (launchd on macOS, systemd on Linux) implement {@link ServiceManager}
+ * and the {@link detectPlatform} dispatch picks one at runtime.
+ *
+ * Everything here is pure data — no Node-side filesystem or process
+ * calls. The launchd / systemd modules import from this file to keep
+ * their public shape uniform.
+ */
+
+/**
+ * Snapshot of the absolute paths the supervisor needs to invoke the
+ * daemon. Resolved at install time so the unit/plist doesn't depend on
+ * the user's interactive PATH (nvm/fnm change the resolved `node`
+ * binary on every shell init; pinning the absolute path at install
+ * time means the service keeps working even if the user later changes
+ * shell defaults).
+ */
+export interface PathSnapshot {
+  /** Absolute path to the node binary. From `process.execPath`. */
+  nodeBin: string;
+  /** Absolute path to the CLI entry script (dist/index.js in prod, src in dev). */
+  cliEntry: string;
+}
+
+export interface InstallOptions {
+  /** Instance name. "default" for the unnamed install. */
+  name: string;
+  /** Resolved instance home (~/.arkeon-wiki or ~/.arkeon-wiki/<name>). */
+  home: string;
+  /** Pinned-at-install-time node + entry paths. */
+  paths: PathSnapshot;
+}
+
+export interface InstallResult {
+  /** Filesystem path of the plist or unit we wrote. */
+  unitPath: string;
+  /** "tech.arkeon.wiki" or "arkeon-wiki@<name>" — the supervisor's handle. */
+  label: string;
+  /** True if the supervisor reports the service running after install. */
+  running: boolean;
+  /** PID, if the supervisor exposes one. */
+  pid: number | null;
+}
+
+export interface UninstallOptions {
+  name: string;
+}
+
+export interface UninstallResult {
+  /** True if we found and removed a unit file. False is fine — idempotent. */
+  removed: boolean;
+  /** Path of the unit we removed, if any. */
+  unitPath: string | null;
+}
+
+export interface ServiceStatus {
+  /** True if a unit/plist exists on disk for this name. */
+  installed: boolean;
+  /** True if the supervisor reports the service running. */
+  running: boolean;
+  /** PID per the supervisor's view, if any. */
+  pid: number | null;
+  /** Path of the unit/plist on disk, if installed. */
+  unitPath: string | null;
+}
+
+/**
+ * Per-platform surface. `launchd.ts` and `systemd.ts` each export a
+ * `manager: ServiceManager` that satisfies this interface.
+ */
+export interface ServiceManager {
+  install(opts: InstallOptions): Promise<InstallResult>;
+  uninstall(opts: UninstallOptions): Promise<UninstallResult>;
+  status(opts: { name: string }): Promise<ServiceStatus>;
+}
+
+export type Platform = "launchd" | "systemd" | "unsupported";

--- a/packages/arkeon/test/unit/service-env-snapshot.test.ts
+++ b/packages/arkeon/test/unit/service-env-snapshot.test.ts
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { readEnvKeys, snapshotEnv } from "../../src/cli/lib/service/index.js";
+
+let dir: string;
+let envPath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "service-env-"));
+  envPath = join(dir, ".env");
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("readEnvKeys", () => {
+  it("returns empty set for missing file", () => {
+    expect(readEnvKeys(join(dir, "missing"))).toEqual(new Set());
+  });
+
+  it("extracts key names, ignoring comments and blanks", () => {
+    writeFileSync(
+      envPath,
+      [
+        "# comment",
+        "",
+        "OPENAI_API_KEY=sk-abc",
+        "ANTHROPIC_API_KEY=sk-ant-xyz",
+        "  WITH_LEADING_SPACE=value",
+        "export EXPORTED_KEY=value",
+        "not a key line",
+        "=missing_name",
+      ].join("\n"),
+    );
+    const keys = readEnvKeys(envPath);
+    expect(keys).toEqual(new Set([
+      "OPENAI_API_KEY",
+      "ANTHROPIC_API_KEY",
+      "WITH_LEADING_SPACE",
+      "EXPORTED_KEY",
+    ]));
+  });
+});
+
+describe("snapshotEnv", () => {
+  it("appends a key when it's in the shell but not in the file", () => {
+    const result = snapshotEnv({
+      keys: ["OPENAI_API_KEY"],
+      envFilePath: envPath,
+      shellEnv: { OPENAI_API_KEY: "sk-test-123" },
+    });
+
+    expect(result.written).toEqual(["OPENAI_API_KEY"]);
+    expect(result.preserved).toEqual([]);
+    expect(result.missing).toEqual([]);
+    expect(readFileSync(envPath, "utf-8")).toContain("OPENAI_API_KEY=sk-test-123");
+  });
+
+  it("preserves an existing key — never overwrites a different value", () => {
+    writeFileSync(envPath, "OPENAI_API_KEY=sk-PRESERVED-value\n");
+    const result = snapshotEnv({
+      keys: ["OPENAI_API_KEY"],
+      envFilePath: envPath,
+      shellEnv: { OPENAI_API_KEY: "sk-SHELL-value" },
+    });
+
+    expect(result.preserved).toEqual(["OPENAI_API_KEY"]);
+    expect(result.written).toEqual([]);
+    expect(readFileSync(envPath, "utf-8")).toBe("OPENAI_API_KEY=sk-PRESERVED-value\n");
+  });
+
+  it("records a key as missing when not in shell or file", () => {
+    const result = snapshotEnv({
+      keys: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"],
+      envFilePath: envPath,
+      shellEnv: {},
+    });
+
+    expect(result.missing).toEqual(["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]);
+    expect(result.written).toEqual([]);
+    expect(result.preserved).toEqual([]);
+  });
+
+  it("is idempotent across repeated calls", () => {
+    const opts = {
+      keys: ["OPENAI_API_KEY"],
+      envFilePath: envPath,
+      shellEnv: { OPENAI_API_KEY: "sk-test" },
+    };
+    const first = snapshotEnv(opts);
+    const after = readFileSync(envPath, "utf-8");
+    const second = snapshotEnv(opts);
+
+    expect(first.written).toEqual(["OPENAI_API_KEY"]);
+    expect(second.written).toEqual([]);
+    expect(second.preserved).toEqual(["OPENAI_API_KEY"]);
+    expect(readFileSync(envPath, "utf-8")).toBe(after);
+  });
+
+  it("dry-run plans without writing", () => {
+    const result = snapshotEnv({
+      keys: ["OPENAI_API_KEY"],
+      envFilePath: envPath,
+      shellEnv: { OPENAI_API_KEY: "sk-dryrun" },
+      apply: false,
+    });
+
+    expect(result.written).toEqual(["OPENAI_API_KEY"]);
+    expect(() => readFileSync(envPath, "utf-8")).toThrow();
+  });
+
+  it("appends without clobbering when other keys already live in the file", () => {
+    writeFileSync(envPath, "OTHER_KEY=untouched\n");
+    const result = snapshotEnv({
+      keys: ["OPENAI_API_KEY"],
+      envFilePath: envPath,
+      shellEnv: { OPENAI_API_KEY: "sk-new" },
+    });
+
+    const text = readFileSync(envPath, "utf-8");
+    expect(result.written).toEqual(["OPENAI_API_KEY"]);
+    expect(text).toContain("OTHER_KEY=untouched");
+    expect(text).toContain("OPENAI_API_KEY=sk-new");
+  });
+
+  it("adds a leading newline when the existing file doesn't end in one", () => {
+    writeFileSync(envPath, "EXISTING=value");
+    snapshotEnv({
+      keys: ["NEW_KEY"],
+      envFilePath: envPath,
+      shellEnv: { NEW_KEY: "value" },
+    });
+    expect(readFileSync(envPath, "utf-8")).toBe("EXISTING=value\nNEW_KEY=value\n");
+  });
+
+  it("quotes values containing whitespace or special chars", () => {
+    snapshotEnv({
+      keys: ["A", "B", "C"],
+      envFilePath: envPath,
+      shellEnv: { A: "simple", B: "has space", C: 'has"quote' },
+    });
+    const text = readFileSync(envPath, "utf-8");
+    expect(text).toContain("A=simple\n");
+    expect(text).toContain('B="has space"\n');
+    expect(text).toContain('C="has\\"quote"\n');
+  });
+
+  it("treats empty-string shell values as missing", () => {
+    const result = snapshotEnv({
+      keys: ["EMPTY_KEY"],
+      envFilePath: envPath,
+      shellEnv: { EMPTY_KEY: "" },
+    });
+    expect(result.missing).toEqual(["EMPTY_KEY"]);
+    expect(result.written).toEqual([]);
+  });
+});

--- a/packages/arkeon/test/unit/service-env-snapshot.test.ts
+++ b/packages/arkeon/test/unit/service-env-snapshot.test.ts
@@ -2,7 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -160,5 +167,59 @@ describe("snapshotEnv", () => {
     });
     expect(result.missing).toEqual(["EMPTY_KEY"]);
     expect(result.written).toEqual([]);
+  });
+
+  it("writes the env file with 0600 permissions", () => {
+    snapshotEnv({
+      keys: ["OPENAI_API_KEY"],
+      envFilePath: envPath,
+      shellEnv: { OPENAI_API_KEY: "sk-secret" },
+    });
+    // Mask file-type bits; we only care about the permission bits.
+    expect(statSync(envPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("tightens existing 0644 permissions to 0600 on idempotent re-run", () => {
+    // User created the file by hand with permissive defaults — install
+    // should bring it to the secret-file standard, even when nothing
+    // new gets written.
+    writeFileSync(envPath, "OPENAI_API_KEY=sk-existing\n");
+    chmodSync(envPath, 0o644);
+    expect(statSync(envPath).mode & 0o777).toBe(0o644);
+
+    const result = snapshotEnv({
+      keys: ["OPENAI_API_KEY"],
+      envFilePath: envPath,
+      shellEnv: { OPENAI_API_KEY: "sk-shell" },
+    });
+
+    expect(result.preserved).toEqual(["OPENAI_API_KEY"]);
+    expect(result.written).toEqual([]);
+    expect(statSync(envPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("creates the empty placeholder file with 0600", () => {
+    // No keys to write, no existing file — snapshotEnv still
+    // creates an empty file (cosmetic). It must also enforce 0600
+    // on that empty file so a later hand-edit landing a key is
+    // already protected.
+    snapshotEnv({
+      keys: ["NOT_IN_SHELL"],
+      envFilePath: envPath,
+      shellEnv: {},
+    });
+    expect(statSync(envPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("dry-run does not chmod (no apply, no write)", () => {
+    writeFileSync(envPath, "EXISTING=v\n");
+    chmodSync(envPath, 0o644);
+    snapshotEnv({
+      keys: ["EXISTING"],
+      envFilePath: envPath,
+      shellEnv: { EXISTING: "v" },
+      apply: false,
+    });
+    expect(statSync(envPath).mode & 0o777).toBe(0o644);
   });
 });

--- a/packages/arkeon/test/unit/service-launchctl.test.ts
+++ b/packages/arkeon/test/unit/service-launchctl.test.ts
@@ -42,4 +42,26 @@ describe("parseLaunchctlPrint", () => {
     const out = "  state =   running  \n      pid =   77  \n";
     expect(parseLaunchctlPrint(out)).toEqual({ state: "running", pid: 77 });
   });
+
+  it("isn't fooled by nested 'state = active' inside coalition blocks", () => {
+    // Real-world launchctl output. Without the first-match rule the
+    // running state would get overwritten by the coalition's 'active'.
+    const out = `gui/501/tech.arkeon.wiki.svc = {
+\tactive count = 1
+\tstate = running
+
+\tpid = 40784
+
+\tresource coalition = {
+\t\tID = 103455
+\t\tstate = active
+\t}
+
+\tjetsam coalition = {
+\t\tstate = active
+\t}
+}
+`;
+    expect(parseLaunchctlPrint(out)).toEqual({ state: "running", pid: 40784 });
+  });
 });

--- a/packages/arkeon/test/unit/service-launchctl.test.ts
+++ b/packages/arkeon/test/unit/service-launchctl.test.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { parseLaunchctlPrint } from "../../src/cli/lib/service/launchctl.js";
+
+describe("parseLaunchctlPrint", () => {
+  it("extracts running state + pid from a typical print output", () => {
+    const out = `gui/501/tech.arkeon.wiki = {
+\tactive count = 1
+\tpath = /Users/test/Library/LaunchAgents/tech.arkeon.wiki.plist
+\ttype = LaunchAgent
+\tstate = running
+
+\tprogram = /usr/local/bin/node
+\tpid = 51234
+\tlast exit code = (never exited)
+}
+`;
+    expect(parseLaunchctlPrint(out)).toEqual({ state: "running", pid: 51234 });
+  });
+
+  it("recognizes 'not running' state and reports null pid", () => {
+    const out = `gui/501/tech.arkeon.wiki = {
+\tactive count = 0
+\tstate = not running
+}
+`;
+    expect(parseLaunchctlPrint(out)).toEqual({ state: "not running", pid: null });
+  });
+
+  it("returns unknown when state line is absent", () => {
+    expect(parseLaunchctlPrint("")).toEqual({ state: "unknown", pid: null });
+    expect(parseLaunchctlPrint("some unrelated output")).toEqual({
+      state: "unknown",
+      pid: null,
+    });
+  });
+
+  it("tolerates varying whitespace and indentation", () => {
+    const out = "  state =   running  \n      pid =   77  \n";
+    expect(parseLaunchctlPrint(out)).toEqual({ state: "running", pid: 77 });
+  });
+});

--- a/packages/arkeon/test/unit/service-launchd-manager.test.ts
+++ b/packages/arkeon/test/unit/service-launchd-manager.test.ts
@@ -216,6 +216,45 @@ describe("createLaunchdManager — uninstall", () => {
   });
 });
 
+describe("createLaunchdManager — start", () => {
+  it("refuses when no plist is installed", async () => {
+    const { run } = fakeLaunchctl({});
+    const mgr = createLaunchdManager({
+      runLaunchctl: run,
+      home,
+      uid: 501,
+      bootWaitMs: 0,
+    });
+    await expect(mgr.start({ name: "default" })).rejects.toThrow(/not installed/);
+  });
+
+  it("kickstarts an installed service and polls until running", async () => {
+    const printRunning = {
+      stdout: "state = running\npid = 7777\n",
+      stderr: "",
+      exitCode: 0,
+    };
+    // Two responses: one consumed by install's post-bootstrap poll, one
+    // for start's post-kickstart poll.
+    const { run, calls } = fakeLaunchctl({ print: [printRunning, printRunning] });
+    const mgr = createLaunchdManager({
+      runLaunchctl: run,
+      home,
+      uid: 501,
+      bootWaitMs: 0,
+    });
+
+    await mgr.install(INSTALL_OPTS);
+    calls.length = 0;
+
+    const result = await mgr.start({ name: "default" });
+    expect(result.running).toBe(true);
+    expect(result.pid).toBe(7777);
+    expect(calls.map((c) => c.args[0])).toEqual(["kickstart", "print"]);
+    expect(calls[0].args).toEqual(["kickstart", "-k", "gui/501/tech.arkeon.wiki"]);
+  });
+});
+
 describe("createLaunchdManager — status", () => {
   it("returns installed=false when no plist exists", async () => {
     const { run } = fakeLaunchctl({});

--- a/packages/arkeon/test/unit/service-launchd-manager.test.ts
+++ b/packages/arkeon/test/unit/service-launchd-manager.test.ts
@@ -87,7 +87,10 @@ describe("createLaunchdManager — install", () => {
     expect(readFileSync(expectedPath, "utf-8")).toContain("<string>tech.arkeon.wiki</string>");
 
     // Verb sequence: bootout (clear prior load) → bootstrap → kickstart → print.
+    // Plist is written to disk BEFORE bootout — see install() in
+    // launchd.ts for the partial-failure reasoning.
     expect(calls.map((c) => c.args[0])).toEqual(["bootout", "bootstrap", "kickstart", "print"]);
+    expect(calls[0].args).toEqual(["bootout", "gui/501/tech.arkeon.wiki"]);
     expect(calls[1].args).toEqual(["bootstrap", "gui/501", expectedPath]);
     expect(calls[2].args).toEqual(["kickstart", "-k", "gui/501/tech.arkeon.wiki"]);
   });
@@ -147,6 +150,51 @@ describe("createLaunchdManager — install", () => {
     expect(result.running).toBe(true);
     expect(result.pid).toBe(4242);
     expect(calls.filter((c) => c.args[0] === "print")).toHaveLength(3);
+  });
+
+  it("re-install replaces the plist on disk and tears down the old load", async () => {
+    // Simulate an upgrade: install once with the original entry path,
+    // then install again with a different path. The on-disk plist
+    // bytes must reflect the second call, and bootout must run between
+    // the two write+bootstrap pairs so the new plist actually takes.
+    const { run, calls } = fakeLaunchctl({});
+    const mgr = createLaunchdManager({
+      runLaunchctl: run,
+      home,
+      uid: 501,
+      bootWaitMs: 0,
+    });
+
+    await mgr.install(INSTALL_OPTS);
+    const firstPlist = readFileSync(
+      join(home, "Library/LaunchAgents/tech.arkeon.wiki.plist"),
+      "utf-8",
+    );
+    expect(firstPlist).toContain("<string>/Users/test/arkeon-wiki/dist/index.js</string>");
+
+    // Second install with a different cliEntry path — simulates upgrading
+    // arkeon-wiki to a build that lives somewhere else.
+    calls.length = 0;
+    await mgr.install({
+      ...INSTALL_OPTS,
+      paths: {
+        nodeBin: "/usr/local/bin/node",
+        cliEntry: "/opt/arkeon-wiki/dist/index.js",
+      },
+    });
+
+    const secondPlist = readFileSync(
+      join(home, "Library/LaunchAgents/tech.arkeon.wiki.plist"),
+      "utf-8",
+    );
+    expect(secondPlist).toContain("<string>/opt/arkeon-wiki/dist/index.js</string>");
+    expect(secondPlist).not.toContain("/Users/test/arkeon-wiki/dist/index.js");
+
+    // Second install must bootout the previous load before bootstrapping
+    // the new plist — otherwise launchd keeps the stale entry pointing
+    // at the old path.
+    const verbs = calls.map((c) => c.args[0]);
+    expect(verbs.indexOf("bootout")).toBeLessThan(verbs.indexOf("bootstrap"));
   });
 
   it("threads a named instance through plist + label + path", async () => {

--- a/packages/arkeon/test/unit/service-launchd-manager.test.ts
+++ b/packages/arkeon/test/unit/service-launchd-manager.test.ts
@@ -1,0 +1,256 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createLaunchdManager } from "../../src/cli/lib/service/launchd.js";
+import type {
+  LaunchctlResult,
+  LaunchctlRunner,
+} from "../../src/cli/lib/service/launchctl.js";
+import type { InstallOptions } from "../../src/cli/lib/service/index.js";
+
+interface Call {
+  args: string[];
+}
+
+/**
+ * Build a launchctl runner that records every invocation and returns
+ * the queued result for that subcommand. Defaults to "no service
+ * loaded" / "ok".
+ */
+function fakeLaunchctl(
+  queue: Record<string, LaunchctlResult[]>,
+): { run: LaunchctlRunner; calls: Call[] } {
+  const calls: Call[] = [];
+  const run: LaunchctlRunner = async (args) => {
+    calls.push({ args: [...args] });
+    const sub = args[0]!;
+    const queued = queue[sub];
+    if (queued && queued.length > 0) {
+      return queued.shift()!;
+    }
+    if (sub === "print") {
+      return { stdout: "", stderr: "Could not find service", exitCode: 113 };
+    }
+    return { stdout: "", stderr: "", exitCode: 0 };
+  };
+  return { run, calls };
+}
+
+let home: string;
+const INSTALL_OPTS: InstallOptions = {
+  name: "default",
+  home: "/Users/test/.arkeon-wiki",
+  paths: {
+    nodeBin: "/usr/local/bin/node",
+    cliEntry: "/Users/test/arkeon-wiki/dist/index.js",
+  },
+};
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "launchd-mgr-"));
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("createLaunchdManager — install", () => {
+  it("writes the plist + bootstraps + kickstarts + reports running", async () => {
+    const printRunning: LaunchctlResult = {
+      stdout: "state = running\npid = 9999\n",
+      stderr: "",
+      exitCode: 0,
+    };
+    const { run, calls } = fakeLaunchctl({ print: [printRunning] });
+    const mgr = createLaunchdManager({
+      runLaunchctl: run,
+      home,
+      uid: 501,
+      bootWaitMs: 0,
+      bootIntervalMs: 0,
+    });
+
+    const result = await mgr.install(INSTALL_OPTS);
+
+    const expectedPath = join(home, "Library/LaunchAgents/tech.arkeon.wiki.plist");
+    expect(result.unitPath).toBe(expectedPath);
+    expect(result.label).toBe("tech.arkeon.wiki");
+    expect(result.running).toBe(true);
+    expect(result.pid).toBe(9999);
+
+    expect(existsSync(expectedPath)).toBe(true);
+    expect(readFileSync(expectedPath, "utf-8")).toContain("<string>tech.arkeon.wiki</string>");
+
+    // Verb sequence: bootout (clear prior load) → bootstrap → kickstart → print.
+    expect(calls.map((c) => c.args[0])).toEqual(["bootout", "bootstrap", "kickstart", "print"]);
+    expect(calls[1].args).toEqual(["bootstrap", "gui/501", expectedPath]);
+    expect(calls[2].args).toEqual(["kickstart", "-k", "gui/501/tech.arkeon.wiki"]);
+  });
+
+  it("creates ~/Library/LaunchAgents/ if it doesn't exist", async () => {
+    const { run } = fakeLaunchctl({});
+    const mgr = createLaunchdManager({
+      runLaunchctl: run,
+      home,
+      uid: 501,
+      bootWaitMs: 0,
+    });
+
+    expect(existsSync(join(home, "Library/LaunchAgents"))).toBe(false);
+    await mgr.install(INSTALL_OPTS);
+    expect(existsSync(join(home, "Library/LaunchAgents"))).toBe(true);
+  });
+
+  it("throws when bootstrap returns non-zero", async () => {
+    const { run } = fakeLaunchctl({
+      bootstrap: [{ stdout: "", stderr: "Service is disabled", exitCode: 5 }],
+    });
+    const mgr = createLaunchdManager({
+      runLaunchctl: run,
+      home,
+      uid: 501,
+      bootWaitMs: 0,
+    });
+
+    await expect(mgr.install(INSTALL_OPTS)).rejects.toThrow(/bootstrap failed/);
+  });
+
+  it("polls until running, then returns the live pid", async () => {
+    const notRunning: LaunchctlResult = {
+      stdout: "state = not running\n",
+      stderr: "",
+      exitCode: 0,
+    };
+    const running: LaunchctlResult = {
+      stdout: "state = running\npid = 4242\n",
+      stderr: "",
+      exitCode: 0,
+    };
+    const { run, calls } = fakeLaunchctl({
+      print: [notRunning, notRunning, running],
+    });
+    const mgr = createLaunchdManager({
+      runLaunchctl: run,
+      home,
+      uid: 501,
+      bootWaitMs: 1000,
+      bootIntervalMs: 0,
+      sleep: async () => {},
+    });
+
+    const result = await mgr.install(INSTALL_OPTS);
+    expect(result.running).toBe(true);
+    expect(result.pid).toBe(4242);
+    expect(calls.filter((c) => c.args[0] === "print")).toHaveLength(3);
+  });
+
+  it("threads a named instance through plist + label + path", async () => {
+    const { run, calls } = fakeLaunchctl({});
+    const mgr = createLaunchdManager({
+      runLaunchctl: run,
+      home,
+      uid: 501,
+      bootWaitMs: 0,
+    });
+
+    const result = await mgr.install({
+      ...INSTALL_OPTS,
+      name: "svc-test",
+      home: "/Users/test/.arkeon-wiki/svc-test",
+    });
+
+    expect(result.label).toBe("tech.arkeon.wiki.svc-test");
+    expect(result.unitPath).toBe(
+      join(home, "Library/LaunchAgents/tech.arkeon.wiki.svc-test.plist"),
+    );
+    const written = readFileSync(result.unitPath, "utf-8");
+    expect(written).toContain("--name");
+    expect(written).toContain("<string>svc-test</string>");
+    expect(calls[2]).toEqual({
+      args: ["kickstart", "-k", "gui/501/tech.arkeon.wiki.svc-test"],
+    });
+  });
+});
+
+describe("createLaunchdManager — uninstall", () => {
+  it("removes the plist and reports removed=true", async () => {
+    const { run, calls } = fakeLaunchctl({});
+    const mgr = createLaunchdManager({
+      runLaunchctl: run,
+      home,
+      uid: 501,
+      bootWaitMs: 0,
+    });
+
+    await mgr.install(INSTALL_OPTS);
+    const result = await mgr.uninstall({ name: "default" });
+
+    expect(result.removed).toBe(true);
+    expect(result.unitPath).toBe(
+      join(home, "Library/LaunchAgents/tech.arkeon.wiki.plist"),
+    );
+    expect(existsSync(result.unitPath!)).toBe(false);
+
+    // Final call should be the cleanup bootout for the label.
+    const last = calls.at(-1)!;
+    expect(last.args).toEqual(["bootout", "gui/501/tech.arkeon.wiki"]);
+  });
+
+  it("is idempotent — no plist on disk returns removed=false without erroring", async () => {
+    const { run } = fakeLaunchctl({});
+    const mgr = createLaunchdManager({
+      runLaunchctl: run,
+      home,
+      uid: 501,
+      bootWaitMs: 0,
+    });
+
+    const result = await mgr.uninstall({ name: "default" });
+    expect(result.removed).toBe(false);
+    expect(result.unitPath).toBeNull();
+  });
+});
+
+describe("createLaunchdManager — status", () => {
+  it("returns installed=false when no plist exists", async () => {
+    const { run } = fakeLaunchctl({});
+    const mgr = createLaunchdManager({
+      runLaunchctl: run,
+      home,
+      uid: 501,
+      bootWaitMs: 0,
+    });
+    const status = await mgr.status({ name: "default" });
+    expect(status).toEqual({
+      installed: false,
+      running: false,
+      pid: null,
+      unitPath: null,
+    });
+  });
+
+  it("reports installed=true but running=false when print fails after install", async () => {
+    const { run } = fakeLaunchctl({});
+    const mgr = createLaunchdManager({
+      runLaunchctl: run,
+      home,
+      uid: 501,
+      bootWaitMs: 0,
+    });
+    await mgr.install(INSTALL_OPTS);
+    // After install, by default print queue is empty — fake returns
+    // exit 113 ("not found"). Status should report installed-but-stopped.
+    const status = await mgr.status({ name: "default" });
+    expect(status.installed).toBe(true);
+    expect(status.running).toBe(false);
+    expect(status.pid).toBeNull();
+    expect(status.unitPath).toBe(
+      join(home, "Library/LaunchAgents/tech.arkeon.wiki.plist"),
+    );
+  });
+});

--- a/packages/arkeon/test/unit/service-launchd-plist.test.ts
+++ b/packages/arkeon/test/unit/service-launchd-plist.test.ts
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_LAUNCHD_LABEL,
+  launchdLabel,
+  launchdPlistPath,
+  renderLaunchdPlist,
+  validateInstanceName,
+} from "../../src/cli/lib/service/index.js";
+
+const DEFAULT_OPTS = {
+  name: "default",
+  home: "/Users/test/.arkeon-wiki",
+  paths: {
+    nodeBin: "/usr/local/bin/node",
+    cliEntry: "/Users/test/arkeon-wiki/dist/index.js",
+  },
+};
+
+describe("validateInstanceName", () => {
+  it("accepts alnum, dot, underscore, hyphen", () => {
+    for (const name of ["default", "svc-test", "dev_1", "team.alpha", "abc123"]) {
+      expect(() => validateInstanceName(name)).not.toThrow();
+    }
+  });
+
+  it.each([
+    "",
+    " ",
+    "has space",
+    "has/slash",
+    "has;semi",
+    "has$var",
+    "has\nnewline",
+  ])("rejects %j", (bad) => {
+    expect(() => validateInstanceName(bad)).toThrow();
+  });
+});
+
+describe("launchdLabel", () => {
+  it("returns the bare reverse-DNS label for the default instance", () => {
+    expect(launchdLabel("default")).toBe(DEFAULT_LAUNCHD_LABEL);
+  });
+
+  it("appends the name as a fourth segment for named instances", () => {
+    expect(launchdLabel("svc-test")).toBe("tech.arkeon.wiki.svc-test");
+  });
+
+  it("validates the name before constructing", () => {
+    expect(() => launchdLabel("bad name")).toThrow();
+  });
+});
+
+describe("launchdPlistPath", () => {
+  it("lives under ~/Library/LaunchAgents", () => {
+    expect(launchdPlistPath("tech.arkeon.wiki", "/Users/foo")).toBe(
+      "/Users/foo/Library/LaunchAgents/tech.arkeon.wiki.plist",
+    );
+  });
+});
+
+describe("renderLaunchdPlist", () => {
+  it("renders the default-instance plist verbatim", () => {
+    expect(renderLaunchdPlist(DEFAULT_OPTS)).toBe(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>tech.arkeon.wiki</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/node</string>
+    <string>/Users/test/arkeon-wiki/dist/index.js</string>
+    <string>start</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+    <key>Crashed</key>
+    <true/>
+  </dict>
+  <key>WorkingDirectory</key>
+  <string>/Users/test/.arkeon-wiki</string>
+  <key>StandardOutPath</key>
+  <string>/Users/test/.arkeon-wiki/arkeon.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/test/.arkeon-wiki/arkeon.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+    <key>ARKEON_WIKI_HOME</key>
+    <string>/Users/test/.arkeon-wiki</string>
+  </dict>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+</dict>
+</plist>
+`);
+  });
+
+  it("threads --name through ProgramArguments for a named instance", () => {
+    const plist = renderLaunchdPlist({
+      ...DEFAULT_OPTS,
+      name: "svc-test",
+      home: "/Users/test/.arkeon-wiki/svc-test",
+    });
+    expect(plist).toContain("<string>tech.arkeon.wiki.svc-test</string>");
+    expect(plist).toContain("    <string>start</string>\n    <string>--name</string>\n    <string>svc-test</string>");
+    expect(plist).toContain("<string>/Users/test/.arkeon-wiki/svc-test</string>");
+    expect(plist).toContain("<string>/Users/test/.arkeon-wiki/svc-test/arkeon.log</string>");
+  });
+
+  it("respects the KeepAlive contract — restart on crash, not on clean exit", () => {
+    const plist = renderLaunchdPlist(DEFAULT_OPTS);
+    expect(plist).toMatch(
+      /<key>KeepAlive<\/key>\s*<dict>\s*<key>SuccessfulExit<\/key>\s*<false\/>\s*<key>Crashed<\/key>\s*<true\/>\s*<\/dict>/,
+    );
+  });
+
+  it("escapes XML-sensitive characters in paths", () => {
+    const plist = renderLaunchdPlist({
+      ...DEFAULT_OPTS,
+      home: "/Users/test/dir with <special> & 'chars'",
+    });
+    expect(plist).toContain(
+      "<string>/Users/test/dir with &lt;special&gt; &amp; &apos;chars&apos;</string>",
+    );
+    expect(plist).not.toContain("<special>");
+    expect(plist).not.toContain("'chars'");
+  });
+
+  it("is deterministic — same input renders identical bytes", () => {
+    const a = renderLaunchdPlist(DEFAULT_OPTS);
+    const b = renderLaunchdPlist({ ...DEFAULT_OPTS });
+    expect(a).toBe(b);
+  });
+
+  it("sets PATH for the supervisor — homebrew + standard system paths", () => {
+    const plist = renderLaunchdPlist(DEFAULT_OPTS);
+    expect(plist).toContain("/usr/local/bin");
+    expect(plist).toContain("/opt/homebrew/bin");
+  });
+
+  it("rejects an invalid name early", () => {
+    expect(() => renderLaunchdPlist({ ...DEFAULT_OPTS, name: "bad name" })).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- New `arkeon-wiki install` / `uninstall` commands that register the daemon with macOS launchd as a user-scope LaunchAgent — survives reboot, restarts on crash. No sudo.
- `up` / `down` / `status` automatically coordinate with the supervisor when a service is installed: `up` delegates to `launchctl kickstart` instead of spawning an orphan; `down` produces a clean exit launchd respects (`KeepAlive: { SuccessfulExit: false }`); `status` surfaces a `service` field.
- API keys (`OPENAI_API_KEY` etc.) flow through `~/.arkeon-wiki/.env` — never stored in the plist (world-readable on multi-user Macs). The env-snapshot helper is idempotent and never overwrites existing keys.

Closes the macOS half of #146. Linux systemd is a follow-up PR — `systemd.ts` plugs into the existing `ServiceManager` facade.

## What's where

- `packages/arkeon/src/cli/lib/service/` — facade + platform detection, plist renderer, launchctl wrapper, env-snapshot, path-snapshot, launchd ServiceManager
- `packages/arkeon/src/cli/commands/local/{install,uninstall}.ts` — new top-level commands
- `packages/arkeon/src/cli/commands/local/{up,status}.ts` — service-aware lifecycle
- `packages/arkeon/scripts/test-service.sh` — manual end-to-end harness (~30s on a Mac)
- `packages/arkeon/test/unit/service-*.test.ts` — 35 new unit tests (parser, renderer, manager with mocked launchctl, env-snapshot)

## Test plan

Unit tests (CI):

- [x] 223/223 unit tests green, including 35 new cases under `test/unit/service-*.test.ts`
- [x] `npm run typecheck -w packages/arkeon` clean

Manual smoke (`packages/arkeon/scripts/test-service.sh`):

- [x] install → status (running) → up (idempotent, managed_by=service) → down (clean exit, supervisor respects) → up (kickstart, no orphan) → uninstall (no artifacts, data preserved)
- [x] `kill -9 <pid>` → supervisor restarts within ~10s with new pid, `/health` green
- [x] `down` produces a clean exit; supervisor does NOT auto-restart (validates `KeepAlive: { SuccessfulExit: false }`)
- [x] data dir survives uninstall

Full end-to-end with real OpenAI API:

- [x] install with env enabled — captured `OPENAI_API_KEY` from shell into `~/.arkeon-wiki/.env` (preserved existing, did not overwrite)
- [x] registered a test space with a sample source + wiki via API
- [x] `POST /fullsmoke/agents/editor/run` — real OpenAI call (28k input + 648 output tokens), edit applied to disk with correct `<a href>` citation
- [x] `kill -9` daemon, supervisor restarted, second agent run succeeded (no auth errors) — proves env-loader correctly reads `~/.arkeon-wiki/.env` on supervisor-triggered restart with zero shell context

## Notes for reviewers

- The phase-by-phase commits are individually reviewable; commit `452a21d` shows two bugs caught by the first manual smoke test (nested `state = active` in launchctl coalition blocks; commander's `--no-env` flag name) plus the regression tests added.
- Dev-mode install is explicitly refused via `snapshotPaths()` — install requires a built CLI, since launchd/systemd can't reach `npx tsx` reliably.
- The `start()` method on `ServiceManager` distinguishes "bring an existing service back up" (kickstart only) from `install()` (which also writes the plist). `up` uses `start()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)