### PR TITLE
reader: decode percent-escapes so files with spaces/& aren't red-linked

### DIFF
--- a/packages/arkeon/src/server/lib/html-links.ts
+++ b/packages/arkeon/src/server/lib/html-links.ts
@@ -55,8 +55,19 @@ export function resolveHref(href: string, fromPath: string): string | null {
   const clean = href.split(/[#?]/, 1)[0];
   if (!clean) return null;
 
+  // Hrefs are URL-encoded; entity source_paths are real filesystem strings.
+  // Decode percent-escapes (`%20` → space, `%26` → `&`, ...) so the resolved
+  // path is comparable to what's on disk. Without this, links to files whose
+  // names contain spaces or other reserved chars render as red links.
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(clean);
+  } catch {
+    decoded = clean;
+  }
+
   const fromDir = posix.dirname(fromPath);
-  const resolved = posix.normalize(posix.join(fromDir, clean));
+  const resolved = posix.normalize(posix.join(fromDir, decoded));
 
   if (resolved.startsWith("../") || resolved === ".." || resolved.startsWith("/")) {
     return null;

--- a/packages/arkeon/test/unit/html-links.test.ts
+++ b/packages/arkeon/test/unit/html-links.test.ts
@@ -53,6 +53,25 @@ describe("resolveHref", () => {
     expect(resolveHref("../../etc/passwd", "wiki/foo.html")).toBeNull();
     expect(resolveHref("../../../foo", "wiki/biology/x.html")).toBeNull();
   });
+
+  it("decodes percent-escaped path segments", () => {
+    expect(
+      resolveHref(
+        "../IARPA_Bengal/Milestones%20%26%20Schedules/A1/Data/README.md",
+        "wiki/foo.html",
+      ),
+    ).toBe("IARPA_Bengal/Milestones & Schedules/A1/Data/README.md");
+    expect(resolveHref("../My%20Notes/x.html", "wiki/foo.html")).toBe(
+      "My Notes/x.html",
+    );
+  });
+
+  it("tolerates malformed percent encoding", () => {
+    // Invalid `%` sequence → fall back to the raw string rather than throw.
+    expect(resolveHref("../foo%2/bar.html", "wiki/x.html")).toBe(
+      "foo%2/bar.html",
+    );
+  });
 });
 
 describe("extractHtmlLinks", () => {

--- a/packages/arkeon/test/unit/reader.test.ts
+++ b/packages/arkeon/test/unit/reader.test.ts
@@ -69,6 +69,22 @@ describe("classifyAnchor", () => {
       "arkeon-redlink",
     ]);
   });
+
+  it("matches percent-escaped hrefs against decoded entity paths", () => {
+    // Filenames with spaces/`&` are URL-encoded in hrefs but stored as
+    // real characters in entities.source_path. Without decoding, these
+    // would falsely flag as red links.
+    const knownEncoded = new Set([
+      "files/Milestones & Schedules/README.md",
+    ]);
+    expect(
+      classifyAnchor(
+        "../files/Milestones%20%26%20Schedules/README.md",
+        from,
+        knownEncoded,
+      ),
+    ).toEqual(["arkeon-file"]);
+  });
 });
 
 describe("instrumentArticle", () => {


### PR DESCRIPTION
## Summary

- `resolveHref` never `decodeURIComponent`d the href before comparing against `entities.source_path`, so anchors into directories whose names contain spaces or `&` (URL-encoded as `%20`/`%26` in HTML) never matched the `knownPaths` set and rendered as red links even when the target was on disk.
- Fix: decode after stripping fragment/query; tolerate malformed encoding by falling back to the raw string. Same fix transparently corrects the relationships sync going forward (both call sites share `resolveHref`).

## Reproducer

Article at `wiki/what-counts-as-results.html` (iarpa space) links to `../IARPA_Bengal/Milestones%20%26%20Schedules/A1%20Self%20Evaluation%20T%26E/Data/v1.0/rag-kg-comparison/README.md`. File exists on disk. Pre-fix render tags it `arkeon-redlink`; post-fix it tags `arkeon-file`.

## Follow-up (not in this PR)

Existing `relationships` rows still carry the encoded `target_path`s and won't be rewritten until each article is next edited (sync short-circuits on unchanged `source_hash`). The rendering is correct immediately, but `GET /:space/redlinks` (and therefore the writer agent's queue) will still show stale false positives until a re-sync. Worth a separate one-time migration that wipes `relationships` and rebuilds from current article content — filing as a follow-up issue.

## Test plan

- [x] `npm run typecheck -w packages/arkeon`
- [x] `npm test -w packages/arkeon -- --run test/unit/html-links.test.ts test/unit/reader.test.ts` (39/39 pass; new cases cover decoded `%20`/`%26`, malformed `%` fallback, and `classifyAnchor` end-to-end)
- [ ] Manually reload the affected article in the iarpa space after daemon restart; confirm the RAG vs KG README link no longer renders red

🤖 Generated with [Claude Code](https://claude.com/claude-code)