### PR TITLE
agents: connector role — cross-space synthesis finder

### DIFF
--- a/packages/arkeon/scripts/manual-connector-test.ts
+++ b/packages/arkeon/scripts/manual-connector-test.ts
@@ -1,0 +1,248 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Manual connector smoke test — fires the bundled connector role
+// against a two-space corpus designed to have a clear cross-space
+// thematic overlap, then inspects the result.
+//
+// Not shipped: developer-time smoke test for the connector PR.
+// Run from packages/arkeon:
+//   OPENAI_API_KEY=… npx tsx scripts/manual-connector-test.ts
+
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runMigrations } from "../src/schema/migrate.js";
+import { closeDb, createSql, initDb } from "../src/server/lib/sql.js";
+import { syncFile, type Space } from "../src/server/lib/sync.js";
+import { ALL_TOOLS } from "../src/server/agents/tools.js";
+import { runAgent } from "../src/server/agents/runtime.js";
+import { buildAgentRole } from "../src/server/agents/role-builder.js";
+
+function banner(s: string) {
+  console.log("\n" + "─".repeat(60));
+  console.log("▌ " + s);
+  console.log("─".repeat(60));
+}
+
+async function main() {
+  if (!process.env.OPENAI_API_KEY) {
+    console.error("OPENAI_API_KEY required");
+    process.exit(1);
+  }
+
+  // Two sibling watch_dirs — both "registered" via the spaces table,
+  // so resolveAllowedSpaces("*") fans out across both.
+  const rootDir = mkdtempSync(join(tmpdir(), "arkeon-connector-"));
+  const augustineDir = join(rootDir, "augustine");
+  const iarpaDir = join(rootDir, "iarpa");
+  mkdirSync(augustineDir, { recursive: true });
+  mkdirSync(iarpaDir, { recursive: true });
+  const dbPath = join(rootDir, "arke.db");
+
+  console.log("rootDir:", rootDir);
+
+  try {
+    await runMigrations({ dbPath });
+    initDb(dbPath);
+
+    const AUGUSTINE: Space = { name: "augustine", watch_dir: augustineDir };
+    const IARPA: Space = { name: "iarpa", watch_dir: iarpaDir };
+    const sql = createSql();
+    await sql`INSERT INTO spaces(name, watch_dir) VALUES('augustine', ${augustineDir})`;
+    await sql`INSERT INTO spaces(name, watch_dir) VALUES('iarpa', ${iarpaDir})`;
+
+    // Augustine space: an article about restless will, plus its source.
+    mkdirSync(join(augustineDir, "wiki"), { recursive: true });
+    mkdirSync(join(augustineDir, "sources"), { recursive: true });
+    writeFileSync(
+      join(augustineDir, "sources/confessions-x.txt"),
+      `Augustine, Confessions X (paraphrase): The heart is divided
+because it pursues many goods at once. Restlessness is the
+structural state of a will that cannot consolidate around a single
+end. "Our heart is restless until it rests in Thee" names the
+diagnosis as much as the cure — the cure being consolidation, not
+mere stillness.`,
+    );
+    writeFileSync(
+      join(augustineDir, "wiki/why-the-heart-is-restless.html"),
+      `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Why is the heart restless?</title>
+  <meta name="label" content="Why is the heart restless?">
+  <meta name="short_description" content="Augustine's diagnosis of restlessness as the structural state of a divided will.">
+</head>
+<body>
+  <h1>Why is the heart restless?</h1>
+  <h2>Question</h2>
+  <p>Restlessness feels like an emotional weather rather than a
+  structural fact. Why does Augustine treat it as the latter?</p>
+  <h2>Current answer</h2>
+  <p>Augustine's diagnosis is that the heart is restless because the
+  will is divided: it pursues many ends simultaneously and cannot
+  consolidate around any one. Consolidation around "one thing, the
+  highest thing" is named both the cure and the missing condition
+  (see <a href="../sources/confessions-x.txt">Confessions X</a>).</p>
+  <h2>Evidence</h2>
+  <p>The source frames restlessness not as a mood but as the natural
+  consequence of split desire — a structural rather than psychological
+  fact (<a href="../sources/confessions-x.txt">Confessions X</a>).</p>
+  <h2>Open threads</h2>
+  <ul>
+    <li>What does consolidation actually look like in practice?</li>
+  </ul>
+</body>
+</html>`,
+    );
+
+    // IARPA space: an article on attention/distraction with a similar
+    // structural diagnosis from a totally different vocabulary.
+    mkdirSync(join(iarpaDir, "wiki"), { recursive: true });
+    mkdirSync(join(iarpaDir, "sources"), { recursive: true });
+    writeFileSync(
+      join(iarpaDir, "sources/multiplexing-paper.txt"),
+      `Smith (2024), "Computational Attention and the Multitasking
+Illusion": Modern distraction is not a failure of will but a
+structural feature of computational environments. The OS-level
+multiplexing of attention IS the harm. Every notification is a
+context switch with measurable cognitive cost. The paper argues for
+"attentional fasting" as the structural response: remove the
+substrate of distraction rather than discipline the user.`,
+    );
+    writeFileSync(
+      join(iarpaDir, "wiki/why-multiplexing-harms-attention.html"),
+      `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Why does multiplexing harm attention?</title>
+  <meta name="label" content="Why does multiplexing harm attention?">
+  <meta name="short_description" content="Context-switching cost as a structural argument for why divided attention cannot rest.">
+</head>
+<body>
+  <h1>Why does multiplexing harm attention?</h1>
+  <h2>Question</h2>
+  <p>Distraction is usually framed as a personal failing. Is it
+  actually a structural property of the system the mind runs in?</p>
+  <h2>Current answer</h2>
+  <p>Smith's argument is that distraction is a property of the
+  scheduling environment, not the operator. The OS-level multiplexing
+  of attention imposes a measurable cost per context switch; rest is
+  unreachable because the substrate keeps splitting attention against
+  the user's will (<a href="../sources/multiplexing-paper.txt">Smith
+  2024</a>).</p>
+  <h2>Evidence</h2>
+  <p>The paper makes the structural claim explicit: "The OS-level
+  multiplexing of attention IS the harm"
+  (<a href="../sources/multiplexing-paper.txt">Smith 2024</a>). The
+  proposed remedy — attentional fasting — is architectural rather
+  than disciplinary.</p>
+  <h2>Open threads</h2>
+  <ul>
+    <li>How does this map onto older accounts of divided desire?</li>
+  </ul>
+</body>
+</html>`,
+    );
+
+    // Sync everything so the relationship graph + tag queue exist.
+    await syncFile(AUGUSTINE, "sources/confessions-x.txt");
+    await syncFile(AUGUSTINE, "wiki/why-the-heart-is-restless.html");
+    await syncFile(IARPA, "sources/multiplexing-paper.txt");
+    await syncFile(IARPA, "wiki/why-multiplexing-harms-attention.html");
+
+    // Confirm cross-space inbound is empty before the connector runs.
+    const sql2 = createSql();
+    const inboundBefore = await sql2`
+      SELECT space_name, source_path, target_path FROM relationships
+      WHERE target_path LIKE '/%'
+    `;
+    console.log("Cross-space relationships BEFORE connector run:", inboundBefore);
+
+    // Fire the connector against the augustine space. spaces: ["*"]
+    // → multi-space, but writes target augustine.
+    const role = buildAgentRole("connector", {});
+    banner("FIRING CONNECTOR (real OpenAI call, multi-space)");
+    const start = Date.now();
+    const result = await runAgent(role, { space: AUGUSTINE }, ALL_TOOLS);
+    const ms = Date.now() - start;
+    console.log(`Connector finished in ${(ms / 1000).toFixed(1)}s`);
+    console.log("steps:", result.steps);
+    console.log("text:", result.text);
+    console.log(
+      "edits:",
+      result.edits.map((e) => ({ kind: e.kind, path: e.path })),
+    );
+    if (result.usage) console.log("usage:", result.usage);
+
+    banner("ON-DISK INSPECTION (augustine space)");
+    for (const edit of result.edits) {
+      const filePath = join(augustineDir, edit.path);
+      if (!existsSync(filePath)) {
+        console.log(`MISSING ON DISK: ${edit.path}`);
+        continue;
+      }
+      const content = readFileSync(filePath, "utf-8");
+      console.log(`\n── ${edit.kind}: ${edit.path} (${content.length} bytes) ──`);
+      console.log(content);
+
+      // Audit cross-space hrefs: did the connector reference IARPA's
+      // article via a clean cross-space link? After the rewriter
+      // resolves it, on-disk should have a filesystem-relative path
+      // ending in iarpa/wiki/...
+      const crossSpaceHits = (content.match(/href="[^"]*iarpa\/[^"]*"/g) ?? []);
+      console.log("cross-space hrefs found:", crossSpaceHits);
+
+      const spaceUrlLeak = (content.match(/href="\/[^"]+"/g) ?? []).filter(
+        (h) => !/^href="(https?:|mailto:|tel:)/.test(h),
+      );
+      if (spaceUrlLeak.length > 0) {
+        console.log("⚠ /-prefixed hrefs leaked on disk:", spaceUrlLeak);
+      } else {
+        console.log("✓ no /-prefixed hrefs leaked on disk");
+      }
+    }
+
+    banner("RELATIONSHIPS AFTER");
+    const allRels = await sql2`
+      SELECT space_name, source_path, target_path FROM relationships
+      ORDER BY space_name, source_path, target_path
+    `;
+    for (const r of allRels) console.log(r);
+
+    banner("CROSS-SPACE EDGES");
+    const crossEdges = await sql2`
+      SELECT space_name, source_path, target_path FROM relationships
+      WHERE target_path LIKE '/%'
+    `;
+    if (crossEdges.length === 0) {
+      console.log("⚠ No cross-space edges created.");
+    } else {
+      for (const r of crossEdges) console.log(r);
+    }
+
+    banner("CONNECTOR TAG STATE");
+    const tags = await sql2`
+      SELECT space_name, source_path, tags FROM entities
+      WHERE tags LIKE '%connector.processed_hash%'
+    `;
+    for (const r of tags) console.log(r);
+  } finally {
+    closeDb();
+    console.log("\nKept rootDir for inspection:", rootDir);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/arkeon/scripts/manual-rewriter-test.ts
+++ b/packages/arkeon/scripts/manual-rewriter-test.ts
@@ -1,0 +1,209 @@
+// Manual rewriter smoke test — fires a real LLM via the bundled
+// writer role against a fresh tiny corpus, then inspects the
+// on-disk output and the relationships table.
+//
+// Not shipped: this is a developer-time smoke test for issue #134.
+// Run from packages/arkeon:
+//   OPENAI_API_KEY=… npx tsx scripts/manual-rewriter-test.ts
+
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runMigrations } from "../src/schema/migrate.js";
+import { closeDb, createSql, initDb } from "../src/server/lib/sql.js";
+import { syncFile, type Space } from "../src/server/lib/sync.js";
+import { ALL_TOOLS } from "../src/server/agents/tools.js";
+import { runAgent } from "../src/server/agents/runtime.js";
+import { buildAgentRole } from "../src/server/agents/role-builder.js";
+
+function banner(s: string) {
+  console.log("\n" + "─".repeat(60));
+  console.log("▌ " + s);
+  console.log("─".repeat(60));
+}
+
+async function main() {
+  if (!process.env.OPENAI_API_KEY) {
+    console.error("OPENAI_API_KEY required");
+    process.exit(1);
+  }
+
+  const workdir = mkdtempSync(join(tmpdir(), "arkeon-manual-"));
+  const dbPath = join(workdir, "arke.db");
+  console.log("workdir:", workdir);
+
+  try {
+    await runMigrations({ dbPath });
+    initDb(dbPath);
+
+    const SPACE: Space = { name: "manual-test", watch_dir: workdir };
+    const sql = createSql();
+    await sql`INSERT INTO spaces(name, watch_dir) VALUES(${SPACE.name}, ${workdir})`;
+
+    mkdirSync(join(workdir, "sources"), { recursive: true });
+    mkdirSync(join(workdir, "wiki"), { recursive: true });
+
+    writeFileSync(
+      join(workdir, "sources/notes-on-attention.txt"),
+      `Augustine on attention (paraphrase, Confessions X):
+The mind is divided. We pursue many goods at once, never
+committing. A heart pulled in directions cannot rest. This is
+the structure of restlessness — the will scattered across
+simultaneously-pursued ends. Healing requires consolidation
+around one thing, the highest thing.`,
+    );
+
+    writeFileSync(
+      join(workdir, "sources/modern-distraction-paper.txt"),
+      `Excerpt from "Computational Attention and the Multitasking
+Illusion" (Smith, 2024): Modern distraction is not a failure
+of will but a structural feature of computational environments.
+The OS-level multiplexing of attention IS the harm. Every
+notification is a context switch with measurable cognitive
+cost. The paper argues for "attentional fasting" as the
+structural response: removing the substrate of distraction
+rather than disciplining the user.`,
+    );
+
+    writeFileSync(
+      join(workdir, "wiki/why-does-the-heart-stay-restless.html"),
+      `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Why does the heart stay restless?</title>
+  <meta name="label" content="Why does the heart stay restless?">
+  <meta name="short_description" content="Augustine's restless heart, recast as a structural diagnosis of modern attention.">
+</head>
+<body>
+  <h1>Why does the heart stay restless?</h1>
+  <h2>Current answer</h2>
+  <p>The restlessness is structural: a will scattered across
+  simultaneous ends cannot consolidate around any of them.
+  See <a href="../sources/notes-on-attention.txt">Augustine's
+  paraphrase</a>.</p>
+  <h2>Open threads</h2>
+  <ul>
+    <li><a href="modern-attention-as-os-multiplexing.html">how does
+    OS-level multiplexing relate to scattered will?</a> — the
+    structural argument from Smith may be a contemporary form of
+    this older insight.</li>
+  </ul>
+</body>
+</html>`,
+    );
+
+    await syncFile(SPACE, "sources/notes-on-attention.txt");
+    await syncFile(SPACE, "sources/modern-distraction-paper.txt");
+    await syncFile(SPACE, "wiki/why-does-the-heart-stay-restless.html");
+
+    const redlinks = await sql`
+      SELECT target_path, COUNT(*) AS demand FROM relationships r
+      LEFT JOIN entities e ON e.space_name = r.space_name AND e.source_path = r.target_path
+      WHERE r.space_name = ${SPACE.name} AND e.source_path IS NULL
+        AND r.target_path NOT LIKE '/%'
+      GROUP BY target_path
+    `;
+    console.log("Queued red links:", redlinks);
+
+    async function fireRole(name: "writer" | "editor" | "proposer") {
+      const role = buildAgentRole(name, {});
+      banner(`FIRING ${name.toUpperCase()} (real OpenAI call)`);
+      const start = Date.now();
+      const result = await runAgent(role, { space: SPACE }, ALL_TOOLS);
+      const ms = Date.now() - start;
+      console.log(`${name} finished in ${(ms / 1000).toFixed(1)}s`);
+      console.log("steps:", result.steps);
+      console.log("text:", result.text);
+      console.log(
+        "edits:",
+        result.edits.map((e) => ({ kind: e.kind, path: e.path })),
+      );
+      if (result.usage) console.log("usage:", result.usage);
+      return result;
+    }
+
+    function auditFile(label: string, filePath: string) {
+      if (!existsSync(filePath)) {
+        console.log(`MISSING ON DISK: ${label}`);
+        return;
+      }
+      const content = readFileSync(filePath, "utf-8");
+      console.log(`\n── ${label} (${content.length} bytes) ──`);
+      console.log(content);
+
+      const spaceUrlHits = (content.match(/href="\/[^"]+"/g) ?? []).filter(
+        (h) => !/^href="(https?:|mailto:|tel:)/.test(h),
+      );
+      if (spaceUrlHits.length > 0) {
+        console.log("⚠ FOUND /-prefixed hrefs on disk:", spaceUrlHits);
+      } else {
+        console.log("✓ no /-prefixed hrefs on disk");
+      }
+
+      const relHrefs = (content.match(/href="[^"]+"/g) ?? []).filter(
+        (h) => !/^href="(https?:|mailto:|tel:|#|\/)/.test(h),
+      );
+      console.log("relative hrefs found:", relHrefs);
+    }
+
+    const writerResult = await fireRole("writer");
+
+    banner("ON-DISK INSPECTION (writer output)");
+    for (const edit of writerResult.edits) {
+      if (edit.kind !== "create") continue;
+      auditFile(edit.path, join(workdir, edit.path));
+    }
+
+    // Editor pass — exercises edit_file with str_replace (asymmetric
+    // rewrite) and insert_at_line.
+    const editorResult = await fireRole("editor");
+    banner("ON-DISK INSPECTION (after editor)");
+    for (const edit of editorResult.edits) {
+      auditFile(`${edit.kind}: ${edit.path}`, join(workdir, edit.path));
+    }
+
+    // Proposer pass — exercises nested plan-path layout
+    // (wiki/_plans/sources/...) which depends on rewriter handling
+    // deeper directories than v0's flatten workaround allowed.
+    const proposerResult = await fireRole("proposer");
+    banner("ON-DISK INSPECTION (proposer output)");
+    for (const edit of proposerResult.edits) {
+      if (edit.kind !== "create") continue;
+      auditFile(edit.path, join(workdir, edit.path));
+    }
+
+    banner("RELATIONSHIPS AUDIT");
+    const allRels = await sql`
+      SELECT source_path, target_path, link_text FROM relationships
+      WHERE space_name = ${SPACE.name}
+      ORDER BY source_path, target_path
+    `;
+    for (const r of allRels) console.log(r);
+
+    banner("RED LINKS AFTER");
+    const rlAfter = await sql`
+      SELECT target_path, COUNT(*) AS demand FROM relationships r
+      LEFT JOIN entities e ON e.space_name = r.space_name AND e.source_path = r.target_path
+      WHERE r.space_name = ${SPACE.name} AND e.source_path IS NULL
+        AND r.target_path NOT LIKE '/%'
+      GROUP BY target_path
+    `;
+    console.log(rlAfter);
+  } finally {
+    closeDb();
+    console.log("\nKept workdir for inspection:", workdir);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/arkeon/scripts/manual-rewriter-test.ts
+++ b/packages/arkeon/scripts/manual-rewriter-test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Manual rewriter smoke test — fires a real LLM via the bundled
 // writer role against a fresh tiny corpus, then inspects the
 // on-disk output and the relationships table.

--- a/packages/arkeon/src/server/agents/templates/connector.yaml
+++ b/packages/arkeon/src/server/agents/templates/connector.yaml
@@ -1,0 +1,192 @@
+provider: openai
+model: gpt-5.4-mini
+reasoning_effort: low
+spaces: ["*"]
+tools:
+  - read_file
+  - read_files
+  - list_entities
+  - get_entity
+  - get_entities
+  - search
+  - edit_file
+  - create_file
+  - mark_processed
+max_steps: 30
+cron: "*/30 * * * *"
+system: |-
+  You are the **connector** for a multi-space wiki. Your job is to
+  find surprising thematic connections between articles across spaces
+  and either (a) extend an existing article in your home space with a
+  citation that points across to the other space, or (b) create a
+  new synthesis article in your home space when the connection is
+  substantive enough to deserve its own page. You never modify
+  another space's contents — your write surface is locked to the
+  triggering space by the runtime.
+
+  This role reads across EVERY registered space (`spaces: ["*"]`).
+  Your home space is `{{space_name}}` — that's where all your
+  `create_file` and `edit_file` calls land. Every other space is
+  read-only for you. When you cite material from another space, you
+  cite it via its `space_url` — paste the field directly into the
+  `<a href>` and the server rewrites it to the right cross-space
+  path.
+
+  ── How a tick works ──────────────────────────────────────────────
+
+  1. Pick ONE wiki in YOUR space that you haven't surveyed at its
+     current content hash:
+
+       list_entities(space="{{space_name}}",
+                     type="wiki",
+                     tag_outdated="connector.processed_hash",
+                     sort="updated_at",
+                     limit=10,
+                     include_counts=true)
+
+     If nothing comes back, reply "no work this tick — every wiki
+     surveyed at its current hash" and stop. Don't invent connections.
+
+  2. Read the chosen article in full.
+
+       read_file(path=<the article>, space="{{space_name}}")
+
+     Pay attention to its central concepts — the words and ideas the
+     article hinges on. Those drive the search in step 3.
+
+  3. Survey OTHER spaces for thematically adjacent material. For each
+     allowed space that isn't your own, search by the chosen
+     article's central concept(s). The `search` tool fans out by
+     default; if you want a single-space scope, pass `space`
+     explicitly:
+
+       search(query=["<central concept>", "<close synonym>", "<variant>"],
+              type="wiki", limit=10)
+
+     For sources that look on-theme, batch-read them and the wiki
+     hits in one call:
+
+       read_files(paths=[<paths from search hits>])
+
+     ALSO consider `get_entity` on your own article — `inbound`
+     across all spaces (queried at request time) shows you who
+     already cites this article, including from other spaces. That
+     can short-circuit the search when the connection already exists
+     in one direction.
+
+  4. Decide whether there's a genuine connection. Tests:
+
+     - **Shared concept, not just shared vocabulary.** Two articles
+       that both contain "attention" but mean different things
+       (machine-learning attention vs. attention as moral
+       orientation) are NOT a connection. Two articles that use
+       different vocabulary for the same underlying concept ARE.
+     - **Substantive, not decorative.** "These both mention
+       Augustine" is decorative. "Both diagnose restlessness as
+       structural rather than psychological" is substantive.
+     - **Not already cited from this side.** Check the article's
+       outbound list. If it already cites the cross-space target,
+       skip — the connection's been made.
+
+     If no connection survives those tests, `mark_processed` the
+     article (so this tick doesn't repeat the same survey on the
+     next tick) and stop with one line: "Surveyed
+     `wiki/<slug>.html`; no cross-space connection."
+
+  5. If a connection survives, pick ONE of two actions:
+
+     **Inline citation** — preferred for narrow connections:
+     `edit_file mode='insert_at_line'` into the Evidence section of
+     your article, adding a single citation-bearing paragraph that
+     names the cross-space source by inline link. Lead with a
+     strong-claim header (`<strong>...</strong>`) that states the
+     connection in one sentence, then 1-3 sentences of body.
+
+     Example body:
+       <p><strong>Augustine's diagnosis recurs in modern attention
+       research.</strong> The structural account of split desire in
+       <a href="/{{space_name}}/sources/notes-on-attention.txt">Augustine's
+       paraphrase</a> reappears as a computational claim in
+       <a href="/iarpa/wiki/why-multiplexing-harms-attention.html">why
+       multiplexing harms attention</a>, where context-switching cost
+       is offered as the modern operationalization of the same
+       phenomenon. The two sources share a structural — not merely
+       analogical — story about why a divided mind cannot rest.</p>
+
+     **New synthesis article** — for connections too thematic for a
+     single inline citation. `create_file` a new wiki in your space
+     whose Question is the cross-space pattern itself, citing the
+     contributing articles via cross-space links. Use the standard
+     four-section body (Question / Current answer / Evidence / Open
+     threads). Reserve this for connections that are genuinely a
+     new thesis, not a footnote.
+
+  6. `mark_processed` the article you surveyed:
+
+       mark_processed(path=<the article>, role="connector",
+                      space="{{space_name}}")
+
+     The tag (`connector.processed_hash`) invalidates automatically
+     when the article's content changes, so a later edit re-surfaces
+     it in your queue. Cross-space content changes do NOT invalidate
+     the tag — that's a known limitation; the connector revisits an
+     article when its OWN content shifts, plus opportunistically on
+     other articles in the rotation.
+
+  7. Reply with ONE LINE:
+     "Connected `wiki/<my-article>.html` to `/<other-space>/wiki/<their-article>.html`
+      via inline citation in Evidence."
+     "Surveyed `wiki/<slug>.html`; no cross-space connection."
+
+  ── Single-space fallback ─────────────────────────────────────────
+
+  If `{{space_name}}` is the only registered space (you'll see this
+  in your allowed-spaces list above), apply the same survey to
+  articles WITHIN your own space — looking for connections that the
+  editor and proposer haven't already made. The editor integrates
+  individual sources into existing articles; the proposer creates
+  plan wikis for gap-filling; you find the patterns that span
+  multiple articles, multiple sources, in unexpected ways. Same
+  decision rules apply: substantive, not decorative; novel, not
+  already cited.
+
+  ── What you DO NOT do ────────────────────────────────────────────
+
+  - Edit articles in any space OTHER than `{{space_name}}`. The
+    runtime enforces this — `edit_file` and `create_file` always
+    target your home space — but state it explicitly so the
+    intention is clear.
+  - Manufacture connections. A weak or surface-level overlap should
+    end with `mark_processed` and a "no connection" reply.
+    Connections that only the LLM finds surprising aren't actually
+    surprising. Aim for connections a careful human reader would
+    recognize as meaningful.
+  - Duplicate the editor's job. If your home space's editor would
+    naturally pick this up on its own next tick, don't pre-empt it.
+    Your value is the cross-space dimension that the editor
+    (single-space-only) can't see.
+  - Drop forward-looking red links unless writing a synthesis
+    article. Inline-citation edits stay tight — no speculative
+    red links inserted as side effects.
+
+  ── Link conventions ──────────────────────────────────────────────
+
+  Every `<a href>` you author uses **space-rooted URL form**:
+
+      → article in your space:        /{{space_name}}/wiki/<slug>.html
+      → source in your space:         /{{space_name}}/<source-path>
+      → article in another space:     /<other-space>/wiki/<slug>.html
+      → source in another space:      /<other-space>/<source-path>
+
+  Every tool result that mentions an entity carries a `space_url`
+  field — paste it straight into your `<a href>`. The server
+  rewrites these to correct on-disk relative paths at persist time.
+  Never compute `../` depth yourself.
+user: |-
+  This is a scheduled tick. Find one wiki in your home space that
+  you haven't surveyed at its current content hash, look for a
+  substantive cross-space connection (or in-space if single-space),
+  and either insert an inline citation, create a synthesis article,
+  or mark the article processed with "no connection" — one decision
+  per tick. If no wiki in your queue, reply "no work this tick" and
+  stop.

--- a/packages/arkeon/src/server/agents/templates/editor.yaml
+++ b/packages/arkeon/src/server/agents/templates/editor.yaml
@@ -74,8 +74,8 @@ system: |-
            paragraph in the Evidence section. Lead with a strong-claim
            header like `<strong>...</strong>`, then 1-3 sentences that
            cite the source via an inline
-           `<a href="../sources/...">` anchor. Add density; do NOT
-           paraphrase what's already there.
+           `<a href="/{{space_name}}/sources/...">` anchor. Add
+           density; do NOT paraphrase what's already there.
 
          - OR `edit_file mode='str_replace'` to revise the Current
            Answer when the source meaningfully reshapes the thesis.
@@ -142,16 +142,21 @@ system: |-
   re-read before the next edit on that file. (Insertions shift line
   numbers; replaces shift bytes.)
 
-  ── Link path math ────────────────────────────────────────────────
+  ── Link conventions ──────────────────────────────────────────────
 
-  Edits to articles use article-relative paths. From a wiki at
-  `wiki/<slug>.html`:
+  Every `<a href>` you insert uses **space-rooted URL form** — never
+  relative paths, never `../`, never depth math:
 
-      sibling article:     `<a href="other-article.html">`
-      source from wiki/:   `<a href="../sources/notes.txt">`
+      → sibling article (your space):  /{{space_name}}/wiki/<slug>.html
+      → source         (your space):  /{{space_name}}/<source-path>
+      → cross-space (v0.5+):           /<other-space>/wiki/<slug>.html
 
-  Never use workspace-rooted paths (`/wiki/...`) — they're reserved
-  for v0.5 cross-space refs.
+  Your current space is `{{space_name}}`. Every tool result that
+  mentions an entity (`list_entities`, `list_redlinks`, `get_entity`)
+  carries a `space_url` field — paste it straight into the `<a href>`.
+  The server rewrites these to correct on-disk relative paths at
+  persist time, so articles still open in `file://` without the
+  daemon.
 
   ── What you DO NOT do ────────────────────────────────────────────
 

--- a/packages/arkeon/src/server/agents/templates/proposer.yaml
+++ b/packages/arkeon/src/server/agents/templates/proposer.yaml
@@ -118,19 +118,17 @@ system: |-
      NONE of (a)/(b)/(c) covers. 0-6 candidates per source is
      typical after gap-filtering.
 
-  8. `create_file` the plan wiki at **exactly** `wiki/_plans/<slug>.html`
-     where `<slug>` is the source path under `sources/` with directory
-     separators replaced by `__` (double underscore) and the file
-     extension stripped:
+  8. `create_file` the plan wiki at `wiki/_plans/<source-path>.html`
+     — mirror the source path under `_plans/` and replace the file
+     extension with `.html`:
 
-       sources/notes.txt              → wiki/_plans/notes.html
-       sources/book-02-ii.txt         → wiki/_plans/book-02-ii.html
-       sources/Augustine/book-04.md   → wiki/_plans/Augustine__book-04.html
+       sources/notes.txt              → wiki/_plans/sources/notes.html
+       sources/book-02-ii.txt         → wiki/_plans/sources/book-02-ii.html
+       sources/Augustine/book-04.md   → wiki/_plans/sources/Augustine/book-04.html
+       meeting_notes/transcript.txt   → wiki/_plans/meeting_notes/transcript.html
 
-     Every plan wiki sits at exactly one level below `_plans/`. NEVER
-     mirror the source directory structure into subfolders under
-     `_plans/` — flat plan paths keep link math deterministic (see
-     below).
+     Subfolders are fine — the rewriter handles depth so plan paths
+     can carry the source's structure without breaking links.
 
      The plan wiki MUST:
        (a) Start with `<!DOCTYPE html>` (required by create_file).
@@ -167,12 +165,12 @@ system: |-
               already integrated, and which OTHER source(s) in the
               corpus speak to the same themes (so the writer knows
               where else to look). Cite the primary source inline:
-              <a href="../../sources/...">…</a>, plus any cross-source
-              parallels:
-              <a href="../../sources/...other...">…</a>.</p>
+              <a href="/{{space_name}}/sources/...">…</a>, plus any
+              cross-source parallels:
+              <a href="/{{space_name}}/sources/...other...">…</a>.</p>
            <h2>Proposed articles</h2>
            <ul>
-             <li><a href="../<slug>.html">question shaped as a sentence?</a>
+             <li><a href="/{{space_name}}/wiki/<slug>.html">question shaped as a sentence?</a>
                  — one-sentence gloss of what this new article would answer.</li>
              ...
            </ul>
@@ -208,23 +206,21 @@ system: |-
     bad:   `why-does-grief-feel-sweet-in-augustine.html` (too long)
     bad:   `grief.html` (topic, not question)
 
-  ── Link paths from a plan wiki ───────────────────────────────────
+  ── Link conventions ──────────────────────────────────────────────
 
-  Because plans always live at `wiki/_plans/<slug>.html` (depth 1
-  below `wiki/`, depth 2 below the workspace root), there is exactly
-  ONE link pattern per target type. No depth-counting. No exceptions.
+  Every `<a href>` uses **space-rooted URL form** — never relative
+  paths, never `../`, never depth math:
 
-      plan → article (slot in wiki/):  ../<article-slug>.html
-      plan → source file:              ../../sources/<source-path>
+      plan → article (your space):  /{{space_name}}/wiki/<slug>.html
+      plan → source  (your space):  /{{space_name}}/<source-path>
+      cross-space (v0.5+):          /<other-space>/wiki/<slug>.html
 
-  Examples (plan at `wiki/_plans/Augustine__book-04.html`):
-
-      <a href="../why-is-grief-sweet.html">…</a>
-      <a href="../../sources/Augustine/book-04.md">…</a>
-
-  If you find yourself writing `../../` or `../../../` to reach
-  another article slot, you have miscounted — articles are siblings
-  of `_plans/`, exactly one `../` away. Recheck before submitting.
+  Your current space is `{{space_name}}`. Every tool result that
+  mentions an entity (`list_redlinks`, `get_entity`, `list_entities`,
+  `search`) carries a `space_url` field — paste it straight into the
+  `<a href>`. The server rewrites these to correct on-disk relative
+  paths at persist time, so plan wikis still open in `file://`
+  without the daemon.
 
   ── What you DO NOT do ────────────────────────────────────────────
 

--- a/packages/arkeon/src/server/agents/templates/writer.yaml
+++ b/packages/arkeon/src/server/agents/templates/writer.yaml
@@ -139,7 +139,7 @@ system: |-
         <h2>Current answer</h2>
         <p>...</p>
         <h2>Evidence</h2>
-        <p>The argument that <a href="../sources/foo.txt">desire is
+        <p>The argument that <a href="/{{space_name}}/sources/foo.txt">desire is
         infinite</a>...</p>
         <h2>Open threads</h2>
         <p>...</p>
@@ -176,21 +176,27 @@ system: |-
 
   ── Link conventions ─────────────────────────────────────────────
 
-  Articles ALWAYS live at exactly `wiki/<slug>.html` — flat, no
-  subfolders under `wiki/`. That single rule fixes the link patterns
-  to just two forms:
+  Every `<a href>` uses **space-rooted URL form** — never relative
+  paths, never `../`, never depth math:
 
-      article → article:  <a href="<other-slug>.html">
-      article → source:   <a href="../sources/<source-path>">
+      article → article (your space):  /{{space_name}}/wiki/<other-slug>.html
+      article → source  (your space):  /{{space_name}}/<source-path>
+      cross-space (v0.5+):             /<other-space>/wiki/<slug>.html
 
-  No `../../`, no `../../../`, no subfolder hops. If you find
-  yourself computing `..` depth, you have misread an existing file —
-  every article is a sibling of every other article.
+  Your current space is `{{space_name}}`. So a link from your new
+  article to a sibling at `wiki/why-grief-is-sweet.html` is
+  `<a href="/{{space_name}}/wiki/why-grief-is-sweet.html">`, and a
+  citation to `sources/augustine/book-04.md` is
+  `<a href="/{{space_name}}/sources/augustine/book-04.md">`.
+
+  Every tool result that mentions an entity (`list_redlinks`,
+  `get_entity`, `list_entities`, `search`) carries a `space_url`
+  field — paste it straight into your `<a href>`. The server rewrites
+  these to correct on-disk relative paths at persist time, so
+  articles still open in `file://` without the daemon. You write
+  canonical; we store resolved.
 
   Don't link an article to itself in its own body.
-
-  Never use workspace-rooted paths (`/wiki/...`) — reserved for
-  v0.5 cross-space refs.
 
   ── What you DO NOT do ────────────────────────────────────────────
 
@@ -204,9 +210,10 @@ system: |-
     editor and proposer feed the queue; if it's empty, you no-op.
   - Tag sources. Source-level tagging belongs to the editor and
     proposer. You operate at the article level.
-  - Create plan wikis. Those belong under `wiki/_plans/<slug>.html`
-    and are the proposer's artifact. Your `create_file` targets are
-    real articles at exactly `wiki/<slug>.html` — flat, no subfolders.
+  - Create plan wikis. Those belong under `wiki/_plans/...` and are
+    the proposer's artifact. Your `create_file` targets are real
+    articles under `wiki/` (subfolders allowed; the rewriter handles
+    paths regardless of depth).
 
   ── Tool semantics ───────────────────────────────────────────────
 

--- a/packages/arkeon/src/server/agents/tools.ts
+++ b/packages/arkeon/src/server/agents/tools.ts
@@ -694,11 +694,18 @@ function decorateEntity(entity: EntityDetail) {
     space_url: spaceUrl(entity.space_name, entity.source_path),
     outbound: entity.outbound.map((o) => ({
       ...o,
+      // target_path is already canonical for cross-space (starts with
+      // `/{otherSpace}/...`) — spaceUrl passes those through verbatim;
+      // in-space targets get prefixed with the entity's own space.
       space_url: spaceUrl(entity.space_name, o.target_path),
     })),
     inbound: entity.inbound.map((i) => ({
       ...i,
-      space_url: spaceUrl(entity.space_name, i.source_path),
+      // Build space_url from the linker's space, NOT the target's —
+      // cross-space inbound rows live in the linker's space, and the
+      // URL we hand back must point at the source article in its
+      // real home (e.g. `/spaceA/wiki/bar.html` when A links into B).
+      space_url: spaceUrl(i.space_name, i.source_path),
     })),
   };
 }

--- a/packages/arkeon/src/server/agents/tools.ts
+++ b/packages/arkeon/src/server/agents/tools.ts
@@ -34,6 +34,7 @@ import {
   listRedLinks,
   parseEntityTypes,
   setEntityTag,
+  type EntityDetail,
   type EntityType,
 } from "../lib/entities.js";
 
@@ -73,6 +74,23 @@ const SPACE_PARAM_DESC =
   "(the triggering space). Omit on a multi-space role to fan out across " +
   "every allowed space (results are tagged with `space` so you can tell " +
   "them apart).";
+
+/**
+ * Build the canonical space-rooted URL form (`/{space}/{path}`) for a
+ * path inside the named space. This is what tool outputs surface as
+ * `space_url` so the agent can copy it straight into an `<a href>` —
+ * the server rewrites that form back to the correct on-disk relative
+ * path at write time.
+ *
+ * Already-canonical inputs (a `target_path` that already starts with
+ * `/` because step 4's `resolveHref` widening produced a cross-space
+ * pointer) pass through unchanged.
+ */
+function spaceUrl(spaceName: string, path: string): string {
+  if (path.startsWith("/")) return path;
+  const segments = path.split("/").map(encodeURIComponent).join("/");
+  return `/${encodeURIComponent(spaceName)}/${segments}`;
+}
 
 /**
  * Format a file's content with line-number prefixes for `read_file`.
@@ -124,6 +142,7 @@ const readFileTool = defineTool("read_file", {
     return {
       path,
       space: target.name,
+      space_url: spaceUrl(target.name, path),
       content: withLineNumbers(raw),
     };
   },
@@ -192,6 +211,7 @@ const readFilesTool = defineTool("read_files", {
         return {
           path,
           space: target.name,
+          space_url: spaceUrl(target.name, path),
           content: withLineNumbers(raw),
         };
       } catch (err) {
@@ -290,10 +310,18 @@ const searchTool = defineTool("search", {
       maxSnippetsPerFile: max_snippets_per_file,
     });
 
+    const decorated = {
+      ...raw,
+      hits: raw.hits.map((h) => ({
+        ...h,
+        space_url: spaceUrl(h.space_name, h.source_path),
+      })),
+    };
+
     return {
       query,
       spaces: targets.map((s) => s.name),
-      keyword: raw,
+      keyword: decorated,
     };
   },
   summarize: (r) => {
@@ -315,8 +343,10 @@ const listEntitiesTool = defineTool("list_entities", {
     "Use to check whether a subject already has a wiki, find unprocessed " +
     "sources (type=file inbound_max=0 → 'nothing links to this file yet'), " +
     "or surface recently-updated articles. Each row carries `space_name`, " +
-    "`source_path`, `type`, `label`, `source_hash`, `properties`, `tags`, " +
-    "and optional `counts.inbound`/`counts.outbound`. `source_hash` is the " +
+    "`source_path`, `space_url` (the canonical `/{space}/{path}` form — " +
+    "paste directly into an <a href>), `type`, `label`, `source_hash`, " +
+    "`properties`, `tags`, and optional `counts.inbound`/`counts.outbound`. " +
+    "`source_hash` is the " +
     "SHA-256 of the file content at last sync — pass it as the `value` to " +
     "`tag_entity` when marking 'I processed this' so content-change " +
     "invalidation works automatically. `properties` is file-derived " +
@@ -517,7 +547,10 @@ const listEntitiesTool = defineTool("list_entities", {
     }
 
     return {
-      entities: allEntities,
+      entities: allEntities.map((e) => ({
+        ...e,
+        space_url: spaceUrl(e.space_name, e.source_path),
+      })),
       total,
       spaces: targets.map((s) => s.name),
     };
@@ -534,10 +567,12 @@ const listEntitiesTool = defineTool("list_entities", {
 const listRedLinksTool = defineTool("list_redlinks", {
   description:
     "List link targets in this space that have no entity (yet). Returns " +
-    "`{target_path, demand, linked_from[]}`, ranked by demand. Use this to " +
-    "find the next article worth writing: high `demand` = many existing " +
-    "articles want this concept defined. `linked_from` shows the last 3 " +
-    "source articles that pointed at the missing target.",
+    "`{target_path, space_url, demand, linked_from[]}`, ranked by demand. " +
+    "`space_url` is the canonical `/{space}/{path}` form — paste directly " +
+    "into the path arg of `create_file` when fulfilling. Use this to find " +
+    "the next article worth writing: high `demand` = many existing articles " +
+    "want this concept defined. `linked_from` shows the last 3 source " +
+    "articles that pointed at the missing target.",
   inputSchema: z.object({
     limit: z
       .number()
@@ -557,12 +592,22 @@ const listRedLinksTool = defineTool("list_redlinks", {
   }),
   call: async ({ limit, offset, space }, ctx) => {
     const targets = resolveToolScope(ctx, space);
-    const all: Array<{ space: string; target_path: string; demand: number; linked_from: string[] }> = [];
+    const all: Array<{
+      space: string;
+      target_path: string;
+      space_url: string;
+      demand: number;
+      linked_from: string[];
+    }> = [];
     let total = 0;
     for (const t of targets) {
       const result = await listRedLinks({ space_name: t.name, limit, offset });
       for (const rl of result.redlinks) {
-        all.push({ space: t.name, ...rl });
+        all.push({
+          space: t.name,
+          space_url: spaceUrl(t.name, rl.target_path),
+          ...rl,
+        });
       }
       total += result.total;
     }
@@ -618,7 +663,7 @@ const getEntityTool = defineTool("get_entity", {
         space: target.name,
       };
     }
-    return { found: true as const, entity };
+    return { found: true as const, entity: decorateEntity(entity) };
   },
   summarize: (r) => {
     if (!r.found) {
@@ -634,6 +679,26 @@ const getEntityTool = defineTool("get_entity", {
     };
   },
 });
+
+/**
+ * Decorate a fetched entity (plus its inbound/outbound link arrays)
+ * with `space_url` fields. Cheaper to do in one place than scatter
+ * `spaceUrl(...)` calls through every consumer.
+ */
+function decorateEntity(entity: EntityDetail) {
+  return {
+    ...entity,
+    space_url: spaceUrl(entity.space_name, entity.source_path),
+    outbound: entity.outbound.map((o) => ({
+      ...o,
+      space_url: spaceUrl(entity.space_name, o.target_path),
+    })),
+    inbound: entity.inbound.map((i) => ({
+      ...i,
+      space_url: spaceUrl(entity.space_name, i.source_path),
+    })),
+  };
+}
 
 /**
  * Tolerant normalization for `get_entity` paths. Stored entity paths
@@ -695,7 +760,7 @@ const getEntitiesTool = defineTool("get_entities", {
             space: target.name,
           };
         }
-        return { found: true as const, entity };
+        return { found: true as const, entity: decorateEntity(entity) };
       }),
     );
     return { space: target.name, results };
@@ -827,7 +892,9 @@ const CREATE_FILE_TEMPLATE = `<!DOCTYPE html>
 </head>
 <body>
   <h1>Article title as a question</h1>
-  <p>Article content with inline <a href="../sources/foo.txt">citations</a>.</p>
+  <p>Article content with inline <a href="/your-space/sources/foo.txt">citations</a>
+  (replace <code>your-space</code> with the actual space name — see role
+  prompt or the <code>space_url</code> field on any tool result).</p>
 </body>
 </html>`;
 

--- a/packages/arkeon/src/server/agents/tools.ts
+++ b/packages/arkeon/src/server/agents/tools.ts
@@ -38,7 +38,7 @@ import {
   type EntityDetail,
   type EntityType,
 } from "../lib/entities.js";
-import { createSql } from "../lib/sql.js";
+import { loadSpacesMap } from "../lib/spaces.js";
 
 import { defineTool, type ToolFactory } from "./define-tool.js";
 import { describeAllowed, resolveSpaceArg } from "./space-scope.js";
@@ -94,21 +94,6 @@ function spaceUrl(spaceName: string, path: string): string {
   return `/${encodeURIComponent(spaceName)}/${segments}`;
 }
 
-/**
- * Pull every registered space into `name → watch_dir`. Used by the
- * href rewriter to resolve cross-space links (`/<other-space>/...`)
- * against the other space's `watch_dir` on disk. Returns an empty
- * map if the spaces table is empty.
- */
-async function loadAllSpaces(): Promise<Map<string, string>> {
-  const sql = createSql();
-  const rows = (await sql`
-    SELECT name, watch_dir FROM spaces WHERE watch_dir IS NOT NULL
-  `) as unknown as Array<{ name: string; watch_dir: string }>;
-  const map = new Map<string, string>();
-  for (const row of rows) map.set(row.name, row.watch_dir);
-  return map;
-}
 
 /**
  * Format a file's content with line-number prefixes for `read_file`.
@@ -862,7 +847,7 @@ const editFileTool = defineTool("edit_file", {
     // relative paths. `old_string` is intentionally NOT rewritten —
     // it must match disk bytes verbatim (i.e. the already-rewritten
     // relative form the agent just read).
-    const spaces = await loadAllSpaces();
+    const spaces = await loadSpacesMap();
     const rewriteOpts = {
       fromPath: input.path,
       spaceName: ctx.space.name,
@@ -973,7 +958,7 @@ const createFileTool = defineTool("create_file", {
     if (failure) {
       throw new Error(formatCreateFileValidationError(failure, html));
     }
-    const spaces = await loadAllSpaces();
+    const spaces = await loadSpacesMap();
     const rewritten = rewriteHrefsForWrite(html, {
       fromPath: path,
       spaceName: ctx.space.name,

--- a/packages/arkeon/src/server/agents/tools.ts
+++ b/packages/arkeon/src/server/agents/tools.ts
@@ -26,6 +26,7 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import { z } from "zod";
 
 import { safeResolve, validateWikiHtmlDocument } from "../lib/file-edits.js";
+import { rewriteHrefsForWrite } from "../lib/href-rewrite.js";
 import { MAX_QUERY_PATTERNS, searchKeyword } from "../lib/search.js";
 import {
   deleteEntityTag,
@@ -37,6 +38,7 @@ import {
   type EntityDetail,
   type EntityType,
 } from "../lib/entities.js";
+import { createSql } from "../lib/sql.js";
 
 import { defineTool, type ToolFactory } from "./define-tool.js";
 import { describeAllowed, resolveSpaceArg } from "./space-scope.js";
@@ -90,6 +92,22 @@ function spaceUrl(spaceName: string, path: string): string {
   if (path.startsWith("/")) return path;
   const segments = path.split("/").map(encodeURIComponent).join("/");
   return `/${encodeURIComponent(spaceName)}/${segments}`;
+}
+
+/**
+ * Pull every registered space into `name → watch_dir`. Used by the
+ * href rewriter to resolve cross-space links (`/<other-space>/...`)
+ * against the other space's `watch_dir` on disk. Returns an empty
+ * map if the spaces table is empty.
+ */
+async function loadAllSpaces(): Promise<Map<string, string>> {
+  const sql = createSql();
+  const rows = (await sql`
+    SELECT name, watch_dir FROM spaces WHERE watch_dir IS NOT NULL
+  `) as unknown as Array<{ name: string; watch_dir: string }>;
+  const map = new Map<string, string>();
+  for (const row of rows) map.set(row.name, row.watch_dir);
+  return map;
 }
 
 /**
@@ -786,7 +804,12 @@ const editFileTool = defineTool("edit_file", {
     "Mandatory protocol: read_file the path FIRST. After a successful edit, " +
     "the read is invalidated — re-read before your next edit on the same path. " +
     "For new files, use create_file (no read needed). To delete a wiki, use " +
-    "delete_wiki (separate tool).",
+    "delete_wiki (separate tool).\n" +
+    "Href handling: hrefs you write in `content` and `new_string` may use " +
+    "space-rooted URL form (`/{space}/{path}`) — the server rewrites them " +
+    "to correct on-disk relative paths. `old_string` is matched verbatim " +
+    "against disk bytes (the already-rewritten relative form), so paste it " +
+    "exactly as `read_file` returned it.",
   inputSchema: z.object({
     mode: z.enum(["insert_at_line", "str_replace"]).describe("Which kind of edit."),
     path: z.string().describe("Relative path inside the space's watch_dir."),
@@ -834,16 +857,29 @@ const editFileTool = defineTool("edit_file", {
       );
     }
 
+    // The rewriter walks `<a>`, `<img>`, `<link>` in the supplied
+    // fragment and translates `/{space}/...` hrefs to on-disk
+    // relative paths. `old_string` is intentionally NOT rewritten —
+    // it must match disk bytes verbatim (i.e. the already-rewritten
+    // relative form the agent just read).
+    const spaces = await loadAllSpaces();
+    const rewriteOpts = {
+      fromPath: input.path,
+      spaceName: ctx.space.name,
+      spaces,
+    };
+
     if (input.mode === "insert_at_line") {
       if (input.line_number == null || input.content == null) {
         throw new Error("edit_file mode='insert_at_line' requires `line_number` and `content`");
       }
+      const content = rewriteHrefsForWrite(input.content, rewriteOpts);
       const result = await ctx.applyEdit(
         {
           kind: "insert_at_line",
           path: input.path,
           line_number: input.line_number,
-          content: input.content,
+          content,
         },
         { edit_kind: "insert_at_line" },
       );
@@ -858,12 +894,13 @@ const editFileTool = defineTool("edit_file", {
       if (input.old_string == null || input.new_string == null) {
         throw new Error("edit_file mode='str_replace' requires `old_string` and `new_string`");
       }
+      const new_string = rewriteHrefsForWrite(input.new_string, rewriteOpts);
       const result = await ctx.applyEdit(
         {
           kind: "str_replace",
           path: input.path,
           old_string: input.old_string,
-          new_string: input.new_string,
+          new_string,
         },
         { edit_kind: "str_replace" },
       );
@@ -936,8 +973,14 @@ const createFileTool = defineTool("create_file", {
     if (failure) {
       throw new Error(formatCreateFileValidationError(failure, html));
     }
+    const spaces = await loadAllSpaces();
+    const rewritten = rewriteHrefsForWrite(html, {
+      fromPath: path,
+      spaceName: ctx.space.name,
+      spaces,
+    });
     const result = await ctx.applyEdit(
-      { kind: "create", path, content: html },
+      { kind: "create", path, content: rewritten },
       { edit_kind: "create" },
     );
     return { path: result.path, mode: "create" as const };

--- a/packages/arkeon/src/server/lib/entities.ts
+++ b/packages/arkeon/src/server/lib/entities.ts
@@ -451,10 +451,21 @@ export function parseEntityTypes(raw: string | null | undefined): EntityType[] |
 /**
  * Fetch a single entity by (space_name, source_path) including outbound
  * relationships. Returns null if the entity does not exist.
+ *
+ * `inbound` is queried across **every** space — relationships rows in
+ * other spaces that point at the canonical `/{this_space}/{path}`
+ * cross-space form surface here as well, so consumers can answer
+ * "who from any space cites this entity?" in one call. Each inbound
+ * row carries `space_name` (the linker's space) so the consumer can
+ * distinguish in-space citers from cross-space ones.
  */
 export interface EntityDetail extends EntityListRow {
   outbound: Array<{ target_path: string; link_text: string | null }>;
-  inbound: Array<{ source_path: string; link_text: string | null }>;
+  inbound: Array<{
+    space_name: string;
+    source_path: string;
+    link_text: string | null;
+  }>;
 }
 
 export async function getEntity(
@@ -478,9 +489,16 @@ export async function getEntity(
     SELECT target_path, link_text FROM relationships
     WHERE space_name = ${space_name} AND source_path = ${source_path}
   `;
+  // Inbound includes two shapes of relationships row:
+  //   - same-space:  (space_name = us, target_path = our path)
+  //   - cross-space: (any space, target_path = "/{us}/{our path}")
+  // Both come from a single SQL query so we don't pay the round-trip cost
+  // of two separate selects.
+  const crossTarget = `/${space_name}/${source_path}`;
   const inbound = await sql`
-    SELECT source_path, link_text FROM relationships
-    WHERE space_name = ${space_name} AND target_path = ${source_path}
+    SELECT space_name, source_path, link_text FROM relationships
+    WHERE (space_name = ${space_name} AND target_path = ${source_path})
+       OR target_path = ${crossTarget}
   `;
 
   return {
@@ -499,6 +517,7 @@ export async function getEntity(
       link_text: r.link_text as string | null,
     })),
     inbound: inbound.map((r) => ({
+      space_name: r.space_name as string,
       source_path: r.source_path as string,
       link_text: r.link_text as string | null,
     })),

--- a/packages/arkeon/src/server/lib/entities.ts
+++ b/packages/arkeon/src/server/lib/entities.ts
@@ -354,6 +354,12 @@ export async function listRedLinks(
   //
   // Replaces the previous N+1 form (aggregate query + per-row linkers
   // fetch). Same shape out, one round-trip instead of (1 + N).
+  //
+  // `target_path NOT LIKE '/%'` filters out cross-space red links
+  // (canonical `/{otherSpace}/{path}` form). The writer is scoped
+  // to its own space and shouldn't try to fulfill another space's
+  // gaps; cross-space inbound edges still live in `relationships`
+  // for graph queries, just not in the per-space writer queue.
   const redlinksSql = `
     WITH red AS (
       SELECT
@@ -366,7 +372,9 @@ export async function listRedLinks(
       FROM relationships r
       LEFT JOIN entities e
         ON e.space_name = r.space_name AND e.source_path = r.target_path
-      WHERE r.space_name = ? AND e.source_path IS NULL
+      WHERE r.space_name = ?
+        AND e.source_path IS NULL
+        AND r.target_path NOT LIKE '/%'
     )
     SELECT
       target_path,
@@ -391,7 +399,9 @@ export async function listRedLinks(
     FROM relationships r
     LEFT JOIN entities e
       ON e.space_name = r.space_name AND e.source_path = r.target_path
-    WHERE r.space_name = ? AND e.source_path IS NULL
+    WHERE r.space_name = ?
+      AND e.source_path IS NULL
+      AND r.target_path NOT LIKE '/%'
   `;
   const totalRow = (await sql.query(totalSql, [opts.space_name])) as unknown as Array<{
     total: number;

--- a/packages/arkeon/src/server/lib/href-rewrite.ts
+++ b/packages/arkeon/src/server/lib/href-rewrite.ts
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Translate space-rooted hrefs (`/{space-name}/{path}`) into the
+ * correct on-disk relative path. Runs before `applyEdit` writes the
+ * content to disk, so the disk form stays as ordinary relative paths
+ * (preserves `file://` parity) but the agent gets to author links in
+ * a depth-independent canonical form. The bake-off in issue #134
+ * documents why agents fail at relative-path arithmetic and why this
+ * sidesteps the failure mode entirely.
+ *
+ * Three classes of href:
+ *
+ *   - **In-space** (`/<this-space>/...`) — strip the prefix, compute
+ *     a posix-relative path from the article's directory to the
+ *     target. Always representable; output is what `<a href>` would
+ *     traditionally hold.
+ *   - **Cross-space** (`/<other-space>/...`) — look up the other
+ *     space's `watch_dir`, compute a filesystem-relative path that
+ *     crosses watch dirs. Brittle if the user later relocates either
+ *     watch_dir, but recoverable (see the auto-fix-on-move follow-up
+ *     in #134). When the other space isn't registered locally, the
+ *     href is left as-is — broken on `file://` and 404 on `http://`,
+ *     which is the correct UX for an unresolved cross-space link.
+ *   - **Anything else** (relative paths, fragments, external URLs)
+ *     — passed through verbatim. Agents that prefer to write
+ *     correct relative paths directly keep working.
+ *
+ * Walks `<a href>`, `<img src>`, and `<link href>`. The same rewriter
+ * runs over full HTML documents (`create_file`) and over snippets
+ * (`insert_at_line` content, `str_replace` new_string) — `node-html-parser`
+ * handles both shapes.
+ *
+ * For `str_replace`: rewrite **only** the new_string. `old_string`
+ * must match disk bytes verbatim, which by definition are the
+ * already-rewritten relative form.
+ */
+
+import { parse as parseHtml } from "node-html-parser";
+import { posix } from "node:path";
+import { relative as fsRelative, resolve as fsResolve } from "node:path";
+
+const SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+
+const REWRITE_TARGETS: ReadonlyArray<{ tag: string; attr: string }> = [
+  { tag: "a", attr: "href" },
+  { tag: "img", attr: "src" },
+  { tag: "link", attr: "href" },
+];
+
+export interface RewriteOpts {
+  /**
+   * Path of the article being edited, relative to its space's
+   * watch_dir (e.g. `wiki/foo.html`, `wiki/_plans/sources/x.html`).
+   * The rewriter computes relative paths *from this file's directory*.
+   */
+  fromPath: string;
+  /** The space the article belongs to. First-segment matches strip-and-relativize. */
+  spaceName: string;
+  /**
+   * Every registered space, keyed by name → absolute `watch_dir`.
+   * Must include the current space.
+   */
+  spaces: ReadonlyMap<string, string>;
+}
+
+/**
+ * Rewrite space-rooted hrefs in a string of HTML (full document or
+ * fragment) and return the serialized result.
+ *
+ * Idempotent: a rewritten output passed back through is left alone
+ * because in-space hrefs are no longer `/`-prefixed.
+ */
+export function rewriteHrefsForWrite(html: string, opts: RewriteOpts): string {
+  const root = parseHtml(html);
+  let mutated = false;
+  for (const { tag, attr } of REWRITE_TARGETS) {
+    for (const el of root.querySelectorAll(tag)) {
+      const value = el.getAttribute(attr);
+      if (value == null) continue;
+      const rewritten = maybeRewriteHref(value, opts);
+      if (rewritten !== null && rewritten !== value) {
+        el.setAttribute(attr, rewritten);
+        mutated = true;
+      }
+    }
+  }
+  // Hand back the original bytes when nothing changed — `node-html-parser`'s
+  // round-trip normalizes whitespace and self-closing tags, which we'd
+  // rather not impose on snippets that didn't need any rewriting.
+  return mutated ? root.toString() : html;
+}
+
+/**
+ * Decide whether an individual href needs rewriting and return its
+ * new value. Returns `null` when the href is in a class we don't
+ * touch (relative, external, fragment, unresolvable cross-space),
+ * which the caller treats as "leave verbatim."
+ */
+export function maybeRewriteHref(
+  href: string,
+  opts: RewriteOpts,
+): string | null {
+  if (SCHEME_RE.test(href)) return null;
+  if (href.startsWith("#")) return null;
+  if (href.startsWith("//")) return null;
+  if (!href.startsWith("/")) return null;
+
+  // Preserve `#fragment` / `?query` suffixes so anchors and viewer
+  // hints round-trip cleanly.
+  const splitAt = href.search(/[#?]/);
+  const pathPart = splitAt === -1 ? href : href.slice(0, splitAt);
+  const suffix = splitAt === -1 ? "" : href.slice(splitAt);
+
+  const rawSegments = pathPart.slice(1).split("/");
+  if (rawSegments.length === 0 || rawSegments[0] === "") return null;
+
+  let decodedSegments: string[];
+  try {
+    decodedSegments = rawSegments.map((s) => decodeURIComponent(s));
+  } catch {
+    // Malformed percent encoding — leave the agent's bytes alone.
+    return null;
+  }
+
+  const firstSegment = decodedSegments[0];
+  const inSpaceParts = decodedSegments.slice(1);
+  const inSpacePath = inSpaceParts.join("/");
+
+  if (firstSegment === opts.spaceName) {
+    const rel = computeInSpaceRelative(opts.fromPath, inSpacePath);
+    return encodeRelPath(rel) + suffix;
+  }
+
+  const otherWatchDir = opts.spaces.get(firstSegment);
+  const thisWatchDir = opts.spaces.get(opts.spaceName);
+  if (otherWatchDir && thisWatchDir) {
+    const rel = computeCrossSpaceRelative(
+      thisWatchDir,
+      opts.fromPath,
+      otherWatchDir,
+      inSpacePath,
+    );
+    return encodeRelPath(rel) + suffix;
+  }
+
+  // First segment matches no registered space. Leave the agent's
+  // bytes alone — a deliberate unresolvable cross-space pointer
+  // should show up as a red link / 404 rather than be silently
+  // mutated into something else.
+  return null;
+}
+
+function computeInSpaceRelative(fromPath: string, targetInSpace: string): string {
+  const fromDir = posix.dirname(fromPath);
+  const rel = posix.relative(fromDir, targetInSpace);
+  return rel === "" ? "." : rel;
+}
+
+function computeCrossSpaceRelative(
+  thisWatchDir: string,
+  fromPath: string,
+  otherWatchDir: string,
+  targetInOtherSpace: string,
+): string {
+  // Watch dirs are absolute filesystem paths; use the OS-native
+  // `path` module (not posix) so Windows separators behave
+  // correctly. Output is normalized back to posix below.
+  const articleAbsDir = fsResolve(thisWatchDir, posix.dirname(fromPath));
+  const targetAbs = fsResolve(otherWatchDir, targetInOtherSpace);
+  const rel = fsRelative(articleAbsDir, targetAbs);
+  const normalized = rel.split(/[\\/]/g).join("/");
+  return normalized === "" ? "." : normalized;
+}
+
+/**
+ * URL-encode each path segment. Matches the existing convention in
+ * `renderArticleIndex` and keeps `resolveHref`'s `decodeURIComponent`
+ * round-trip clean for filenames with spaces, ampersands, etc.
+ */
+function encodeRelPath(p: string): string {
+  return p
+    .split("/")
+    .map((seg) => (seg === ".." || seg === "." ? seg : encodeURIComponent(seg)))
+    .join("/");
+}

--- a/packages/arkeon/src/server/lib/href-rewrite.ts
+++ b/packages/arkeon/src/server/lib/href-rewrite.ts
@@ -39,7 +39,7 @@
 
 import { parse as parseHtml } from "node-html-parser";
 import { posix } from "node:path";
-import { relative as fsRelative, resolve as fsResolve } from "node:path";
+import { relative as fsRelative, resolve as fsResolve, sep as fsSep } from "node:path";
 
 const SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
 
@@ -130,6 +130,7 @@ export function maybeRewriteHref(
 
   if (firstSegment === opts.spaceName) {
     const rel = computeInSpaceRelative(opts.fromPath, inSpacePath);
+    if (rel === null) return null;
     return encodeRelPath(rel) + suffix;
   }
 
@@ -142,6 +143,7 @@ export function maybeRewriteHref(
       otherWatchDir,
       inSpacePath,
     );
+    if (rel === null) return null;
     return encodeRelPath(rel) + suffix;
   }
 
@@ -152,9 +154,25 @@ export function maybeRewriteHref(
   return null;
 }
 
-function computeInSpaceRelative(fromPath: string, targetInSpace: string): string {
+function computeInSpaceRelative(
+  fromPath: string,
+  targetInSpace: string,
+): string | null {
+  // Normalize first so any `..` segments collapse. If the result
+  // still escapes the space root, refuse the rewrite — we don't
+  // emit relative paths that step outside the watch_dir, even when
+  // the agent literally asks for them (`/{thisSpace}/../../etc/passwd`
+  // would otherwise produce a working filesystem-relative link).
+  const normalized = posix.normalize(targetInSpace);
+  if (
+    normalized.startsWith("../") ||
+    normalized === ".." ||
+    normalized.startsWith("/")
+  ) {
+    return null;
+  }
   const fromDir = posix.dirname(fromPath);
-  const rel = posix.relative(fromDir, targetInSpace);
+  const rel = posix.relative(fromDir, normalized);
   return rel === "" ? "." : rel;
 }
 
@@ -163,12 +181,20 @@ function computeCrossSpaceRelative(
   fromPath: string,
   otherWatchDir: string,
   targetInOtherSpace: string,
-): string {
+): string | null {
   // Watch dirs are absolute filesystem paths; use the OS-native
   // `path` module (not posix) so Windows separators behave
   // correctly. Output is normalized back to posix below.
-  const articleAbsDir = fsResolve(thisWatchDir, posix.dirname(fromPath));
+  const normDir = fsResolve(otherWatchDir);
   const targetAbs = fsResolve(otherWatchDir, targetInOtherSpace);
+  // Refuse if the resolved target falls outside the destination
+  // space's watch_dir. Without this guard, `/other/../../etc/passwd`
+  // resolves to `/etc/passwd` and the rewriter happily produces a
+  // valid filesystem-relative href escaping every space root.
+  if (targetAbs !== normDir && !targetAbs.startsWith(normDir + fsSep)) {
+    return null;
+  }
+  const articleAbsDir = fsResolve(thisWatchDir, posix.dirname(fromPath));
   const rel = fsRelative(articleAbsDir, targetAbs);
   const normalized = rel.split(/[\\/]/g).join("/");
   return normalized === "" ? "." : normalized;

--- a/packages/arkeon/src/server/lib/href-rewrite.ts
+++ b/packages/arkeon/src/server/lib/href-rewrite.ts
@@ -187,13 +187,13 @@ function computeCrossSpaceRelative(
   // correctly. Output is normalized back to posix below.
   const normDir = fsResolve(otherWatchDir);
   const targetAbs = fsResolve(otherWatchDir, targetInOtherSpace);
-  // Refuse if the resolved target falls outside the destination
-  // space's watch_dir. Without this guard, `/other/../../etc/passwd`
-  // resolves to `/etc/passwd` and the rewriter happily produces a
-  // valid filesystem-relative href escaping every space root.
-  if (targetAbs !== normDir && !targetAbs.startsWith(normDir + fsSep)) {
-    return null;
-  }
+  // Refuse if the resolved target is the bare watch_dir (no file
+  // path) or falls outside it. The watch_dir-only case matches the
+  // explicit skip in `detectCrossSpace`; the outside case prevents
+  // `/other/../../etc/passwd` from producing a working
+  // filesystem-relative href escaping every space root.
+  if (targetAbs === normDir) return null;
+  if (!targetAbs.startsWith(normDir + fsSep)) return null;
   const articleAbsDir = fsResolve(thisWatchDir, posix.dirname(fromPath));
   const rel = fsRelative(articleAbsDir, targetAbs);
   const normalized = rel.split(/[\\/]/g).join("/");

--- a/packages/arkeon/src/server/lib/html-links.ts
+++ b/packages/arkeon/src/server/lib/html-links.ts
@@ -3,28 +3,30 @@
 
 /**
  * Walk every `<a href="...">` in an HTML wiki and resolve hrefs to
- * space-relative paths. Replaces the old markdown-links + wikilink
- * pipeline.
+ * canonical `target_path` strings for the relationships table.
  *
  * Resolution rules:
- *   - External URLs (anything with a scheme: `https://`, `mailto:`,
- *     `tel:`, etc.) → dropped.
+ *   - External URLs (any scheme: `https://`, `mailto:`, `tel:`, …) → dropped.
  *   - Pure fragments (`#section`) → dropped (no edge to record).
- *   - Server-absolute paths starting with `/` → dropped in v0.
- *     The committed URL scheme reserves `/{other-space}/...` for
- *     cross-space links (v0.5); v0 doesn't emit or follow them.
+ *   - Server-absolute paths (`/{space}/...`) → passed through as the
+ *     canonical cross-space target. These are what the post-write
+ *     rewriter emits when it can't resolve the named space against the
+ *     local registry; preserving them keeps the relationship graph
+ *     intact for unresolvable-yet-intentional cross-space pointers.
  *   - Relative paths → resolved against the article's directory,
- *     normalized, fragment/query stripped.
- *   - Resolved paths that escape the space root (`../../foo`) → dropped.
+ *     normalized, fragment/query stripped. The result is space-relative
+ *     when it stays inside the watch_dir, or the `/{otherSpace}/{path}`
+ *     canonical form when it lands inside a registered sibling space
+ *     (requires `opts.spaces`).
+ *   - Resolved paths that escape into NO registered space → dropped.
  *
  * Returned links carry `href` (original attribute), `text` (anchor body),
- * and `resolved` (the space-relative path the relationship row points
- * at, or `null` if the link is external/unresolvable and should not
- * produce a row).
+ * and `resolved` (the canonical `target_path`, or `null` if the link is
+ * external/unresolvable and should not produce a row).
  */
 
 import { parse } from "node-html-parser";
-import { posix } from "node:path";
+import { posix, resolve as fsResolve, sep as fsSep } from "node:path";
 
 export interface HtmlLink {
   href: string;
@@ -32,25 +34,52 @@ export interface HtmlLink {
   resolved: string | null;
 }
 
-export function extractHtmlLinks(html: string, fromPath: string): HtmlLink[] {
+export interface ResolveOpts {
+  /** Name of the space the article lives in. */
+  thisSpaceName: string;
+  /** Absolute `watch_dir` for the article's space. */
+  thisWatchDir: string;
+  /** Every registered space, keyed by name → absolute `watch_dir`. */
+  spaces: ReadonlyMap<string, string>;
+}
+
+export function extractHtmlLinks(
+  html: string,
+  fromPath: string,
+  opts?: ResolveOpts,
+): HtmlLink[] {
   const root = parse(html);
   const out: HtmlLink[] = [];
   for (const a of root.querySelectorAll("a")) {
     const href = a.getAttribute("href");
     if (!href) continue;
     const text = a.text.trim();
-    out.push({ href, text, resolved: resolveHref(href, fromPath) });
+    out.push({ href, text, resolved: resolveHref(href, fromPath, opts) });
   }
   return out;
 }
 
 const SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
 
-export function resolveHref(href: string, fromPath: string): string | null {
+export function resolveHref(
+  href: string,
+  fromPath: string,
+  opts?: ResolveOpts,
+): string | null {
   if (SCHEME_RE.test(href)) return null;
   if (href.startsWith("#")) return null;
   if (href.startsWith("//")) return null;
-  if (href.startsWith("/")) return null; // cross-space reserved for v0.5
+
+  // Server-absolute path: canonical cross-space target (`/{space}/{path}`).
+  // Pass through verbatim — these are already in the form `target_path`
+  // expects. The post-write rewriter only emits this shape when the named
+  // space isn't registered locally; preserving it lets cross-space pointers
+  // round-trip through sync without being lost.
+  if (href.startsWith("/")) {
+    const clean = href.split(/[#?]/, 1)[0];
+    if (!clean || clean === "/") return null;
+    return clean;
+  }
 
   const clean = href.split(/[#?]/, 1)[0];
   if (!clean) return null;
@@ -70,9 +99,39 @@ export function resolveHref(href: string, fromPath: string): string | null {
   const resolved = posix.normalize(posix.join(fromDir, decoded));
 
   if (resolved.startsWith("../") || resolved === ".." || resolved.startsWith("/")) {
+    // The href escapes this space's watch_dir. If we have a spaces
+    // map, check whether it actually lands inside another registered
+    // space — if so, emit the canonical `/{otherSpace}/{path}` form
+    // so the relationship graph carries the cross-space edge.
+    if (opts) {
+      const cross = detectCrossSpace(decoded, fromPath, opts);
+      if (cross) return cross;
+    }
     return null;
   }
   if (resolved === "." || resolved === "") return null;
 
   return resolved;
+}
+
+function detectCrossSpace(
+  decodedRelativeHref: string,
+  fromPath: string,
+  opts: ResolveOpts,
+): string | null {
+  const articleAbsDir = fsResolve(opts.thisWatchDir, posix.dirname(fromPath));
+  const absTarget = fsResolve(articleAbsDir, decodedRelativeHref);
+  for (const [otherName, otherDir] of opts.spaces) {
+    if (otherName === opts.thisSpaceName) continue;
+    const normDir = fsResolve(otherDir);
+    if (absTarget === normDir) continue; // bare watch_dir; no file path
+    if (!absTarget.startsWith(normDir + fsSep)) continue;
+    const within = absTarget
+      .slice(normDir.length + 1)
+      .split(fsSep)
+      .join("/");
+    if (!within) continue;
+    return `/${otherName}/${within}`;
+  }
+  return null;
 }

--- a/packages/arkeon/src/server/lib/reader.ts
+++ b/packages/arkeon/src/server/lib/reader.ts
@@ -28,7 +28,7 @@
  */
 
 import { parse } from "node-html-parser";
-import { posix } from "node:path";
+import { posix, resolve as fsResolve, sep as fsSep } from "node:path";
 
 import { resolveHref } from "./html-links.js";
 
@@ -65,6 +65,73 @@ export function classifyAnchor(
   return classes;
 }
 
+export interface CrossSpaceTarget {
+  /** The other space's name. */
+  space: string;
+  /** The path within that space's watch_dir. */
+  path: string;
+  /** Any `#fragment` or `?query` suffix on the original href. */
+  suffix: string;
+}
+
+/**
+ * Detect whether a relative href on disk actually resolves into
+ * another registered space's watch_dir. Returns the cross-space
+ * target if so — the reader uses this to rewrite the rendered `href`
+ * back to `/{otherSpace}/{path}` for http:// click-through, since
+ * `../../work/other/wiki/foo.html` would otherwise resolve to a URL
+ * the daemon doesn't serve.
+ *
+ * Returns null for in-space relative hrefs, externals, fragments,
+ * server-absolute paths, and unresolvable escapes (`../../etc/passwd`
+ * style — they're not under any registered space).
+ */
+export function crossSpaceTarget(
+  href: string,
+  fromPath: string,
+  thisSpaceName: string,
+  thisWatchDir: string,
+  spaces: ReadonlyMap<string, string>,
+): CrossSpaceTarget | null {
+  if (!href) return null;
+  if (href.startsWith("#")) return null;
+  if (SCHEME_RE.test(href)) return null;
+  if (href.startsWith("//")) return null;
+  if (href.startsWith("/")) return null;
+
+  const splitAt = href.search(/[#?]/);
+  const pathPart = splitAt === -1 ? href : href.slice(0, splitAt);
+  const suffix = splitAt === -1 ? "" : href.slice(splitAt);
+  if (!pathPart) return null;
+
+  let decoded: string;
+  try {
+    decoded = pathPart
+      .split("/")
+      .map((s) => decodeURIComponent(s))
+      .join("/");
+  } catch {
+    return null;
+  }
+
+  const articleAbsDir = fsResolve(thisWatchDir, posix.dirname(fromPath));
+  const absTarget = fsResolve(articleAbsDir, decoded);
+
+  for (const [otherName, otherDir] of spaces) {
+    if (otherName === thisSpaceName) continue;
+    const normDir = fsResolve(otherDir);
+    if (absTarget === normDir) continue; // bare watch_dir, no file
+    if (!absTarget.startsWith(normDir + fsSep)) continue;
+    const within = absTarget
+      .slice(normDir.length + 1)
+      .split(fsSep)
+      .join("/");
+    if (!within) continue;
+    return { space: otherName, path: within, suffix };
+  }
+  return null;
+}
+
 const CHROME_CSS = `
 #arkeon-chrome {
   position: sticky;
@@ -98,17 +165,62 @@ a.arkeon-redlink:hover { color: #900; text-decoration: underline; }
  * element we skip re-injecting (defensive against double-renders, not a
  * real concern since articles on disk never contain one).
  */
+export interface InstrumentOpts {
+  /**
+   * The article's own space's `watch_dir`, absolute. Needed to
+   * resolve cross-space relative hrefs against the filesystem.
+   * Optional — when omitted (older callers), cross-space rewriting
+   * is disabled.
+   */
+  watchDir?: string;
+  /**
+   * Every registered space, keyed by name → absolute `watch_dir`.
+   * Used to detect cross-space relative hrefs and translate them to
+   * the routed `/{space}/{path}` form for http:// click-through.
+   * Defaults to an empty map (no cross-space rewriting).
+   */
+  spaces?: ReadonlyMap<string, string>;
+}
+
 export function instrumentArticle(
   html: string,
   fromPath: string,
   knownPaths: Set<string>,
   spaceName: string,
+  opts: InstrumentOpts = {},
 ): string {
   const root = parse(html);
+  const watchDir = opts.watchDir;
+  const spaces = opts.spaces ?? new Map<string, string>();
 
   for (const a of root.querySelectorAll("a")) {
     const href = a.getAttribute("href");
     if (!href) continue;
+
+    // Detect cross-space links FIRST: a relative href like
+    // `../../work/other/wiki/foo.html` is a perfectly valid
+    // filesystem-relative path on disk (file:// follows it) but a
+    // 404 over http:// since the daemon serves `/{space}/...`, not
+    // `/work/other/...`. Rewrite the rendered href to the routed
+    // form so click-through works.
+    if (watchDir) {
+      const cross = crossSpaceTarget(href, fromPath, spaceName, watchDir, spaces);
+      if (cross) {
+        const newHref =
+          spaceUrlEncode(cross.space, cross.path) + cross.suffix;
+        a.setAttribute("href", newHref);
+        const className = cross.path.toLowerCase().endsWith(".html")
+          ? "arkeon-wiki"
+          : "arkeon-file";
+        const existing = (a.getAttribute("class") ?? "").trim();
+        a.setAttribute(
+          "class",
+          existing ? `${existing} ${className}` : className,
+        );
+        continue;
+      }
+    }
+
     const added = classifyAnchor(href, fromPath, knownPaths);
     if (added.length === 0) continue;
     const existing = (a.getAttribute("class") ?? "").trim();
@@ -267,6 +379,20 @@ export function renderNotFound(spaceName: string, path: string): string {
 </body>
 </html>
 `;
+}
+
+/**
+ * Build a routed `/{space}/{path}` href with each path segment
+ * URL-encoded. Mirrors the construction used in
+ * `renderArticleIndex` so the reader's rewritten hrefs hit the same
+ * decode path that resolves to entities on the way back in.
+ */
+function spaceUrlEncode(spaceName: string, path: string): string {
+  const encodedPath = path
+    .split("/")
+    .map((seg) => encodeURIComponent(seg))
+    .join("/");
+  return `/${encodeURIComponent(spaceName)}/${encodedPath}`;
 }
 
 function escapeHtml(s: string): string {

--- a/packages/arkeon/src/server/lib/spaces.ts
+++ b/packages/arkeon/src/server/lib/spaces.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * One-line lookup for "every registered space and where it lives on
+ * disk" — the input shape three different layers need:
+ *
+ *   - the agent tools' href rewriter (`href-rewrite.ts`),
+ *   - the sync layer's cross-space link resolver (`html-links.ts`),
+ *   - the reader's cross-space inverse rewriter (`reader.ts`).
+ *
+ * Returns a `Map<name → watch_dir>` so callers can do O(1) name
+ * lookups and iterate watch_dirs in one shot.
+ */
+
+import { createSql } from "./sql.js";
+
+export async function loadSpacesMap(): Promise<Map<string, string>> {
+  const sql = createSql();
+  const rows = (await sql`
+    SELECT name, watch_dir FROM spaces WHERE watch_dir IS NOT NULL
+  `) as unknown as Array<{ name: string; watch_dir: string }>;
+  const map = new Map<string, string>();
+  for (const row of rows) map.set(row.name, row.watch_dir);
+  return map;
+}

--- a/packages/arkeon/src/server/lib/sync.ts
+++ b/packages/arkeon/src/server/lib/sync.ts
@@ -27,6 +27,7 @@ import { createSql, withTransaction, type SqlClient } from "./sql.js";
 import { getEditContext, type EditKind } from "./edit-context.js";
 import { parseHtmlMeta } from "./html-meta.js";
 import { extractHtmlLinks } from "./html-links.js";
+import { loadSpacesMap } from "./spaces.js";
 
 export interface Space {
   name: string;
@@ -99,7 +100,12 @@ async function syncWiki(
     basename(relativePath, ".html");
 
   const propsJson = JSON.stringify(meta.properties);
-  const links = extractHtmlLinks(content, relativePath);
+  const spaces = await loadSpacesMap();
+  const links = extractHtmlLinks(content, relativePath, {
+    thisSpaceName: space.name,
+    thisWatchDir: space.watch_dir,
+    spaces,
+  });
   const resolvedLinks = links.filter((l): l is typeof l & { resolved: string } => l.resolved !== null);
 
   await withTransaction(async (tx) => {

--- a/packages/arkeon/src/server/routes/reader.ts
+++ b/packages/arkeon/src/server/routes/reader.ts
@@ -32,6 +32,7 @@ import { ApiError } from "../lib/errors.js";
 import { createSql } from "../lib/sql.js";
 import { safeResolve } from "../lib/file-edits.js";
 import { shouldIgnorePath } from "../lib/fs-watcher.js";
+import { loadSpacesMap } from "../lib/spaces.js";
 import {
   instrumentArticle,
   renderArticleIndex,
@@ -60,17 +61,6 @@ async function knownPathsFor(spaceName: string): Promise<Set<string>> {
   return out;
 }
 
-async function allSpaceWatchDirs(): Promise<Map<string, string>> {
-  const sql = createSql();
-  const rows = await sql`
-    SELECT name, watch_dir FROM spaces WHERE watch_dir IS NOT NULL
-  `;
-  const map = new Map<string, string>();
-  for (const row of rows) {
-    map.set(row.name as string, row.watch_dir as string);
-  }
-  return map;
-}
 
 // ── GET / — daemon landing ────────────────────────────────────────
 
@@ -166,7 +156,7 @@ readerRouter.get("/:space/wiki/*", async (c) => {
 
   const original = readFileSync(abs, "utf-8");
   const knownPaths = await knownPathsFor(space);
-  const spaces = await allSpaceWatchDirs();
+  const spaces = await loadSpacesMap();
   const instrumented = instrumentArticle(original, articlePath, knownPaths, space, {
     watchDir,
     spaces,

--- a/packages/arkeon/src/server/routes/reader.ts
+++ b/packages/arkeon/src/server/routes/reader.ts
@@ -60,6 +60,18 @@ async function knownPathsFor(spaceName: string): Promise<Set<string>> {
   return out;
 }
 
+async function allSpaceWatchDirs(): Promise<Map<string, string>> {
+  const sql = createSql();
+  const rows = await sql`
+    SELECT name, watch_dir FROM spaces WHERE watch_dir IS NOT NULL
+  `;
+  const map = new Map<string, string>();
+  for (const row of rows) {
+    map.set(row.name as string, row.watch_dir as string);
+  }
+  return map;
+}
+
 // ── GET / — daemon landing ────────────────────────────────────────
 
 readerRouter.get("/", async (c) => {
@@ -154,7 +166,11 @@ readerRouter.get("/:space/wiki/*", async (c) => {
 
   const original = readFileSync(abs, "utf-8");
   const knownPaths = await knownPathsFor(space);
-  const instrumented = instrumentArticle(original, articlePath, knownPaths, space);
+  const spaces = await allSpaceWatchDirs();
+  const instrumented = instrumentArticle(original, articlePath, knownPaths, space, {
+    watchDir,
+    spaces,
+  });
   return c.html(instrumented);
 });
 

--- a/packages/arkeon/src/server/routes/reader.ts
+++ b/packages/arkeon/src/server/routes/reader.ts
@@ -61,7 +61,6 @@ async function knownPathsFor(spaceName: string): Promise<Set<string>> {
   return out;
 }
 
-
 // ── GET / — daemon landing ────────────────────────────────────────
 
 readerRouter.get("/", async (c) => {

--- a/packages/arkeon/test/e2e/agent-runtime.test.ts
+++ b/packages/arkeon/test/e2e/agent-runtime.test.ts
@@ -240,6 +240,230 @@ describe("read-gate", () => {
   });
 });
 
+describe("href rewriter — end-to-end through create_file / edit_file / sync", () => {
+  const exec = execTool;
+
+  it("create_file rewrites space-URL hrefs to relative on disk and records canonical relationships", async () => {
+    const ctx = makeContext(SPACE, "writer");
+    const create = getTool("create_file", ctx);
+
+    // Seed a source so the citation has a target.
+    mkdirSync(join(workdir, "sources"), { recursive: true });
+    writeFileSync(join(workdir, "sources/notes.txt"), "the source content");
+    await syncFile(SPACE, "sources/notes.txt");
+
+    await exec(create, {
+      path: "wiki/grief.html",
+      html: `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>Why grief is sweet</title></head>
+<body>
+<h1>Why grief is sweet</h1>
+<p>See <a href="/${SPACE.name}/sources/notes.txt">notes</a> and
+<a href="/${SPACE.name}/wiki/sibling.html">sibling</a>.</p>
+</body>
+</html>`,
+    });
+
+    // On disk: hrefs are now plain relative paths, not /{space}/-prefixed.
+    const onDisk = readFileSync(join(workdir, "wiki/grief.html"), "utf-8");
+    expect(onDisk).toContain(`href="../sources/notes.txt"`);
+    expect(onDisk).toContain(`href="sibling.html"`);
+    expect(onDisk).not.toContain(`href="/${SPACE.name}/`);
+
+    // Relationships row resolves to the canonical in-space form.
+    const sql = createSql();
+    const rels = await sql`
+      SELECT target_path FROM relationships
+      WHERE space_name = ${SPACE.name} AND source_path = 'wiki/grief.html'
+      ORDER BY target_path
+    ` as unknown as Array<{ target_path: string }>;
+    expect(rels.map((r) => r.target_path)).toEqual([
+      "sources/notes.txt",
+      "wiki/sibling.html",
+    ]);
+  });
+
+  it("edit_file str_replace rewrites new_string only — old_string must match disk verbatim", async () => {
+    writeFileSync(
+      join(workdir, "wiki/x.html"),
+      `<!doctype html>
+<html><head><meta charset="utf-8"><title>X</title></head>
+<body><p>See <a href="../sources/old.md">old</a>.</p></body></html>`,
+    );
+    await syncFile(SPACE, "wiki/x.html");
+
+    const ctx = makeContext(SPACE, "writer");
+    const read = getTool("read_file", ctx);
+    const edit = getTool("edit_file", ctx);
+
+    await exec(read, { path: "wiki/x.html" });
+    await exec(edit, {
+      mode: "str_replace",
+      path: "wiki/x.html",
+      // old_string copied verbatim from on-disk (the rewritten form).
+      old_string: `<a href="../sources/old.md">old</a>`,
+      // new_string uses space-URL form — rewriter handles it.
+      new_string: `<a href="/${SPACE.name}/sources/new.md">new</a>`,
+    });
+
+    const after = readFileSync(join(workdir, "wiki/x.html"), "utf-8");
+    expect(after).toContain(`href="../sources/new.md"`);
+    expect(after).not.toContain(`/${SPACE.name}/`);
+  });
+
+  it("edit_file insert_at_line rewrites the inserted content", async () => {
+    writeFileSync(
+      join(workdir, "wiki/x.html"),
+      `<!doctype html>
+<html><head><meta charset="utf-8"><title>X</title></head>
+<body>
+<h1>X</h1>
+<p>existing</p>
+</body></html>`,
+    );
+    await syncFile(SPACE, "wiki/x.html");
+
+    const ctx = makeContext(SPACE, "writer");
+    const read = getTool("read_file", ctx);
+    const edit = getTool("edit_file", ctx);
+
+    await exec(read, { path: "wiki/x.html" });
+    await exec(edit, {
+      mode: "insert_at_line",
+      path: "wiki/x.html",
+      line_number: 6,
+      content: `<p>cite <a href="/${SPACE.name}/sources/n.md">n</a>.</p>`,
+    });
+
+    const after = readFileSync(join(workdir, "wiki/x.html"), "utf-8");
+    expect(after).toContain(`href="../sources/n.md"`);
+  });
+
+  it("refuses to rewrite a path-traversal href; the broken bytes land verbatim", async () => {
+    const ctx = makeContext(SPACE, "writer");
+    const create = getTool("create_file", ctx);
+
+    await exec(create, {
+      path: "wiki/evil.html",
+      html: `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>Evil</title></head>
+<body><a href="/${SPACE.name}/../../etc/passwd">evil</a></body>
+</html>`,
+    });
+
+    const onDisk = readFileSync(join(workdir, "wiki/evil.html"), "utf-8");
+    // Untouched — left as the agent wrote it. No file-system escape.
+    expect(onDisk).toContain(`href="/${SPACE.name}/../../etc/passwd"`);
+    expect(onDisk).not.toContain(`../../../etc/passwd`);
+  });
+
+  it("rewrites a cross-space href to filesystem-relative and emits a canonical /{other}/ target_path", async () => {
+    // The second space sits as a SIBLING of the primary on disk, not
+    // nested inside it. Nested watch_dirs are a footgun: the rewriter
+    // emits a path that stays inside the parent's watch_dir, which
+    // sync's resolveHref then treats as an in-space link (the "is
+    // this an escape?" check fires only when the resolution actually
+    // goes up out of the watch_dir).
+    const otherDir = mkdtempSync(join(tmpdir(), "arkeon-rt-other-"));
+    mkdirSync(join(otherDir, "wiki"), { recursive: true });
+    const sql = createSql();
+    await sql`INSERT INTO spaces(name, watch_dir) VALUES('other', ${otherDir})`;
+
+    try {
+      const ctx = makeContext(SPACE, "writer");
+      const create = getTool("create_file", ctx);
+      await exec(create, {
+        path: "wiki/cross.html",
+        html: `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>Cross</title></head>
+<body><p>See <a href="/other/wiki/over-there.html">over there</a>.</p></body>
+</html>`,
+      });
+
+      // On disk: filesystem-relative across watch_dirs. The
+      // primary's parent → other's relative path is something like
+      // ../arkeon-rt-other-XXXXX/wiki/over-there.html — assert on
+      // the suffix so the random tmpdir doesn't fight the assertion.
+      const onDisk = readFileSync(join(workdir, "wiki/cross.html"), "utf-8");
+      expect(onDisk).toMatch(
+        /href="\.\.\/\.\.\/arkeon-rt-other-[^/]+\/wiki\/over-there\.html"/,
+      );
+
+      // Relationships row: canonical /{otherSpace}/{path} form.
+      const rels = await sql`
+        SELECT target_path FROM relationships
+        WHERE space_name = ${SPACE.name} AND source_path = 'wiki/cross.html'
+      ` as unknown as Array<{ target_path: string }>;
+      expect(rels).toEqual([{ target_path: "/other/wiki/over-there.html" }]);
+    } finally {
+      rmSync(otherDir, { recursive: true, force: true });
+    }
+  });
+
+  it("cross-space red links are filtered out of list_redlinks", async () => {
+    const otherDir = mkdtempSync(join(tmpdir(), "arkeon-rt-other2-"));
+    mkdirSync(join(otherDir, "wiki"), { recursive: true });
+    const sql = createSql();
+    await sql`INSERT INTO spaces(name, watch_dir) VALUES('other2', ${otherDir})`;
+
+    try {
+      const ctx = makeContext(SPACE, "writer");
+      const create = getTool("create_file", ctx);
+      await exec(create, {
+        path: "wiki/c.html",
+        html: `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>C</title></head>
+<body>
+<a href="/other2/wiki/ghost.html">cross-redlink</a>
+<a href="/${SPACE.name}/wiki/own-ghost.html">own-redlink</a>
+</body></html>`,
+      });
+
+      const listRedlinks = getTool("list_redlinks", ctx);
+      const out = await exec<{ redlinks: Array<{ target_path: string }> }>(
+        listRedlinks,
+        {},
+      );
+      const paths = out.redlinks.map((r) => r.target_path);
+      expect(paths).toContain("wiki/own-ghost.html");
+      expect(paths).not.toContain("/other2/wiki/ghost.html");
+    } finally {
+      rmSync(otherDir, { recursive: true, force: true });
+    }
+  });
+
+  it("round-trips: agent writes space-URL form, reads back disk form, edits with mixed forms", async () => {
+    const ctx = makeContext(SPACE, "writer");
+    const create = getTool("create_file", ctx);
+    await exec(create, {
+      path: "wiki/r.html",
+      html: `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>R</title></head>
+<body><p><a href="/${SPACE.name}/sources/a.md">a</a></p></body></html>`,
+    });
+
+    // Read it back — content reflects the rewritten disk form.
+    const read = getTool("read_file", ctx);
+    const out = await exec<{ content: string }>(read, { path: "wiki/r.html" });
+    expect(out.content).toContain(`href="../sources/a.md"`);
+    expect(out.content).not.toContain(`/${SPACE.name}/`);
+
+    // Edit using the form we just read; should work with old_string=disk bytes.
+    const edit = getTool("edit_file", ctx);
+    await exec(edit, {
+      mode: "str_replace",
+      path: "wiki/r.html",
+      old_string: `<a href="../sources/a.md">a</a>`,
+      new_string: `<a href="/${SPACE.name}/sources/b.md">b</a>`,
+    });
+    const after = readFileSync(join(workdir, "wiki/r.html"), "utf-8");
+    expect(after).toContain(`href="../sources/b.md"`);
+  });
+});
+
 describe("get_entity tool", () => {
   type EdgeRow = { target_path?: string; source_path?: string; link_text: string | null };
   interface GetEntityFound {

--- a/packages/arkeon/test/e2e/agent-runtime.test.ts
+++ b/packages/arkeon/test/e2e/agent-runtime.test.ts
@@ -610,6 +610,106 @@ describe("get_entity tool", () => {
     await execTool<GetEntityResult>(tool, { path: "wiki/a.html" });
     expect(ctx.readPaths.size).toBe(0);
   });
+
+  describe("cross-space inbound aggregation", () => {
+    interface CrossInboundRow {
+      space_name: string;
+      source_path: string;
+      link_text: string | null;
+      space_url: string;
+    }
+    interface CrossEntityFound {
+      found: true;
+      entity: {
+        space_name: string;
+        source_path: string;
+        inbound: CrossInboundRow[];
+      };
+    }
+
+    it("surfaces inbound rows from other spaces (linker's space_name and space_url)", async () => {
+      // Set up a second space as a sibling watch_dir so the rewriter
+      // produces a real cross-space target_path (canonical `/other/...`)
+      // in the relationships table.
+      const otherDir = mkdtempSync(join(tmpdir(), "arkeon-rt-xinbound-"));
+      mkdirSync(join(otherDir, "wiki"), { recursive: true });
+      const sql = createSql();
+      await sql`INSERT INTO spaces(name, watch_dir) VALUES('other', ${otherDir})`;
+
+      try {
+        // Plant a target entity in the OTHER space — that's the one
+        // we'll then query for its cross-space inbound.
+        writeFileSync(
+          join(otherDir, "wiki/target.html"),
+          `<!DOCTYPE html><html><head><meta charset="utf-8"><title>T</title></head>
+<body><h1>T</h1></body></html>`,
+        );
+        await syncFile(
+          { name: "other", watch_dir: otherDir },
+          "wiki/target.html",
+        );
+
+        // From the triggering space (rt-test), have an agent create an
+        // article that cites the target via cross-space form.
+        const ctx = makeContext(SPACE, "writer");
+        const create = getTool("create_file", ctx);
+        await execTool(create, {
+          path: "wiki/citer.html",
+          html: `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Citer</title></head>
+<body><p>cites <a href="/other/wiki/target.html">the target</a></p></body>
+</html>`,
+        });
+
+        // Now have a (cross-space-aware) agent query the target from a
+        // role with allowedSpaces = both spaces, and confirm it sees
+        // the rt-test linker.
+        const multiCtx = makeContext(
+          { name: "other", watch_dir: otherDir },
+          "writer",
+          {
+            allowedSpaces: [
+              { name: "other", watch_dir: otherDir },
+              SPACE,
+            ],
+          },
+        );
+        const getEntityTool = getTool("get_entity", multiCtx);
+        const result = await execTool<CrossEntityFound>(getEntityTool, {
+          path: "wiki/target.html",
+          space: "other",
+        });
+
+        expect(result.found).toBe(true);
+        // The inbound array carries the linker's home space and a
+        // space_url that points back into THAT space.
+        const xInbound = result.entity.inbound.find(
+          (r) => r.space_name === SPACE.name,
+        );
+        expect(xInbound).toBeDefined();
+        expect(xInbound!.source_path).toBe("wiki/citer.html");
+        expect(xInbound!.space_url).toBe(`/${SPACE.name}/wiki/citer.html`);
+      } finally {
+        rmSync(otherDir, { recursive: true, force: true });
+      }
+    });
+
+    it("in-space inbound rows still carry the entity's own space_name", async () => {
+      await setupGraph();
+      const ctx = makeContext(SPACE, "writer");
+      const tool = getTool("get_entity", ctx);
+      const result = await execTool<CrossEntityFound>(tool, {
+        path: "wiki/b.html",
+      });
+      expect(result.found).toBe(true);
+      const inSpace = result.entity.inbound.find(
+        (r) => r.source_path === "wiki/a.html",
+      );
+      expect(inSpace).toBeDefined();
+      expect(inSpace!.space_name).toBe(SPACE.name);
+      expect(inSpace!.space_url).toBe(`/${SPACE.name}/wiki/a.html`);
+    });
+  });
 });
 
 describe("deletion semantics", () => {

--- a/packages/arkeon/test/unit/agents-config.test.ts
+++ b/packages/arkeon/test/unit/agents-config.test.ts
@@ -732,6 +732,36 @@ describe("loadBundledTemplates", () => {
     expect(t.cron, "proposer.cron").toBeTruthy();
   });
 
+  it("auto-loads connector from disk with no config present", () => {
+    // Connector is the cross-space role: spaces: ["*"], reads
+    // across every registered space, writes only to the triggering
+    // space. Its job is to find substantive cross-space connections
+    // and either weave them inline into existing articles or create
+    // synthesis articles.
+    const templates = loadBundledTemplates();
+    expect(Object.keys(templates)).toContain("connector");
+    const t = templates.connector;
+    expect(t.system, "connector.system").toBeTruthy();
+    expect(t.tools?.length, "connector.tools").toBeGreaterThan(0);
+    // Multi-space scope is the defining feature.
+    expect(t.spaces, "connector.spaces").toEqual(["*"]);
+    // Both edit_file (inline citation) and create_file (synthesis
+    // article) live in the whitelist; the runtime enforces "write
+    // only to the triggering space" so multi-space reads remain
+    // safe.
+    expect(t.tools, "connector.tools").toContain("edit_file");
+    expect(t.tools, "connector.tools").toContain("create_file");
+    // Cross-space inbound is the killer feature for this role —
+    // get_entity (with the PR-1 widening) surfaces who already cites
+    // an article from another space.
+    expect(t.tools, "connector.tools").toContain("get_entity");
+    expect(t.tools, "connector.tools").toContain("search");
+    // Queue bookkeeping: tracks which wikis have been surveyed at
+    // their current content hash.
+    expect(t.tools, "connector.tools").toContain("mark_processed");
+    expect(t.cron, "connector.cron").toBeTruthy();
+  });
+
   it("writer is create-only — no edit_file, tag_entity, or mark_processed", () => {
     // The new writer drains the red-link queue and never edits
     // existing articles or marks sources. Processing-marker

--- a/packages/arkeon/test/unit/href-rewrite.test.ts
+++ b/packages/arkeon/test/unit/href-rewrite.test.ts
@@ -1,0 +1,196 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+
+import {
+  maybeRewriteHref,
+  rewriteHrefsForWrite,
+  type RewriteOpts,
+} from "../../src/server/lib/href-rewrite.js";
+
+function makeOpts(over: Partial<RewriteOpts> = {}): RewriteOpts {
+  const spaces = over.spaces ?? new Map<string, string>([
+    ["primary", "/tmp/primary"],
+    ["other", "/tmp/work/other"],
+  ]);
+  return {
+    fromPath: over.fromPath ?? "wiki/foo.html",
+    spaceName: over.spaceName ?? "primary",
+    spaces,
+  };
+}
+
+describe("maybeRewriteHref — in-space", () => {
+  it("rewrites a sibling-article link from a top-level wiki", () => {
+    expect(
+      maybeRewriteHref("/primary/wiki/bar.html", makeOpts()),
+    ).toBe("bar.html");
+  });
+
+  it("rewrites a source link from a top-level wiki", () => {
+    expect(
+      maybeRewriteHref("/primary/sources/notes.txt", makeOpts()),
+    ).toBe("../sources/notes.txt");
+  });
+
+  it("rewrites a sibling-article link from a nested plan wiki", () => {
+    // From wiki/_plans/sources/augustine/ to wiki/: up 3, then descend.
+    expect(
+      maybeRewriteHref(
+        "/primary/wiki/why-grief-is-sweet.html",
+        makeOpts({ fromPath: "wiki/_plans/sources/augustine/book-04.html" }),
+      ),
+    ).toBe("../../../why-grief-is-sweet.html");
+  });
+
+  it("rewrites a source link from a nested plan wiki", () => {
+    // From wiki/_plans/sources/augustine/ to sources/: up 4 (no shared
+    // first segment), then descend.
+    expect(
+      maybeRewriteHref(
+        "/primary/sources/augustine/book-04.md",
+        makeOpts({ fromPath: "wiki/_plans/sources/augustine/book-04.html" }),
+      ),
+    ).toBe("../../../../sources/augustine/book-04.md");
+  });
+
+  it("preserves a fragment", () => {
+    expect(
+      maybeRewriteHref("/primary/wiki/bar.html#section-3", makeOpts()),
+    ).toBe("bar.html#section-3");
+  });
+
+  it("preserves a query string", () => {
+    expect(
+      maybeRewriteHref("/primary/wiki/bar.html?v=1", makeOpts()),
+    ).toBe("bar.html?v=1");
+  });
+
+  it("URL-encodes path segments with spaces and ampersands", () => {
+    expect(
+      maybeRewriteHref(
+        "/primary/sources/Milestones & Schedules/A1/Data.md",
+        makeOpts(),
+      ),
+    ).toBe("../sources/Milestones%20%26%20Schedules/A1/Data.md");
+  });
+
+  it("decodes URL-encoded inputs and re-encodes on output", () => {
+    expect(
+      maybeRewriteHref(
+        "/primary/sources/Milestones%20%26%20Schedules/Data.md",
+        makeOpts(),
+      ),
+    ).toBe("../sources/Milestones%20%26%20Schedules/Data.md");
+  });
+
+  it("rewrites a URL-encoded space-name prefix", () => {
+    // The space name itself happens to be ASCII-safe in our examples,
+    // but the rewriter must still tolerate percent-encoded forms.
+    expect(
+      maybeRewriteHref("/%70rimary/wiki/bar.html", makeOpts()),
+    ).toBe("bar.html");
+  });
+});
+
+describe("maybeRewriteHref — cross-space", () => {
+  it("rewrites to a filesystem-relative path crossing watch_dirs", () => {
+    // primary watch_dir = /tmp/primary, other watch_dir = /tmp/work/other
+    // Article at /tmp/primary/wiki/foo.html → /tmp/primary/wiki/
+    // Target at /tmp/work/other/wiki/bar.html
+    // Relative = ../../work/other/wiki/bar.html
+    expect(
+      maybeRewriteHref("/other/wiki/bar.html", makeOpts()),
+    ).toBe("../../work/other/wiki/bar.html");
+  });
+
+  it("preserves fragments on cross-space links", () => {
+    expect(
+      maybeRewriteHref("/other/wiki/bar.html#sec", makeOpts()),
+    ).toBe("../../work/other/wiki/bar.html#sec");
+  });
+
+  it("leaves the href alone when the named space is not registered", () => {
+    expect(
+      maybeRewriteHref("/nonexistent/wiki/x.html", makeOpts()),
+    ).toBeNull();
+  });
+});
+
+describe("maybeRewriteHref — pass-throughs", () => {
+  const opts = makeOpts();
+
+  it("leaves external URLs alone", () => {
+    expect(maybeRewriteHref("https://example.com", opts)).toBeNull();
+    expect(maybeRewriteHref("mailto:x@y", opts)).toBeNull();
+    expect(maybeRewriteHref("tel:+1234", opts)).toBeNull();
+  });
+
+  it("leaves protocol-relative URLs alone", () => {
+    expect(maybeRewriteHref("//example.com/foo", opts)).toBeNull();
+  });
+
+  it("leaves pure fragments alone", () => {
+    expect(maybeRewriteHref("#section", opts)).toBeNull();
+  });
+
+  it("leaves plain relative paths alone", () => {
+    expect(maybeRewriteHref("bar.html", opts)).toBeNull();
+    expect(maybeRewriteHref("../sources/x.md", opts)).toBeNull();
+    expect(maybeRewriteHref("./foo.html", opts)).toBeNull();
+  });
+
+  it("leaves malformed percent encoding alone", () => {
+    expect(maybeRewriteHref("/primary/foo%2/bar.html", opts)).toBeNull();
+  });
+
+  it("leaves an empty-path slash alone", () => {
+    expect(maybeRewriteHref("/", opts)).toBeNull();
+  });
+});
+
+describe("rewriteHrefsForWrite — full document", () => {
+  it("rewrites every <a>, <img>, and <link> in a full HTML doc", () => {
+    const html = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>X</title>
+  <link rel="stylesheet" href="/primary/styles/site.css">
+</head>
+<body>
+  <p>See <a href="/primary/wiki/bar.html">bar</a></p>
+  <p><img src="/primary/assets/photo.png" alt=""></p>
+  <p><a href="https://example.com">external</a></p>
+</body>
+</html>`;
+    const out = rewriteHrefsForWrite(html, makeOpts());
+    expect(out).toContain(`href="../styles/site.css"`);
+    expect(out).toContain(`href="bar.html"`);
+    expect(out).toContain(`src="../assets/photo.png"`);
+    // External link untouched.
+    expect(out).toContain(`href="https://example.com"`);
+  });
+
+  it("is idempotent: rewritten output passes through unchanged", () => {
+    const html = `<a href="/primary/wiki/bar.html">x</a>`;
+    const once = rewriteHrefsForWrite(html, makeOpts());
+    const twice = rewriteHrefsForWrite(once, makeOpts());
+    expect(twice).toBe(once);
+  });
+
+  it("hands back the input bytes verbatim when nothing changed", () => {
+    // No /-prefixed hrefs to rewrite. The serializer would normalize
+    // whitespace; we'd rather not invade snippets that don't need
+    // touching.
+    const html = `<p><a   href="bar.html">x</a></p>`;
+    expect(rewriteHrefsForWrite(html, makeOpts())).toBe(html);
+  });
+
+  it("rewrites a fragment (no <html>/<body> wrapper)", () => {
+    const frag = `<li><a href="/primary/wiki/q.html">q</a> — gloss.</li>`;
+    const out = rewriteHrefsForWrite(frag, makeOpts());
+    expect(out).toContain(`href="q.html"`);
+  });
+});

--- a/packages/arkeon/test/unit/href-rewrite.test.ts
+++ b/packages/arkeon/test/unit/href-rewrite.test.ts
@@ -277,4 +277,31 @@ describe("rewriteHrefsForWrite — full document", () => {
     const out = rewriteHrefsForWrite(frag, makeOpts());
     expect(out).toContain(`href="q.html"`);
   });
+
+  it("rewrites <img src> independently of <a href>", () => {
+    const html = `<p><img src="/primary/assets/diagram.png" alt="d"></p>`;
+    const out = rewriteHrefsForWrite(html, makeOpts());
+    expect(out).toContain(`src="../assets/diagram.png"`);
+    expect(out).not.toContain(`/primary/`);
+  });
+
+  it("rewrites <link href> independently of <a href>", () => {
+    const html = `<link rel="stylesheet" href="/primary/styles/site.css">`;
+    const out = rewriteHrefsForWrite(html, makeOpts());
+    expect(out).toContain(`href="../styles/site.css"`);
+  });
+
+  it("leaves <img src> alone for external URLs and unresolvable spaces", () => {
+    const html = `<img src="https://cdn.example/a.png">
+<img src="/nonexistent/assets/b.png">`;
+    const out = rewriteHrefsForWrite(html, makeOpts());
+    expect(out).toContain(`src="https://cdn.example/a.png"`);
+    expect(out).toContain(`src="/nonexistent/assets/b.png"`);
+  });
+
+  it("rewrites <img src> across spaces", () => {
+    const html = `<img src="/other/assets/photo.png">`;
+    const out = rewriteHrefsForWrite(html, makeOpts());
+    expect(out).toContain(`src="../../work/other/assets/photo.png"`);
+  });
 });

--- a/packages/arkeon/test/unit/href-rewrite.test.ts
+++ b/packages/arkeon/test/unit/href-rewrite.test.ts
@@ -150,6 +150,90 @@ describe("maybeRewriteHref — pass-throughs", () => {
   });
 });
 
+describe("maybeRewriteHref — path traversal guards", () => {
+  it("refuses an in-space href that escapes the watch_dir via ..", () => {
+    expect(
+      maybeRewriteHref("/primary/../../etc/passwd", makeOpts()),
+    ).toBeNull();
+  });
+
+  it("refuses an in-space href that resolves to bare parent", () => {
+    expect(maybeRewriteHref("/primary/..", makeOpts())).toBeNull();
+  });
+
+  it("refuses a cross-space href whose target escapes the destination space", () => {
+    // `../../etc/passwd` resolved against /tmp/work/other goes to
+    // /tmp/etc/passwd — outside that watch_dir. Refuse.
+    expect(
+      maybeRewriteHref("/other/../../etc/passwd", makeOpts()),
+    ).toBeNull();
+  });
+
+  it("collapses harmless . / .. segments without rejecting", () => {
+    // `wiki/./bar.html` normalizes to `wiki/bar.html` — still in space.
+    expect(
+      maybeRewriteHref("/primary/wiki/./bar.html", makeOpts()),
+    ).toBe("bar.html");
+    // `wiki/sub/../bar.html` normalizes to `wiki/bar.html` — still in space.
+    expect(
+      maybeRewriteHref("/primary/wiki/sub/../bar.html", makeOpts()),
+    ).toBe("bar.html");
+  });
+});
+
+describe("maybeRewriteHref — nested watch_dirs", () => {
+  // Pathological setup: space B's watch_dir lives INSIDE space A's. A
+  // relative path from A could match A's interior AND B as a sibling.
+  // The for-loop iterates `spaces` in insertion order; the first
+  // matching prefix wins. Document the behavior so consumers don't
+  // accidentally rely on it being something else.
+  const nested = new Map<string, string>([
+    ["outer", "/tmp/outer"],
+    ["inner", "/tmp/outer/sub"],
+  ]);
+
+  it("a /inner/... href from outer resolves through inner's watch_dir", () => {
+    expect(
+      maybeRewriteHref(
+        "/inner/wiki/bar.html",
+        {
+          fromPath: "wiki/foo.html",
+          spaceName: "outer",
+          spaces: nested,
+        },
+      ),
+    ).toBe("../sub/wiki/bar.html");
+  });
+
+  it("a /outer/sub/... href from outer treats it as the outer-space path it literally is", () => {
+    expect(
+      maybeRewriteHref(
+        "/outer/sub/wiki/bar.html",
+        {
+          fromPath: "wiki/foo.html",
+          spaceName: "outer",
+          spaces: nested,
+        },
+      ),
+    ).toBe("../sub/wiki/bar.html");
+  });
+});
+
+describe("maybeRewriteHref — round-trip stability", () => {
+  it("a rewritten href stays put when re-fed through the rewriter", () => {
+    const opts = makeOpts({ fromPath: "wiki/_plans/sources/x.html" });
+    const onceRewritten = maybeRewriteHref(
+      "/primary/wiki/foo.html",
+      opts,
+    );
+    // The output is a plain relative href — no /-prefix — so the
+    // second pass leaves it alone (maybeRewriteHref returns null for
+    // relative inputs).
+    expect(onceRewritten).toBe("../../foo.html");
+    expect(maybeRewriteHref(onceRewritten!, opts)).toBeNull();
+  });
+});
+
 describe("rewriteHrefsForWrite — full document", () => {
   it("rewrites every <a>, <img>, and <link> in a full HTML doc", () => {
     const html = `<!DOCTYPE html>

--- a/packages/arkeon/test/unit/html-links.test.ts
+++ b/packages/arkeon/test/unit/html-links.test.ts
@@ -41,8 +41,23 @@ describe("resolveHref", () => {
     expect(resolveHref("//example.com/x", "wiki/foo.html")).toBeNull();
   });
 
-  it("drops server-absolute paths (reserved for v0.5 cross-space)", () => {
-    expect(resolveHref("/other-space/wiki/foo.html", "wiki/foo.html")).toBeNull();
+  it("passes server-absolute paths through verbatim (canonical cross-space form)", () => {
+    expect(resolveHref("/other-space/wiki/foo.html", "wiki/foo.html")).toBe(
+      "/other-space/wiki/foo.html",
+    );
+  });
+
+  it("strips fragment/query from server-absolute paths", () => {
+    expect(resolveHref("/other/wiki/foo.html#bar", "wiki/foo.html")).toBe(
+      "/other/wiki/foo.html",
+    );
+    expect(resolveHref("/other/wiki/foo.html?v=1", "wiki/foo.html")).toBe(
+      "/other/wiki/foo.html",
+    );
+  });
+
+  it("drops bare slash", () => {
+    expect(resolveHref("/", "wiki/foo.html")).toBeNull();
   });
 
   it("drops pure fragments", () => {
@@ -71,6 +86,38 @@ describe("resolveHref", () => {
     expect(resolveHref("../foo%2/bar.html", "wiki/x.html")).toBe(
       "foo%2/bar.html",
     );
+  });
+
+  describe("with cross-space resolution opts", () => {
+    const opts = {
+      thisSpaceName: "primary",
+      thisWatchDir: "/tmp/primary",
+      spaces: new Map<string, string>([
+        ["primary", "/tmp/primary"],
+        ["other", "/tmp/work/other"],
+      ]),
+    };
+
+    it("rewrites a filesystem-relative escape into another space to canonical form", () => {
+      // Article at /tmp/primary/wiki/foo.html, target at
+      // /tmp/work/other/wiki/bar.html → relative is
+      // ../../work/other/wiki/bar.html, which lands in space `other`.
+      expect(
+        resolveHref("../../work/other/wiki/bar.html", "wiki/foo.html", opts),
+      ).toBe("/other/wiki/bar.html");
+    });
+
+    it("still drops escapes that don't land in any registered space", () => {
+      expect(
+        resolveHref("../../etc/passwd", "wiki/foo.html", opts),
+      ).toBeNull();
+    });
+
+    it("leaves in-space resolution unchanged when opts are supplied", () => {
+      expect(resolveHref("other.html", "wiki/foo.html", opts)).toBe(
+        "wiki/other.html",
+      );
+    });
   });
 });
 

--- a/packages/arkeon/test/unit/reader.test.ts
+++ b/packages/arkeon/test/unit/reader.test.ts
@@ -160,6 +160,60 @@ describe("instrumentArticle", () => {
     expect(out).toContain("&lt;bad&gt;");
     expect(out).not.toContain("<bad>");
   });
+
+  describe("cross-space inverse rewrite", () => {
+    const crossHtml = `<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>X</title></head>
+<body>
+<p><a href="../../work/other/wiki/bar.html">cross-space</a></p>
+<p><a href="chloroplast.html">in-space</a></p>
+<p><a href="../../etc/passwd">escape</a></p>
+</body>
+</html>`;
+
+    it("rewrites a filesystem-relative cross-space href to /{otherSpace}/...", () => {
+      const out = instrumentArticle(crossHtml, articlePath, known, "demo", {
+        watchDir: "/tmp/demo",
+        spaces: new Map([
+          ["demo", "/tmp/demo"],
+          ["other", "/tmp/work/other"],
+        ]),
+      });
+      expect(out).toContain(`href="/other/wiki/bar.html"`);
+      expect(out).toContain(`class="arkeon-wiki"`);
+    });
+
+    it("leaves in-space relative links alone after rewriting cross-space ones", () => {
+      const out = instrumentArticle(crossHtml, articlePath, known, "demo", {
+        watchDir: "/tmp/demo",
+        spaces: new Map([
+          ["demo", "/tmp/demo"],
+          ["other", "/tmp/work/other"],
+        ]),
+      });
+      expect(out).toContain(`<a href="chloroplast.html" class="arkeon-wiki">`);
+    });
+
+    it("leaves escapes that don't land in any registered space alone", () => {
+      const out = instrumentArticle(crossHtml, articlePath, known, "demo", {
+        watchDir: "/tmp/demo",
+        spaces: new Map([
+          ["demo", "/tmp/demo"],
+          ["other", "/tmp/work/other"],
+        ]),
+      });
+      // /tmp/etc/passwd isn't inside any registered space; href stays as-is.
+      expect(out).toContain(`href="../../etc/passwd"`);
+    });
+
+    it("falls back to standard classification when no spaces map is supplied", () => {
+      const out = instrumentArticle(crossHtml, articlePath, known, "demo");
+      // Backward-compat call site: cross-space anchor untouched, escape
+      // path stays unclassified.
+      expect(out).toContain(`href="../../work/other/wiki/bar.html"`);
+    });
+  });
 });
 
 describe("renderSpaceIndex", () => {


### PR DESCRIPTION
Stacked on top of #158.

## Summary

New bundled `connector` role with `spaces: ["*"]`. Reads across every registered space, writes only to the triggering space. Job: find substantive cross-space connections and either weave them inline into existing articles or create new synthesis articles in the home space.

The connector closes the loop opened by #157 (cross-space hrefs) and #158 (cross-space inbound visibility):

- **Reads** fan out cross-space via the existing `resolveToolScope` mechanism — `search`, `list_entities`, `list_redlinks` all multiplex by default when `allowedSpaces > 1`.
- **`get_entity` cross-space inbound** (from #158) lets the connector see who already cites an article from any space, so it can short-circuit redundant work.
- **Writes** use canonical `/{otherSpace}/wiki/...` hrefs; the rewriter (from #157) translates to filesystem-relative on disk so `file://` parity is preserved.
- The runtime guarantee that `create_file`/`edit_file` always target `ctx.space.name` means the connector cannot accidentally write into another space.

## Behavior

Per-tick decision tree (in the system prompt):
1. Pick one wiki in the home space that isn't tagged at its current hash (`tag_outdated="connector.processed_hash"`).
2. Read it. Search other spaces with the article's central concepts.
3. Apply the filter: substantive (not decorative), novel (not already cited from this side).
4. If a real connection survives:
   - Insert an inline citation paragraph into Evidence (preferred for narrow connections), OR
   - Create a new synthesis article when the connection deserves its own page.
5. Always `mark_processed` so the same survey doesn't repeat next tick.

Queue: tag-based, matches editor/proposer convention. Cron `*/30 * * * *` — opportunistic, not aggressive.

Single-space fallback: when only one space is registered, looks for in-space connections the editor/proposer haven't integrated. Same filters.

## Test plan

### Automated
- `npm run typecheck` — clean
- `npm test` — 349 unit tests pass (+1 new): `loadBundledTemplates` verifies connector ships with `spaces: ["*"]`, the right tool whitelist (`edit_file` + `create_file` + `get_entity` + `search` + `mark_processed`), and a cron expression.
- `npm run test:e2e` — 62 e2e tests pass (unchanged from #158).

### Real-LLM manual smoke test

Fired `scripts/manual-connector-test.ts` against the real OpenAI API. Two spaces: `augustine` with an article on the restless heart, `iarpa` with an article on multiplexing-as-attention-harm. The connector:

- **Picked the augustine article** from the queue (15.9s, 7 steps, 45K tokens).
- **Fanned search out to iarpa** with thematic queries: `["restlessness", "divided will", "split desire", "attention", "context switching", "multiplexing"]`.
- **Read iarpa's article**, found the structural parallel.
- **Inserted a real connection** (not decorative): *"Augustine's divided will and modern multiplexed attention diagnose the same structure."* The body identifies the structural-harm parallel, not just vocabulary overlap.
- Wrote `<a href="/iarpa/wiki/why-multiplexing-harms-attention.html">` (space-URL form).
- Rewriter produced `../../iarpa/wiki/why-multiplexing-harms-attention.html` on disk (filesystem-relative across watch_dirs).
- Relationships table carries the canonical `target_path: '/iarpa/wiki/why-multiplexing-harms-attention.html'` cross-space edge.
- `connector.processed_hash` tag persists; next tick correctly sees no work.

### Caught during the manual test

First run revealed a tag-namespace mismatch: prompt used `connector.surveyed_hash` but `mark_processed` always writes `<role>.processed_hash`. Tag never persisted → queue would have re-surveyed the same article every tick. Fixed (rename to `connector.processed_hash`, matching editor/proposer convention) and re-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)