### PR TITLE
reader: sort the article index by most-recently-updated first

### DIFF
--- a/packages/arkeon/src/server/lib/reader.ts
+++ b/packages/arkeon/src/server/lib/reader.ts
@@ -186,8 +186,8 @@ export interface ArticleIndexRow {
 }
 
 /**
- * Render the per-space alphabetical article index. Each row links to
- * the wiki article via its on-disk path under `/{space}/wiki/...`.
+ * Render the per-space article index. Rendered in input order — the
+ * caller decides the sort (the route picks most-recently-updated first).
  *
  * `label` falls back to the bare filename if missing (the writer is
  * supposed to emit `<title>`, so this is just defensive).
@@ -196,15 +196,7 @@ export function renderArticleIndex(
   spaceName: string,
   articles: ArticleIndexRow[],
 ): string {
-  const sorted = [...articles].sort((a, b) => {
-    const al = (a.label ?? posix.basename(a.source_path)).toLowerCase();
-    const bl = (b.label ?? posix.basename(b.source_path)).toLowerCase();
-    if (al < bl) return -1;
-    if (al > bl) return 1;
-    return 0;
-  });
-
-  const rows = sorted
+  const rows = articles
     .map((a) => {
       const display = escapeHtml(a.label ?? posix.basename(a.source_path));
       const href = `/${encodeURIComponent(spaceName)}/${a.source_path
@@ -241,7 +233,7 @@ export function renderArticleIndex(
   <p class="crumb"><a href="/">&larr; spaces</a></p>
   <h1>${escapeHtml(spaceName)}</h1>
   <ul>
-${sorted.length === 0 ? empty : rows}
+${articles.length === 0 ? empty : rows}
   </ul>
 </body>
 </html>

--- a/packages/arkeon/src/server/lib/sync.ts
+++ b/packages/arkeon/src/server/lib/sync.ts
@@ -109,13 +109,16 @@ async function syncWiki(
         SET label = ${label},
             source_hash = ${hash},
             properties = ${propsJson},
-            updated_at = datetime('now')
+            updated_at = strftime('%Y-%m-%d %H:%M:%f', 'now')
         WHERE space_name = ${space.name} AND source_path = ${relativePath}
       `;
     } else {
+      // updated_at is set explicitly with ms precision (matching the UPDATE
+      // branch) so the "latest first" sort in the article index can break
+      // ties on entities created in the same second.
       await tx`
-        INSERT INTO entities (space_name, source_path, type, label, source_hash, properties)
-        VALUES (${space.name}, ${relativePath}, 'wiki', ${label}, ${hash}, ${propsJson})
+        INSERT INTO entities (space_name, source_path, type, label, source_hash, properties, updated_at)
+        VALUES (${space.name}, ${relativePath}, 'wiki', ${label}, ${hash}, ${propsJson}, strftime('%Y-%m-%d %H:%M:%f', 'now'))
       `;
     }
 
@@ -167,15 +170,15 @@ async function syncSource(
       SET label = ${label},
           source_hash = ${hash},
           properties = ${propsJson},
-          updated_at = datetime('now')
+          updated_at = strftime('%Y-%m-%d %H:%M:%f', 'now')
       WHERE space_name = ${space.name} AND source_path = ${relativePath}
     `;
     return { action: "updated", type: "file", label, linksExtracted: 0 };
   }
 
   await sql`
-    INSERT INTO entities (space_name, source_path, type, label, source_hash, properties)
-    VALUES (${space.name}, ${relativePath}, 'file', ${label}, ${hash}, ${propsJson})
+    INSERT INTO entities (space_name, source_path, type, label, source_hash, properties, updated_at)
+    VALUES (${space.name}, ${relativePath}, 'file', ${label}, ${hash}, ${propsJson}, strftime('%Y-%m-%d %H:%M:%f', 'now'))
   `;
   return { action: "created", type: "file", label, linksExtracted: 0 };
 }

--- a/packages/arkeon/src/server/routes/reader.ts
+++ b/packages/arkeon/src/server/routes/reader.ts
@@ -102,6 +102,7 @@ readerRouter.get("/:space/", async (c) => {
     SELECT source_path, label, properties
     FROM entities
     WHERE space_name = ${space} AND type = 'wiki'
+    ORDER BY updated_at DESC, source_path ASC
   `;
   const articles: ArticleIndexRow[] = rows.map((r) => {
     let shortDescription: string | null = null;

--- a/packages/arkeon/test/e2e/reader.test.ts
+++ b/packages/arkeon/test/e2e/reader.test.ts
@@ -143,7 +143,16 @@ describe("Phase 2 reader", () => {
     expect(res.headers.get("location")).toBe(`/${SPACE}/`);
   });
 
-  it("GET /:space/ returns an alphabetical article index", async () => {
+  it("GET /:space/ returns the article index with most-recently-updated first", async () => {
+    // Write a new wiki *after* the corpus is already synced — its
+    // updated_at will be strictly later than the original two, so it
+    // must render above them regardless of any tie-breaker.
+    writeFileSync(
+      join(workdir, "wiki/late-arrival.html"),
+      `<!doctype html><html><head><title>Late Arrival</title></head><body><h1>Late Arrival</h1></body></html>`,
+    );
+    await waitForEntity(SPACE, "wiki/late-arrival.html");
+
     const res = await fetch(`${baseUrl}/${SPACE}/`);
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toMatch(/text\/html/);
@@ -155,11 +164,17 @@ describe("Phase 2 reader", () => {
     expect(body).toContain(
       `<a href="/${SPACE}/wiki/photosynthesis.html">Photosynthesis</a>`,
     );
+    expect(body).toContain(
+      `<a href="/${SPACE}/wiki/late-arrival.html">Late Arrival</a>`,
+    );
     expect(body).toContain("How plants convert light into chemical energy.");
 
+    const lateIdx = body.indexOf(">Late Arrival<");
     const choIdx = body.indexOf(">Chlorophyll<");
     const phoIdx = body.indexOf(">Photosynthesis<");
-    expect(choIdx).toBeLessThan(phoIdx); // alphabetical
+    expect(lateIdx).toBeGreaterThan(0);
+    expect(lateIdx).toBeLessThan(choIdx);
+    expect(lateIdx).toBeLessThan(phoIdx);
   });
 
   it("GET /:space/wiki/* returns the article with chrome and link classes", async () => {

--- a/packages/arkeon/test/unit/reader.test.ts
+++ b/packages/arkeon/test/unit/reader.test.ts
@@ -189,17 +189,19 @@ describe("renderSpaceIndex", () => {
 });
 
 describe("renderArticleIndex", () => {
-  it("sorts alphabetically by label (case-insensitive)", () => {
+  it("preserves input order (the route sorts by updated_at DESC)", () => {
     const out = renderArticleIndex("demo", [
       { source_path: "wiki/zebra.html", label: "Zebra", short_description: null },
       { source_path: "wiki/apple.html", label: "apple", short_description: null },
       { source_path: "wiki/banana.html", label: "Banana", short_description: null },
     ]);
-    const appleIdx = out.indexOf("apple");
-    const bananaIdx = out.indexOf("Banana");
-    const zebraIdx = out.indexOf("Zebra");
+    // Use path strings (unique to each row) rather than labels (which can
+    // collide with CSS like `-apple-system`).
+    const zebraIdx = out.indexOf("/demo/wiki/zebra.html");
+    const appleIdx = out.indexOf("/demo/wiki/apple.html");
+    const bananaIdx = out.indexOf("/demo/wiki/banana.html");
+    expect(zebraIdx).toBeLessThan(appleIdx);
     expect(appleIdx).toBeLessThan(bananaIdx);
-    expect(bananaIdx).toBeLessThan(zebraIdx);
   });
 
   it("links to /:space/<source_path>", () => {


### PR DESCRIPTION
## Summary

- `GET /:space/` previously rendered alphabetically by label. Switch to `updated_at DESC, source_path ASC` so newly created/edited wikis float to the top — much more useful when an agent is actively producing.
- Sort is pushed into SQL; `renderArticleIndex` now renders in input order so the route owns the policy.
- Bumps `syncFile`'s `updated_at` writes (both INSERT and UPDATE) to millisecond precision (`strftime('%Y-%m-%d %H:%M:%f', 'now')`). Production worked fine at second precision, but the e2e test exposed that concurrent same-second writes tied unpredictably — ms precision is a small fix that makes the new sort stable.

Mixed-precision DB rows are safe: the format remains text-sortable (`"2026-05-14 22:21:33.456"` sorts after `"2026-05-14 22:21:33"`), and lex comparisons used by `updated_since` filters still behave correctly. Existing rows pick up ms precision the next time they're touched.

## Test plan

- [x] `npm run typecheck -w packages/arkeon`
- [x] `npm test -w packages/arkeon` — 306/306 pass
- [x] `npm run test:e2e -w packages/arkeon` — 53/53 pass (existing e2e rewritten to verify "latest first": writes a fresh wiki post-bootstrap and asserts it renders above the original two)
- [ ] Visit `/iarpa/` after deploy and confirm the most recently written wikis are at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)