### PR TITLE
edit_file: sanitize trailing tool-call garbage in insert_at_line + str_replace

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"4c45cee0-aaba-4f4d-ac43-17027fa2b162","pid":65590,"procStart":"Fri May 15 13:49:54 2026","acquiredAt":1778863528664}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"4c45cee0-aaba-4f4d-ac43-17027fa2b162","pid":65590,"procStart":"Fri May 15 13:49:54 2026","acquiredAt":1778863528664}

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ tasks/
 # Misc
 *.log
 2026-*.txt
+.claude/

--- a/packages/arkeon/src/server/lib/file-edits.ts
+++ b/packages/arkeon/src/server/lib/file-edits.ts
@@ -138,7 +138,15 @@ export async function applyEdit(
             `(file has ${lines.length} lines)`,
         );
       }
-      const inserted = edit.content.split("\n");
+      const sanitized = sanitizeEditedHtmlContent(edit.content);
+      if (sanitized.trimmed) {
+        console.warn(
+          `[edit_file/insert_at_line] ${edit.path}: stripped ${sanitized.trimmed.length} bytes ` +
+            `of trailing garbage after last HTML closing tag. ` +
+            `Sample: ${JSON.stringify(sanitized.trimmed.slice(0, 120))}`,
+        );
+      }
+      const inserted = sanitized.clean.split("\n");
       if (inserted[inserted.length - 1] === "") inserted.pop();
       lines.splice(edit.line_number - 1, 0, ...inserted);
       writeFileSync(absPath, lines.join("\n"), "utf-8");
@@ -167,7 +175,15 @@ export async function applyEdit(
             `Expand the span until it is.`,
         );
       }
-      const updated = original.replace(edit.old_string, edit.new_string);
+      const sanitized = sanitizeEditedHtmlContent(edit.new_string);
+      if (sanitized.trimmed) {
+        console.warn(
+          `[edit_file/str_replace] ${edit.path}: stripped ${sanitized.trimmed.length} bytes ` +
+            `of trailing garbage after last HTML closing tag. ` +
+            `Sample: ${JSON.stringify(sanitized.trimmed.slice(0, 120))}`,
+        );
+      }
+      const updated = original.replace(edit.old_string, sanitized.clean);
       writeFileSync(absPath, updated, "utf-8");
       const sync = await syncFile(space, edit.path);
       return { path: edit.path, kind: "str_replace", sync };
@@ -193,6 +209,57 @@ function countOccurrences(haystack: string, needle: string): number {
     pos += needle.length;
   }
   return count;
