### PR TITLE
entities: cross-space inbound in getEntity

### DIFF
--- a/packages/arkeon/src/server/agents/tools.ts
+++ b/packages/arkeon/src/server/agents/tools.ts
@@ -694,11 +694,18 @@ function decorateEntity(entity: EntityDetail) {
     space_url: spaceUrl(entity.space_name, entity.source_path),
     outbound: entity.outbound.map((o) => ({
       ...o,
+      // target_path is already canonical for cross-space (starts with
+      // `/{otherSpace}/...`) — spaceUrl passes those through verbatim;
+      // in-space targets get prefixed with the entity's own space.
       space_url: spaceUrl(entity.space_name, o.target_path),
     })),
     inbound: entity.inbound.map((i) => ({
       ...i,
-      space_url: spaceUrl(entity.space_name, i.source_path),
+      // Build space_url from the linker's space, NOT the target's —
+      // cross-space inbound rows live in the linker's space, and the
+      // URL we hand back must point at the source article in its
+      // real home (e.g. `/spaceA/wiki/bar.html` when A links into B).
+      space_url: spaceUrl(i.space_name, i.source_path),
     })),
   };
 }

--- a/packages/arkeon/src/server/lib/entities.ts
+++ b/packages/arkeon/src/server/lib/entities.ts
@@ -451,10 +451,21 @@ export function parseEntityTypes(raw: string | null | undefined): EntityType[] |
 /**
  * Fetch a single entity by (space_name, source_path) including outbound
  * relationships. Returns null if the entity does not exist.
+ *
+ * `inbound` is queried across **every** space — relationships rows in
+ * other spaces that point at the canonical `/{this_space}/{path}`
+ * cross-space form surface here as well, so consumers can answer
+ * "who from any space cites this entity?" in one call. Each inbound
+ * row carries `space_name` (the linker's space) so the consumer can
+ * distinguish in-space citers from cross-space ones.
  */
 export interface EntityDetail extends EntityListRow {
   outbound: Array<{ target_path: string; link_text: string | null }>;
-  inbound: Array<{ source_path: string; link_text: string | null }>;
+  inbound: Array<{
+    space_name: string;
+    source_path: string;
+    link_text: string | null;
+  }>;
 }
 
 export async function getEntity(
@@ -478,9 +489,16 @@ export async function getEntity(
     SELECT target_path, link_text FROM relationships
     WHERE space_name = ${space_name} AND source_path = ${source_path}
   `;
+  // Inbound includes two shapes of relationships row:
+  //   - same-space:  (space_name = us, target_path = our path)
+  //   - cross-space: (any space, target_path = "/{us}/{our path}")
+  // Both come from a single SQL query so we don't pay the round-trip cost
+  // of two separate selects.
+  const crossTarget = `/${space_name}/${source_path}`;
   const inbound = await sql`
-    SELECT source_path, link_text FROM relationships
-    WHERE space_name = ${space_name} AND target_path = ${source_path}
+    SELECT space_name, source_path, link_text FROM relationships
+    WHERE (space_name = ${space_name} AND target_path = ${source_path})
+       OR target_path = ${crossTarget}
   `;
 
   return {
@@ -499,6 +517,7 @@ export async function getEntity(
       link_text: r.link_text as string | null,
     })),
     inbound: inbound.map((r) => ({
+      space_name: r.space_name as string,
       source_path: r.source_path as string,
       link_text: r.link_text as string | null,
     })),

--- a/packages/arkeon/test/e2e/agent-runtime.test.ts
+++ b/packages/arkeon/test/e2e/agent-runtime.test.ts
@@ -610,6 +610,106 @@ describe("get_entity tool", () => {
     await execTool<GetEntityResult>(tool, { path: "wiki/a.html" });
     expect(ctx.readPaths.size).toBe(0);
   });
+
+  describe("cross-space inbound aggregation", () => {
+    interface CrossInboundRow {
+      space_name: string;
+      source_path: string;
+      link_text: string | null;
+      space_url: string;
+    }
+    interface CrossEntityFound {
+      found: true;
+      entity: {
+        space_name: string;
+        source_path: string;
+        inbound: CrossInboundRow[];
+      };
+    }
+
+    it("surfaces inbound rows from other spaces (linker's space_name and space_url)", async () => {
+      // Set up a second space as a sibling watch_dir so the rewriter
+      // produces a real cross-space target_path (canonical `/other/...`)
+      // in the relationships table.
+      const otherDir = mkdtempSync(join(tmpdir(), "arkeon-rt-xinbound-"));
+      mkdirSync(join(otherDir, "wiki"), { recursive: true });
+      const sql = createSql();
+      await sql`INSERT INTO spaces(name, watch_dir) VALUES('other', ${otherDir})`;
+
+      try {
+        // Plant a target entity in the OTHER space — that's the one
+        // we'll then query for its cross-space inbound.
+        writeFileSync(
+          join(otherDir, "wiki/target.html"),
+          `<!DOCTYPE html><html><head><meta charset="utf-8"><title>T</title></head>
+<body><h1>T</h1></body></html>`,
+        );
+        await syncFile(
+          { name: "other", watch_dir: otherDir },
+          "wiki/target.html",
+        );
+
+        // From the triggering space (rt-test), have an agent create an
+        // article that cites the target via cross-space form.
+        const ctx = makeContext(SPACE, "writer");
+        const create = getTool("create_file", ctx);
+        await execTool(create, {
+          path: "wiki/citer.html",
+          html: `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Citer</title></head>
+<body><p>cites <a href="/other/wiki/target.html">the target</a></p></body>
+</html>`,
+        });
+
+        // Now have a (cross-space-aware) agent query the target from a
+        // role with allowedSpaces = both spaces, and confirm it sees
+        // the rt-test linker.
+        const multiCtx = makeContext(
+          { name: "other", watch_dir: otherDir },
+          "writer",
+          {
+            allowedSpaces: [
+              { name: "other", watch_dir: otherDir },
+              SPACE,
+            ],
+          },
+        );
+        const getEntityTool = getTool("get_entity", multiCtx);
+        const result = await execTool<CrossEntityFound>(getEntityTool, {
+          path: "wiki/target.html",
+          space: "other",
+        });
+
+        expect(result.found).toBe(true);
+        // The inbound array carries the linker's home space and a
+        // space_url that points back into THAT space.
+        const xInbound = result.entity.inbound.find(
+          (r) => r.space_name === SPACE.name,
+        );
+        expect(xInbound).toBeDefined();
+        expect(xInbound!.source_path).toBe("wiki/citer.html");
+        expect(xInbound!.space_url).toBe(`/${SPACE.name}/wiki/citer.html`);
+      } finally {
+        rmSync(otherDir, { recursive: true, force: true });
+      }
+    });
+
+    it("in-space inbound rows still carry the entity's own space_name", async () => {
+      await setupGraph();
+      const ctx = makeContext(SPACE, "writer");
+      const tool = getTool("get_entity", ctx);
+      const result = await execTool<CrossEntityFound>(tool, {
+        path: "wiki/b.html",
+      });
+      expect(result.found).toBe(true);
+      const inSpace = result.entity.inbound.find(
+        (r) => r.source_path === "wiki/a.html",
+      );
+      expect(inSpace).toBeDefined();
+      expect(inSpace!.space_name).toBe(SPACE.name);
+      expect(inSpace!.space_url).toBe(`/${SPACE.name}/wiki/a.html`);
+    });
+  });
 });
 
 describe("deletion semantics", () => {


### PR DESCRIPTION
Stacked on top of #157.

## Summary

Multi-space agents (a future connector role with `spaces: [\"*\"]`, or any role configured to read across multiple spaces) need to answer **"who from any space cites this entity?"** — but the prior `getEntity` filtered inbound by `space_name`, so a relationship row created in space A pointing at `/B/wiki/foo.html` was invisible when calling `getEntity(\"B\", \"wiki/foo.html\")`.

`getEntity` now runs a single inbound query that matches both shapes:
- same-space rows  (`space_name = us AND target_path = our path`)
- cross-space rows (`target_path = \"/{us}/{our path}\"`, any space)

`EntityDetail.inbound` rows now carry `space_name` (the linker's home space). The `decorateEntity` helper in `tools.ts` builds `space_url` from each row's actual `space_name` rather than the target's, so the URL points back to the source article in its real home.

Cost: one extra SQL predicate (the OR clause) per `get_entity` call. No schema change, no new tables, no write-path complication. The HTTP `/{space}/entities/{path}` endpoint inherits the new shape via the existing `{...entity}` spread.

## Test plan

- `npm run typecheck` — clean
- `npm test` — 348 unit tests pass
- `npm run test:e2e` — 62 e2e tests pass (added 2):
  - Cross-space inbound surfaces with the linker's `space_name` and a `space_url` pointing back into the linker's space
  - In-space inbound still carries the entity's own `space_name`

## What this unblocks

The next PR adds a bundled `connector` role with `spaces: [\"*\"]` whose job is to find surprising cross-space connections. Without this fix it could *find* connections via search but couldn't see them reflected back via `get_entity` — the most natural "what cites this?" query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)