### PR TITLE
agents: writer + proposer must weave across the broader corpus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,16 +80,18 @@ Editor never creates articles. Zero edits per tick is fine — many sources are 
 1. Picks one source the editor has tagged but the proposer hasn't (`list_entities?type=file&has_tag=editor.processed_hash&not_has_tag=proposer.processed_hash`).
 2. Reads the source.
 3. **Calls `get_entity` on the source path** — `entity.inbound` lists every article that already cites this source (the editor's integration points). These tell the proposer which concepts the editor already integrated.
-4. Identifies the GAP — questions the source raises that aren't already covered by (a) an existing article citing this source, (b) any other existing article, or (c) an already-queued red link.
-5. `create_file` a plan wiki at `wiki/_plans/<source-path>.html` (mirrors source path, drops extension to `.html`) containing a Summary that cites the source inline, plus a list of red links to the gap articles. `<meta name="kind" content="plan">` distinguishes plan wikis from real articles.
-6. `tag_entity` the source with `key="proposer.processed_hash"` value=source_hash.
+4. **Searches the broader corpus** for thematically-adjacent material on the source's main themes — so the plan can seed cross-source citations the writer will follow later. Without this step plans tend to cite only their originating source, which biases the writer toward single-source articles.
+5. Identifies the GAP — questions the source raises that aren't already covered by (a) an existing article citing this source, (b) any other existing article, or (c) an already-queued red link.
+6. `create_file` a plan wiki at `wiki/_plans/<source-path>.html` (mirrors source path, drops extension to `.html`) containing a Summary that cites the source inline plus any cross-source parallels found in step 4, plus a list of red links to the gap articles. `<meta name="kind" content="plan">` distinguishes plan wikis from real articles.
+7. `tag_entity` the source with `key="proposer.processed_hash"` value=source_hash.
 
 Proposer never edits existing articles and never writes article bodies — only red-link slugs in a plan wiki.
 
 **`writer`** (red-link-driven). Each tick:
 1. Picks the highest-demand entry from `list_redlinks`.
 2. Reads the 1-3 plan wikis / articles that linked at it (via `linked_from` + `get_entity`), then follows their inline `<a href="../sources/...">` citations back to the source files.
-3. `create_file` the new article at the red link's `target_path`. Standard four-section body (`Question` / `Current answer` / `Evidence` / `Open threads`) with inline source citations. Drops 1-2 forward-looking red links in Open Threads to keep the queue alive.
+3. **Searches the broader corpus by default** for adjacent material on the question's central concept and reads whatever the plan didn't already point at. Single-source articles are an explicit escape hatch (justified in the one-line reply), not the default — most questions are richer when the article cites multiple sources.
+4. `create_file` the new article at the red link's `target_path`. Standard four-section body (`Question` / `Current answer` / `Evidence` / `Open threads`) with inline source citations. Drops 1-2 forward-looking red links in Open Threads to keep the queue alive.
 
 Writer **only creates new articles**. No `edit_file` in its whitelist; no fallback "write from scratch when queue is empty" branch — empty queue → no-op.
 

--- a/packages/arkeon/src/server/agents/templates/proposer.yaml
+++ b/packages/arkeon/src/server/agents/templates/proposer.yaml
@@ -89,7 +89,23 @@ system: |-
        list_entities(type="wiki", limit=100)
        list_redlinks(limit=50)
 
-  6. Identify the GAP. For each candidate question the source raises,
+  6. **Search the broader corpus** for adjacent material on the
+     source's main themes. The questions you propose will be
+     answered by the writer, who follows the plan's citations to
+     pick source material — so if the plan only mentions THIS
+     source, the writer never knows the rest of the corpus has
+     parallel material. For each major theme the source raises,
+     run search() across the rest of the source-class:
+
+       search(query=["<concept noun>", "<author-vocabulary variant>"],
+              type="file", limit=10)
+
+     (The corpus may organize sources by author, by paper, by
+     domain — search by content, not by directory. Read enough of
+     the top hits to confirm thematic relevance, then keep their
+     paths handy for step 8.)
+
+  7. Identify the GAP. For each candidate question the source raises,
      SKIP if:
        (a) An existing article that cites this source already covers
            it (the editor handled it in its tick).
@@ -101,7 +117,7 @@ system: |-
      NONE of (a)/(b)/(c) covers. 0-6 candidates per source is
      typical after gap-filtering.
 
-  7. `create_file` the plan wiki at **exactly** `wiki/_plans/<slug>.html`
+  8. `create_file` the plan wiki at **exactly** `wiki/_plans/<slug>.html`
      where `<slug>` is the source path under `sources/` with directory
      separators replaced by `__` (double underscore) and the file
      extension stripped:
@@ -124,7 +140,11 @@ system: |-
        (e) Cite the source inline in the Summary paragraph with a
            working `<a href>` — this is what makes the plan wiki
            legibly belong to the source.
-       (f) List proposed red links in `<h2>Proposed articles</h2>`.
+       (f) **Also cite the cross-source material you found in step
+           6** — name the adjacent sources by inline link in the
+           Summary so the writer's `read_files` chain picks them up
+           when it drains a red link from this plan.
+       (g) List proposed red links in `<h2>Proposed articles</h2>`.
            Use 0 entries if the editor fully integrated everything;
            the empty plan is still a legitimate artifact.
 
@@ -142,9 +162,13 @@ system: |-
          <body>
            <h1>Plan: <short title></h1>
            <h2>Summary</h2>
-           <p>One paragraph: what's in the source, and what the editor
-              already integrated (briefly). Cite the source:
-              <a href="../../sources/...">…</a>.</p>
+           <p>One paragraph: what's in the source, what the editor
+              already integrated, and which OTHER source(s) in the
+              corpus speak to the same themes (so the writer knows
+              where else to look). Cite the primary source inline:
+              <a href="../../sources/...">…</a>, plus any cross-source
+              parallels:
+              <a href="../../sources/...other...">…</a>.</p>
            <h2>Proposed articles</h2>
            <ul>
              <li><a href="../<slug>.html">question shaped as a sentence?</a>
@@ -154,7 +178,7 @@ system: |-
          </body>
          </html>
 
-  8. Mark the source as processed. The server reads the entity's
+  9. Mark the source as processed. The server reads the entity's
      current `source_hash` and stores it under the key
      `proposer.processed_hash` for you — you don't handle the hash
      yourself.
@@ -166,7 +190,7 @@ system: |-
      longer matches, and `tag_outdated="proposer.processed_hash"`
      re-surfaces the source in your queue.
 
-  9. Reply with ONE LINE summarizing the tick:
+  10. Reply with ONE LINE summarizing the tick:
        "Proposed 4 red links from sources/X.md (editor already
         integrated 3 concepts; 4 gaps remain)."
        "No gaps to propose from sources/X.md (editor integrated