+}
+
+/**
+ * Defensive sanitizer for HTML content produced by an LLM and passed
+ * verbatim into `insert_at_line.content` or `str_replace.new_string`.
+ *
+ * Strips trailing non-whitespace bytes that sit AFTER the last
+ * well-formed HTML closing tag in the content. Surfaced by issue #160
+ * where a connector tick on gpt-5.4-mini emitted structured-output
+ * tool-call channel markers (`"}]}]commentary to=functions.X`) plus
+ * multilingual filler tokens at the end of the `content` parameter,
+ * which then landed verbatim in the article body and persisted to
+ * disk.
+ *
+ * Heuristic: agents authoring wiki edits emit `<p>…</p>` or
+ * `<li>…</li>`-shaped fragments. Anything after the last `</tag>`
+ * other than whitespace is suspicious. If we find no closing tag at
+ * all the content is left alone (could be a self-closing block,
+ * could be plain text — out of our domain).
+ *
+ * Caller is expected to console.warn the trimmed bytes so the issue
+ * is visible to operators tailing the daemon log.
+ */
+export function sanitizeEditedHtmlContent(
+  content: string,
+): { clean: string; trimmed?: string } {
+  // Walk every well-formed closing tag and remember the end position
+  // of the last one. Permissive on whitespace inside the tag (`</p >`
+  // is rare but parses).
+  let lastCloseEnd = -1;
+  const closingTagRe = /<\/[a-zA-Z][a-zA-Z0-9]*\s*>/g;
+  let m;
+  while ((m = closingTagRe.exec(content)) !== null) {
+    lastCloseEnd = m.index + m[0].length;
+  }
+  if (lastCloseEnd === -1) {
+    // No HTML closing tags. Leave the content alone — could be
+    // plain-text editing, could be a self-closing-only block.
+    return { clean: content };
+  }
+  const trailing = content.slice(lastCloseEnd);
+  if (trailing.trim().length === 0) {
+    // Trailing whitespace / newlines are fine.
+    return { clean: content };
+  }
+  // Suspicious trailing payload. Strip it; preserve one trailing
+  // newline so the inserted block ends cleanly.
+  return {
+    clean: content.slice(0, lastCloseEnd) + "\n",
+    trimmed: trailing,
+  };
 }
 
 /**

--- a/packages/arkeon/test/unit/file-edits.test.ts
+++ b/packages/arkeon/test/unit/file-edits.test.ts
@@ -3,7 +3,11 @@
 
 import { describe, it, expect } from "vitest";
 
-import { safeResolve, validateWikiHtmlDocument } from "../../src/server/lib/file-edits.js";
+import {
+  safeResolve,
+  sanitizeEditedHtmlContent,
+  validateWikiHtmlDocument,
+} from "../../src/server/lib/file-edits.js";
 
 describe("safeResolve", () => {
   it("resolves a relative path under the watch dir", () => {
@@ -93,5 +97,72 @@ describe("validateWikiHtmlDocument", () => {
   it("rejects a document with no <body>", () => {
     const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>X</title></head></html>`;
     expect(validateWikiHtmlDocument(html)).toEqual({ reason: "missing-body" });
+  });
+});
+
+describe("sanitizeEditedHtmlContent", () => {
+  it("leaves well-formed HTML unchanged", () => {
+    const input = `<p>Hello world</p>`;
+    const result = sanitizeEditedHtmlContent(input);
+    expect(result.clean).toBe(input);
+    expect(result.trimmed).toBeUndefined();
+  });
+
+  it("preserves trailing whitespace and newlines", () => {
+    const input = `<p>Hello</p>\n  \n`;
+    const result = sanitizeEditedHtmlContent(input);
+    expect(result.clean).toBe(input);
+    expect(result.trimmed).toBeUndefined();
+  });
+
+  it("strips the issue #160 leak pattern", () => {
+    // Faithful reproduction of the actual leak observed in
+    // wiki/why-does-lifelong-learning-feel-like-freedom.html.
+    const input = `<p><strong>Lifelong learning is optimization culture.</strong> Body text here.</p>"}]}]၊commentary to=functions.mark_processed  ปมถวายสัตย์  诺果  全民彩票天天ে?}}`;
+    const result = sanitizeEditedHtmlContent(input);
+    expect(result.clean).toBe(`<p><strong>Lifelong learning is optimization culture.</strong> Body text here.</p>\n`);
+    expect(result.trimmed).toContain("commentary to=functions");
+    expect(result.trimmed).toContain("诺果");
+  });
+
+  it("strips garbage after the last of multiple closing tags", () => {
+    const input = `<p>First.</p><p>Second.</p> stray bytes`;
+    const result = sanitizeEditedHtmlContent(input);
+    expect(result.clean).toBe(`<p>First.</p><p>Second.</p>\n`);
+    expect(result.trimmed).toBe(` stray bytes`);
+  });
+
+  it("leaves plain text alone when no closing tag exists", () => {
+    // A legitimate use case: inserting an HTML comment, a self-closing
+    // tag, or plain text. We can't disambiguate from a partial-tag
+    // leak, so we choose not to mangle.
+    const input = `just some text`;
+    const result = sanitizeEditedHtmlContent(input);
+    expect(result.clean).toBe(input);
+    expect(result.trimmed).toBeUndefined();
+  });
+
+  it("leaves self-closing tags alone when no </tag> appears", () => {
+    const input = `<br/><img src="x.png"/>`;
+    const result = sanitizeEditedHtmlContent(input);
+    expect(result.clean).toBe(input);
+    expect(result.trimmed).toBeUndefined();
+  });
+
+  it("permits closing tags with optional internal whitespace", () => {
+    // `</p >` is unusual but valid HTML and shouldn't be misclassified.
+    const input = `<p>Hello</p >`;
+    const result = sanitizeEditedHtmlContent(input);
+    expect(result.clean).toBe(input);
+    expect(result.trimmed).toBeUndefined();
+  });
+
+  it("strips JSON tool-call closure even without channel routing text", () => {
+    // Other leak shapes: just `"}]}` or just `}}` would still be
+    // suspicious after a clean `</p>`.
+    const input = `<p>Hello world</p>"}]}`;
+    const result = sanitizeEditedHtmlContent(input);
+    expect(result.clean).toBe(`<p>Hello world</p>\n`);
+    expect(result.trimmed).toBe(`"}]}`);
   });
 });


### PR DESCRIPTION
Closes #160.

## Problem

A connector tick on `gpt-5.4-mini` ([#159](https://github.com/Arkeon-Technologies/arkeon-wiki/pull/159) — fresh role) emitted OpenAI structured-output tool-call channel markers (`"}]}]commentary to=functions.mark_processed`) plus multilingual filler tokens at the END of the `content` parameter passed to `edit_file insert_at_line`. The runtime persisted the value verbatim, so the garbage landed in the article body on disk and propagated to the relationships table + index:

```html
<p><strong>Lifelong learning is optimization culture...</strong></p>"}]}]၊commentary to=functions.mark_processed  ปมถวายสัตย์  诺果  全民彩票天天ে?}}
  <h2>Open threads</h2>
```

## Why defend at the runtime

The class: any LLM that loses structured-output discipline near the end of a tool-call args emission can leak whatever comes after the intended `content`. The editor has done ~60 prior `insert_at_line` edits on this corpus without producing this, and the connector's *second* tick produced clean output — so the failure is non-deterministic. But defending the chokepoint is cheap and stops the failure mode regardless of which agent or model surfaces it.

## Approach

`sanitizeEditedHtmlContent` (exported, unit-tested) — walks every closing tag in the content, locates the last well-formed `</tag>`, and strips non-whitespace bytes after it. Returns `{ clean, trimmed? }`. Wired into both `insert_at_line.content` and `str_replace.new_string`. When `trimmed` is non-empty the chokepoint logs a warning to the daemon log:

```
[edit_file/insert_at_line] wiki/foo.html: stripped 73 bytes of trailing garbage
after last HTML closing tag. Sample: "\"}]}]commentary to=functions.mark_processed..."
```

So operators can see when it fires.

**Conservative choices:**

- Content with NO closing tag at all (self-closing blocks, plain-text inserts) is left untouched. We can't distinguish that from a partial-tag leak; mangling legit input is worse than missing a leak. Agents shouldn't be inserting plain text into HTML wiki bodies anyway.
- Trailing whitespace / newlines are preserved (treated as non-garbage).
- Closing tags with internal whitespace (`</p >`) are recognized.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — **357 unit tests pass** (8 new in `file-edits.test.ts` covering the issue #160 leak pattern, multi-tag content, plain-text passthrough, self-closing-only content, internal-whitespace closing tags, simpler `"}]}` patterns)
- [x] `npm run test:e2e` — 62 e2e tests pass
- [x] Live corpus: rebuilt the augustine daemon's dist, fired a connector tick, no warning fired, no garbage in resulting article body. The defense is dormant on healthy emissions and only trips on leaks.
- [x] Hand-cleaned the previously-corrupted article (the user's request) — the sanitizer didn't need to re-handle it.

## Follow-ups (out of scope)

- Should `create_file`'s `html` parameter also run through the sanitizer? It already passes through `validateWikiHtmlDocument` which is stricter — a leak would likely break the structural checks. But adding the sanitizer there too is cheap. Filing separately if it surfaces.
- If the connector keeps producing this leak in the future at non-trivial rates, the prompt itself may need tightening — but that's role-specific and only worth doing if reproductions accumulate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)