--- a/packages/arkeon/src/server/agents/templates/proposer.yaml
+++ b/packages/arkeon/src/server/agents/templates/proposer.yaml
@@ -97,13 +97,14 @@ system: |-
      parallel material. For each major theme the source raises,
      run search() across the rest of the source-class:
 
-       search(query=["<concept noun>", "<author-vocabulary variant>"],
+       search(query=["<concept noun>", "<close synonym>", "<related-vocabulary variant>"],
               type="file", limit=10)
 
-     (The corpus may organize sources by author, by paper, by
-     domain — search by content, not by directory. Read enough of
-     the top hits to confirm thematic relevance, then keep their
-     paths handy for step 8.)
+     (Search by content, not by directory. The corpus may organize
+     sources by author, paper, domain, or anything else — what
+     matters is whether other files cover the same theme. Read
+     enough of the top hits to confirm thematic relevance, then
+     keep their paths handy for step 8.)
 
   7. Identify the GAP. For each candidate question the source raises,
      SKIP if:

--- a/packages/arkeon/src/server/agents/templates/writer.yaml
+++ b/packages/arkeon/src/server/agents/templates/writer.yaml
@@ -68,11 +68,22 @@ system: |-
      (Use the singular `read_file` only when there's exactly one
      source.)
 
-  4. Optionally `search()` across sources for adjacent material if
-     the linking articles or plan don't give you enough context:
+  4. **Search the broader corpus** for adjacent material on the
+     question's central concept. The source(s) the plan/linker
+     cited are a starting point, not the whole picture — most
+     questions are richer when the article cites multiple sources,
+     and a corpus with two or more discrete source-classes (e.g.
+     two authors, multiple papers, distinct domains) almost always
+     has cross-source angles worth surfacing. Run search() with
+     2-3 noun variants of the concept:
 
        search(query=["<noun phrase>", "<variant>", "<another>"],
               type="file", limit=10)
+
+     Then `read_files` whatever the search surfaces that the plan
+     didn't already point you at. Only skip this step if the
+     question is genuinely confined to one source's territory
+     (and you can justify that in the one-line reply).
 
   5. Write the article via `create_file` at the red link's
      `target_path`. The article is a full HTML document; the tool


### PR DESCRIPTION
## Summary

Two prompt-only changes to the bundled role templates that fix a real failure mode surfaced during the SETUP.md walkthrough: on a corpus with two source-classes (Augustine + Chesterton), **56% of articles cited only one author**, even though both authors spoke to nearly every theme.

## Root cause

Two cooperating shortcuts in the prompts:

- **Writer step 4** read: *"Optionally search() across sources for adjacent material if the linking articles or plan don't give you enough context."* The model treats "I got one source from the plan → I have enough context → skip" — so cross-source weaving rarely happens at writer time.
- **Proposer plans** only ever cited the one source they were generated from. Without parallels in the plan's Summary, the writer's `get_entity`/`read_files` chain has nothing else to follow. **17 of 17 plan wikis** cited exactly one source.

The 44% of articles that DID cross authors got there *retroactively* — the editor adding citations as new sources were processed. Real but slow and asymmetric (almost always 1 + N).

## Changes

- **`writer.yaml` step 4**: reframed from "Optionally search…" to a default step. The model is now told to search for the central concept across the broader corpus and `read_files` whatever the plan didn't already point at. Single-source escape hatch is still there for questions genuinely confined to one author's territory, but the default is cross-source.
- **`proposer.yaml` new step 6**: search the broader corpus for thematically-adjacent material on the source's main themes, then cite the parallels in the plan's Summary inline so the writer's read chain picks them up naturally.
- **`proposer.yaml` plan-wiki template**: Summary paragraph now explicitly invites cross-source citation, and the structural-requirements list gains a "(f) cite the cross-source material you found in step 6" item.

Subsequent step numbering in `proposer.yaml` is bumped to keep the tick sequence consistent.

## Operator-side validation

The live Augustine/Chesterton walkthrough corpus had this exact issue. I added an equivalent clause to `defaults.instructions:` on that wiki, and the very next writer tick produced an article ("Why does outrage feel like sanity?") that genuinely weaves both authors in the same paragraph:

> Augustine says passions do not become true by becoming louder; they become true only when they are governed by love of the right end… Chesterton makes the same point from the other side: the modern mind mistakes being "critical" for being clean.

> Augustine would call that disordered love; Chesterton would call it a false balance.

The upstream-template version of the fix should produce that behavior for any operator running a multi-source-class corpus, without their having to write the cross-weaving instruction by hand.

## Test plan

- [x] `npm run typecheck -w packages/arkeon` clean
- [x] `npm test -w packages/arkeon` — 263/263 (templates are YAML, no test asserts prompt content directly, but structural parsing is unchanged)
- [x] Validated equivalent operator override on the live walkthrough corpus — next writer tick cross-cited both authors in the same paragraph
- [ ] Manual: drop the new templates against a different two-source-class corpus to confirm the effect generalizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)