### PR TITLE
api: serve llms.txt + /help orientation guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,7 @@ JSON API:
 - `GET /{space}/search?q=&type=&limit=&snippets=&regex=` — keyword search via ripgrep. `q` repeatable up to 10 times to OR patterns.
 - `POST /{space}/chat`, `GET /{space}/chat/:conversation_id`, `DELETE ...` — **501 Phase 1 stubs**, wired up in Phase 3.
 - `GET /health` / `GET /ready` — liveness/readiness.
+- `GET /llms.txt` / `GET /help` — hand-written orientation guide for human and LLM callers (data model, flows, every route). Source: `src/server/lib/llms-txt.ts`. **When you add or change an endpoint that's useful for accessing the wiki, update `llms-txt.ts` so callers see the new surface.** A drift-guard unit test (`test/unit/llms-txt.test.ts`) asserts every known route string is present; adding a route without touching the guide will fail CI once you add it to the test, but the test can't detect endpoints you forgot to register at all — treat the guide as a required deliverable for any new route, not an optional polish step.
 
 Human-facing reader (Phase 2):
 

--- a/packages/arkeon/src/server/app.ts
+++ b/packages/arkeon/src/server/app.ts
@@ -8,6 +8,7 @@ import { requestContextMiddleware } from "./middleware/request-context.js";
 import { ApiError, errorBody } from "./lib/errors.js";
 import { mapDatabaseError } from "./lib/db-errors.js";
 import { createSql } from "./lib/sql.js";
+import { LLMS_TXT } from "./lib/llms-txt.js";
 import { spacesRouter } from "./routes/spaces.js";
 import { spaceScopedRouter } from "./routes/space-scoped.js";
 import { readerRouter } from "./routes/reader.js";
@@ -28,6 +29,13 @@ export function createApp() {
       return c.json({ status: "unavailable" }, 503);
     }
   });
+
+  app.get("/llms.txt", (c) =>
+    c.body(LLMS_TXT, 200, { "content-type": "text/plain; charset=utf-8" }),
+  );
+  app.get("/help", (c) =>
+    c.body(LLMS_TXT, 200, { "content-type": "text/plain; charset=utf-8" }),
+  );
 
   app.route("/spaces", spacesRouter);
   app.route("/", spaceScopedRouter);

--- a/packages/arkeon/src/server/lib/llms-txt.ts
+++ b/packages/arkeon/src/server/lib/llms-txt.ts
@@ -1,0 +1,282 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Static API guide served at `GET /llms.txt` and `GET /help`. Hand-
+ * maintained — when you add or change a route, update this file. The
+ * smoke test in `llms-txt.test.ts` fails if a known route string is
+ * missing, which catches the most common drift.
+ */
+
+export const LLMS_TXT = `# arkeon-wiki
+
+A filesystem-first knowledge graph. Point the daemon at a directory; it
+watches files, indexes them into SQLite, and treats <a href> links
+between HTML wikis as relationship edges. The filesystem is the source
+of truth — SQLite is the index, the API is a read/write surface over
+that index, and changes to disk are reflected automatically.
+
+This page is the orientation guide for callers (humans and LLMs). It
+describes the data model, the canonical flows, and every route. There
+is no auth.
+
+================================================================
+## Concepts
+
+**Space**: a registered watch directory, identified by name. URLs are
+all rooted at the space: \`/{space}/...\`. Names match
+\`[a-zA-Z0-9][a-zA-Z0-9._-]*\`. Multiple spaces can coexist on one
+daemon.
+
+**Entity**: a row in the index for one file. Two types:
+  - \`wiki\`  — an article under \`wiki/**/*.html\` with a \`<title>\` and
+            optional \`<meta name="X" content="Y">\` tags. Wiki bodies
+            should follow the four-section shape: \`Question\`,
+            \`Current answer\`, \`Evidence\`, \`Open threads\`.
+  - \`file\`  — any other text file in the watch dir (markdown, source,
+            CSV, JSON, plain text, extensionless README, etc.). Binary
+            files (PDF, DOCX, images, archives) are intentionally not
+            indexed; use the \`sources/scan\` endpoint to see what was
+            skipped.
+
+**Relationship**: every internal \`<a href>\` in a wiki becomes an
+edge with \`source_path\` → \`target_path\`. Paths are resolved relative
+to the article's directory. External URLs (\`https://\`, \`mailto:\`,
+\`tel:\`, ...), pure fragments (\`#section\`), and paths that escape
+every registered space are NOT recorded as relationships — but the
+underlying \`<a>\` tags stay in the file and render normally in the
+reader. The relationship graph is the internal corpus only; external
+citations aren't surfaced through the API.
+
+**Red link**: a relationship whose \`target_path\` does not (yet) match
+an entity row — a link to a future article. Red links are the queue
+the \`writer\` agent draws from. See \`GET /{space}/redlinks\`.
+
+**Plan wiki**: a wiki under \`wiki/_plans/...\` with
+\`<meta name="kind" content="plan">\`. Authored by the \`proposer\`
+agent; lists the gap-articles a given source suggests, with red links.
+Plans are real wikis — they appear in the index and you can read them.
+
+**Properties vs tags** (both JSON bags on the entity):
+  - \`properties\` is file-derived: rebuilt from \`<meta>\` tags every
+    time the file changes. Don't expect tags written here to persist.
+  - \`tags\` is agent-applied bookkeeping (e.g.
+    \`editor.processed_hash\`, \`proposer.processed_hash\`). Survives
+    content edits; cleared only when the file is deleted.
+
+================================================================
+## Canonical flows
+
+### Discovery — "what's in this daemon?"
+  1. \`GET /spaces\`                           — list spaces + entity counts.
+  2. \`GET /{space}/entities?type=wiki&sort=label&limit=200\`
+                                              — browse the article index.
+  3. \`GET /{space}/entities?type=wiki&sort=updated_at&limit=20\`
+                                              — what's been written or
+                                                edited most recently.
+
+### Search → read
+  1. \`GET /{space}/search?q=KEYWORD\`         — ripgrep across the corpus.
+                                                Returns matched paths
+                                                with snippets, ranked by
+                                                match count. Repeat \`q\`
+                                                up to 10 times to OR
+                                                patterns. \`?regex=true\`
+                                                opts into regex mode.
+  2. \`GET /{space}/entities/{path}\`          — metadata + inbound +
+                                                outbound for a hit.
+  3. \`GET /{space}/entities/{path}?include=content\`
+                                              — same plus the file body
+                                                from disk. (\`include=
+                                                content\` does NOT work
+                                                on the list endpoint —
+                                                only on the single-entity
+                                                endpoint, to avoid
+                                                payload bloat.)
+
+### Browsing the graph
+  - From any entity, \`outbound[]\` lists what it links to;
+    \`inbound[]\` lists who links to it. Walk from there.
+  - \`GET /{space}/redlinks\` exposes the unresolved targets — useful
+    to find aspirational topics the corpus has gestured at but not yet
+    written.
+
+### Reading articles (human-facing HTML)
+  - \`GET /\`                                  — daemon landing: spaces
+                                                list.
+  - \`GET /{space}/\`                          — alphabetical article
+                                                index for the space.
+  - \`GET /{space}/wiki/{path}\`               — wiki article with
+                                                chrome injection and
+                                                link classes
+                                                (\`arkeon-wiki\`,
+                                                \`arkeon-file\`,
+                                                \`arkeon-redlink\`).
+  - \`GET /{space}/{path}\`                    — fallback: any non-wiki
+                                                file in the watch dir
+                                                served with the right
+                                                Content-Type (markdown,
+                                                PDF, images, etc.).
+
+### Operator tasks
+  - \`GET /{space}/sources/scan\`              — every file in the watch
+                                                dir partitioned into
+                                                supported (indexed) vs
+                                                unsupported (binary,
+                                                skipped). Convert
+                                                unsupported files to
+                                                text to let the agents
+                                                read them.
+  - \`GET /{space}/recent\`                    — \`entity_edits\` feed
+                                                across humans and
+                                                agents.
+  - \`POST /{space}/agents/{role}/run\`        — fire one agent role on
+                                                demand. Synchronous;
+                                                409 if the space is
+                                                busy.
+
+================================================================
+## Routes
+
+### Daemon-level
+
+\`GET  /health\`                  — liveness. \`{"status":"ok"}\`.
+\`GET  /ready\`                   — readiness (DB reachable).
+\`GET  /llms.txt\`                — this document.
+\`GET  /help\`                    — alias for \`/llms.txt\`.
+\`GET  /\`                        — HTML spaces list (human-facing).
+
+### Spaces
+
+\`GET  /spaces\`                  — \`{spaces: [{name, watch_dir, created_at, entity_count}]}\`.
+\`GET  /spaces/{name}\`           — single space.
+\`POST /spaces\`                  — register a directory. Body
+                                  \`{name, watch_dir}\`. 409 on name
+                                  collision.
+
+### Entities
+
+\`GET  /{space}/entities\`
+  Filterable listing. Query params:
+    \`type\`                       — \`wiki\` | \`file\` | \`wiki,file\`
+    \`label_contains\`             — substring on \`label\`
+    \`path_contains\`              — substring on \`source_path\`
+    \`inbound_min\` / \`inbound_max\`  — edge-count bounds
+    \`outbound_min\` / \`outbound_max\`
+    \`updated_since\`              — ISO timestamp
+    \`edited_by_role\`             — last edit was by this role
+    \`has_tag\` / \`not_has_tag\`    — tag-key presence
+    \`tag_equals\`                 — \`key:value\`
+    \`tag_current\` / \`tag_outdated\`
+                                   — tag value matches/diverges from
+                                     current \`source_hash\`
+    \`sort\`                       — \`updated_at\` (default) | \`label\`
+                                   | \`inbound\` | \`outbound\`
+    \`limit\`                      — default 100, max 10000
+    \`offset\`
+    \`include=counts\`             — adds \`{inbound, outbound}\` per row
+  Response: \`{entities: [...], total, limit, offset}\`.
+
+\`GET  /{space}/entities/{path}\`
+  Single entity. Returns metadata + \`outbound[]\` + \`inbound[]\`.
+    \`?include=content\`           — adds \`content\` (file body from
+                                     disk). Use this for reading.
+
+### Relationships and history
+
+\`GET  /{space}/redlinks?limit=&offset=\`
+  Red-link queue. \`{redlinks: [{target_path, demand, linked_from:
+  string[]}], total, limit, offset}\`. Ranked by \`demand\` (number of
+  inbound edges).
+
+\`GET  /{space}/recent?since=&role=&limit=&offset=\`
+  \`entity_edits\` feed. Each row: \`{entity_path, by_role, edit_kind,
+  edit_note, content_hash, at}\`. \`by_role\` is one of \`human\`,
+  \`editor\`, \`proposer\`, \`writer\`, \`connector\`.
+
+### Search
+
+\`GET  /{space}/search?q=&type=&limit=&snippets=&regex=\`
+  Keyword search via ripgrep. \`q\` repeatable up to 10 times (OR).
+  \`type=wiki\` / \`type=file\` to restrict. \`regex=true\` to opt into
+  regex mode. \`snippets=N\` to cap snippets per file (default reasonable).
+  Response shape:
+    \`{query, keyword: {hits: [{space_name, source_path, type, label,
+      match_count, snippets: [{line_number, text}]}], total,
+      unmatched_files}}\`.
+
+### Operator
+
+\`GET  /{space}/sources/scan\`
+  Walks the watch dir and partitions every file into supported (will
+  be indexed) vs unsupported (binary, silently skipped). Response:
+    \`{space, watch_dir, total, supported: {count, by_ext}, unsupported:
+      {count, by_ext, examples: {".pdf": [paths]}}}\`.
+
+### Agents
+
+\`POST /{space}/agents/{role}/run\`
+  Fire one agent role on demand. Synchronous — blocks until done.
+  Roles: \`editor\`, \`proposer\`, \`writer\`, \`connector\`.
+    - \`editor\` — picks one unprocessed source, integrates its claims
+      into existing articles via str_replace / insert_at_line, or
+      appends red links to Open Threads. Never creates articles.
+    - \`proposer\` — runs after \`editor\` has tagged a source. Reads
+      the source plus everything that already cites it, writes a plan
+      wiki at \`wiki/_plans/{source-path}.html\` listing gap articles
+      as red links.
+    - \`writer\` — pulls the top-demand red link from the queue, reads
+      the plan(s) and sources that pointed at it, creates the new
+      article at the target path.
+    - \`connector\` — cross-space synthesis finder (newer role; see
+      space config for details).
+  Response on success: \`{space, role, duration_ms, steps, edits:
+  [{path, kind}], skipped, reason, usage, text}\`.
+  Errors: \`404\` (unknown role), \`409\` (space is already running a
+  role).
+
+### Chat (Phase 3, not yet implemented)
+
+\`POST   /{space}/chat\`                       → 501
+\`GET    /{space}/chat/{conversation_id}\`     → 501
+\`DELETE /{space}/chat/{conversation_id}\`     → 501
+
+================================================================
+## Errors
+
+All errors return JSON:
+  \`{"error": {"code": "...", "message": "...", "request_id": "..."}}\`
+
+Common codes: \`validation_error\` (400), \`not_found\` (404),
+\`space_busy\` (409, agent runs), \`not_implemented\` (501, chat
+stubs), \`internal_error\` (500).
+
+================================================================
+## Worked example
+
+Suppose a caller wants to answer "What does this corpus say about
+question leakage?" against the \`iarpa\` space:
+
+  1. Search:
+       GET /iarpa/search?q=leakage&type=wiki&limit=5
+  2. Pick the top hit (say \`wiki/how-do-we-prevent-question-leakage.html\`)
+     and read it with its outbound graph:
+       GET /iarpa/entities/wiki/how-do-we-prevent-question-leakage.html?include=content
+  3. Walk inbound to see which articles already cite this answer:
+       (use the \`inbound[]\` array on the response)
+  4. For unresolved questions in the area, check the red-link queue:
+       GET /iarpa/redlinks
+  5. For raw-source material the corpus has indexed:
+       GET /iarpa/entities?type=file&path_contains=leakage
+
+================================================================
+## Notes
+
+  - The filesystem is the source of truth. Editing a file in your
+    editor flows back to the index automatically via the file watcher
+    (~500ms debounce).
+  - \`<a href>\` links to nonexistent targets are red links, not errors.
+    Resolution is a LEFT JOIN at query time.
+  - Articles render identically under \`file://\` and \`http://\` — the
+    reader decorates anchors but never rewrites hrefs.
+`;

--- a/packages/arkeon/src/server/lib/llms-txt.ts
+++ b/packages/arkeon/src/server/lib/llms-txt.ts
@@ -25,8 +25,9 @@ is no auth.
 
 **Space**: a registered watch directory, identified by name. URLs are
 all rooted at the space: \`/{space}/...\`. Names match
-\`[a-zA-Z0-9][a-zA-Z0-9._-]*\`. Multiple spaces can coexist on one
-daemon.
+\`[a-zA-Z0-9][a-zA-Z0-9._-]*\`, max 100 chars, and cannot collide with
+a daemon-level route name (\`health\`, \`ready\`, \`help\`, \`llms.txt\`,
+\`spaces\` are reserved). Multiple spaces can coexist on one daemon.
 
 **Entity**: a row in the index for one file. Two types:
   - \`wiki\`  — an article under \`wiki/**/*.html\` with a \`<title>\` and
@@ -48,9 +49,21 @@ underlying \`<a>\` tags stay in the file and render normally in the
 reader. The relationship graph is the internal corpus only; external
 citations aren't surfaced through the API.
 
-**Red link**: a relationship whose \`target_path\` does not (yet) match
-an entity row — a link to a future article. Red links are the queue
-the \`writer\` agent draws from. See \`GET /{space}/redlinks\`.
+**Cross-space links**: a wiki can link to an article in another
+registered space via the canonical \`/{otherSpace}/{path}\` href form.
+On disk these write as ordinary relative paths (so wikis still open
+under \`file://\`); over HTTP the reader rewrites them back to
+\`/{otherSpace}/...\` so the link clicks through. In the relationship
+graph the edge's \`target_path\` is stored in the canonical
+\`/{otherSpace}/{path}\` form. \`GET /{space}/entities/{path}\` returns
+inbound citations from any space (each inbound row carries the
+linker's home \`space_name\`); cross-space red links are filtered out
+of \`GET /{space}/redlinks\` so a writer scoped to space A doesn't try
+to fulfill gaps in space B.
+
+**Red link**: a same-space relationship whose \`target_path\` does not
+(yet) match an entity row — a link to a future article. Red links are
+the queue the \`writer\` agent draws from. See \`GET /{space}/redlinks\`.
 
 **Plan wiki**: a wiki under \`wiki/_plans/...\` with
 \`<meta name="kind" content="plan">\`. Authored by the \`proposer\`
@@ -151,8 +164,9 @@ Plans are real wikis — they appear in the index and you can read them.
 \`GET  /spaces\`                  — \`{spaces: [{name, watch_dir, created_at, entity_count}]}\`.
 \`GET  /spaces/{name}\`           — single space.
 \`POST /spaces\`                  — register a directory. Body
-                                  \`{name, watch_dir}\`. 409 on name
-                                  collision.
+                                  \`{name, watch_dir}\`. Returns 201
+                                  with \`{name, watch_dir}\`. 409 on
+                                  name collision.
 
 ### Entities
 
@@ -190,16 +204,16 @@ Plans are real wikis — they appear in the index and you can read them.
   inbound edges).
 
 \`GET  /{space}/recent?since=&role=&limit=&offset=\`
-  \`entity_edits\` feed. Each row: \`{entity_path, by_role, edit_kind,
-  edit_note, content_hash, at}\`. \`by_role\` is one of \`human\`,
-  \`editor\`, \`proposer\`, \`writer\`, \`connector\`.
+  \`entity_edits\` feed. Response: \`{space, edits: [{entity_path,
+  by_role, edit_kind, edit_note, content_hash, at}]}\`. \`by_role\` is
+  one of \`human\`, \`editor\`, \`proposer\`, \`writer\`, \`connector\`.
 
 ### Search
 
 \`GET  /{space}/search?q=&type=&limit=&snippets=&regex=\`
   Keyword search via ripgrep. \`q\` repeatable up to 10 times (OR).
   \`type=wiki\` / \`type=file\` to restrict. \`regex=true\` to opt into
-  regex mode. \`snippets=N\` to cap snippets per file (default reasonable).
+  regex mode. \`snippets=N\` to cap snippets per file (default 3).
   Response shape:
     \`{query, keyword: {hits: [{space_name, source_path, type, label,
       match_count, snippets: [{line_number, text}]}], total,
@@ -245,7 +259,13 @@ Plans are real wikis — they appear in the index and you can read them.
 ## Errors
 
 All errors return JSON:
-  \`{"error": {"code": "...", "message": "...", "request_id": "..."}}\`
+  \`{"error": {"code": "...", "message": "...", "request_id": "...",
+              "details": {...}}}\`
+
+\`details\` is optional and only set for codes that carry structured
+context. Today's only example: \`space_busy\` populates
+\`details.in_flight_role\` so a caller can tell which role is holding
+the per-space mutex.
 
 Common codes: \`validation_error\` (400), \`not_found\` (404),
 \`space_busy\` (409, agent runs), \`not_implemented\` (501, chat

--- a/packages/arkeon/src/server/routes/spaces.ts
+++ b/packages/arkeon/src/server/routes/spaces.ts
@@ -23,6 +23,20 @@ const SPACE_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
 const MAX_SPACE_NAME_LEN = 100;
 
 /**
+ * Daemon-level route names that would shadow a space called the same
+ * thing. Hono's exact-match routes win over `/:space`, so a user who
+ * registers a space called `help` would find `GET /help` returns the
+ * orientation guide instead of their article index. Reject up front.
+ */
+const RESERVED_SPACE_NAMES = new Set([
+  "health",
+  "ready",
+  "help",
+  "llms.txt",
+  "spaces",
+]);
+
+/**
  * POST /spaces — register a new space and start watching.
  * Body: { name: string, watch_dir: string }
  *
@@ -55,6 +69,14 @@ spacesRouter.post("/", async (c) => {
       400,
       "validation_error",
       `space name cannot contain '..' (path-traversal guard).`,
+    );
+  }
+  if (RESERVED_SPACE_NAMES.has(body.name.toLowerCase())) {
+    throw new ApiError(
+      400,
+      "validation_error",
+      `space name '${body.name}' is reserved (collides with a daemon-level route). ` +
+        `Reserved: ${[...RESERVED_SPACE_NAMES].join(", ")}.`,
     );
   }
 

--- a/packages/arkeon/test/unit/llms-txt-route.test.ts
+++ b/packages/arkeon/test/unit/llms-txt-route.test.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Integration test for the /llms.txt + /help routes. Mounts the real
+ * Hono app, fetches both URLs, asserts they serve the LLMS_TXT
+ * constant byte-for-byte under `text/plain`. Catches wiring bugs
+ * (mounted under a router with a different content-type, alias drift
+ * between the two routes) that the content-only smoke test can't see.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createApp } from "../../src/server/app.js";
+import { initDb, closeDb } from "../../src/server/lib/sql.js";
+import { runMigrations } from "../../src/schema/migrate.js";
+import { LLMS_TXT } from "../../src/server/lib/llms-txt.js";
+
+let workdir: string;
+let app: ReturnType<typeof createApp>;
+
+beforeAll(async () => {
+  workdir = mkdtempSync(join(tmpdir(), "arkeon-llms-route-"));
+  const dbPath = join(workdir, "arke.db");
+  initDb(dbPath);
+  await runMigrations({ dbPath });
+  app = createApp();
+});
+
+afterAll(() => {
+  closeDb();
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+describe("/llms.txt + /help routes", () => {
+  it("GET /llms.txt returns the constant as text/plain", async () => {
+    const res = await app.fetch(new Request("http://test/llms.txt"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(await res.text()).toBe(LLMS_TXT);
+  });
+
+  it("GET /help serves the same bytes as /llms.txt", async () => {
+    const res = await app.fetch(new Request("http://test/help"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(await res.text()).toBe(LLMS_TXT);
+  });
+
+  it("POST /spaces rejects a space called 'help' so the route can't be shadowed", async () => {
+    const res = await app.fetch(
+      new Request("http://test/spaces", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "help", watch_dir: workdir }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("validation_error");
+    expect(body.error.message).toContain("reserved");
+  });
+});

--- a/packages/arkeon/test/unit/llms-txt.test.ts
+++ b/packages/arkeon/test/unit/llms-txt.test.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Drift guard for the hand-written API guide at /llms.txt and /help.
+ * If you add or rename a route, update src/server/lib/llms-txt.ts so
+ * these strings are still present.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { LLMS_TXT } from "../../src/server/lib/llms-txt.js";
+
+const REQUIRED_ROUTES = [
+  "GET  /health",
+  "GET  /ready",
+  "GET  /llms.txt",
+  "GET  /help",
+  "GET  /spaces",
+  "POST /spaces",
+  "GET  /{space}/entities",
+  "GET  /{space}/entities/{path}",
+  "GET  /{space}/redlinks",
+  "GET  /{space}/recent",
+  "GET  /{space}/search",
+  "GET  /{space}/sources/scan",
+  "POST /{space}/agents/{role}/run",
+];
+
+const REQUIRED_CONCEPTS = [
+  "Space",
+  "Entity",
+  "Red link",
+  "Plan wiki",
+  "Properties vs tags",
+];
+
+const REQUIRED_AGENT_ROLES = ["editor", "proposer", "writer", "connector"];
+
+describe("llms.txt", () => {
+  for (const route of REQUIRED_ROUTES) {
+    it(`mentions ${route}`, () => {
+      expect(LLMS_TXT).toContain(route);
+    });
+  }
+
+  for (const concept of REQUIRED_CONCEPTS) {
+    it(`mentions concept "${concept}"`, () => {
+      expect(LLMS_TXT).toContain(concept);
+    });
+  }
+
+  for (const role of REQUIRED_AGENT_ROLES) {
+    it(`mentions agent role "${role}"`, () => {
+      expect(LLMS_TXT).toContain(role);
+    });
+  }
+
+  it("is plain ASCII-ish text, not HTML", () => {
+    expect(LLMS_TXT.startsWith("# arkeon-wiki")).toBe(true);
+    expect(LLMS_TXT).not.toContain("<html>");
+    expect(LLMS_TXT).not.toContain("<!DOCTYPE");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `GET /llms.txt` and `GET /help` (alias) serving a hand-written orientation guide for callers — humans and LLMs. Covers the data model (spaces, wiki/file entities, relationships, red links, plan wikis, properties-vs-tags), the canonical flows (discovery, search→read, graph walk, operator tasks), every route with query params and response shapes, an error envelope reference, and a worked curl example.
- Wires the same `LLMS_TXT` constant to both routes so they stay byte-identical; mounted in `app.ts` next to `/health` and `/ready`.
- Adds a drift-guard unit test (`llms-txt.test.ts`, 23 cases) that asserts every route string, concept name, and agent role is present in the doc. Rename a route without updating the guide and CI fails.

## Test plan

- [x] `npm run typecheck -w packages/arkeon`
- [x] `npx vitest run packages/arkeon/test/unit/llms-txt.test.ts` — 23/23
- [ ] After merge, hit `curl http://localhost:<port>/llms.txt` and `curl http://localhost:<port>/help` against a running daemon to eyeball the content end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)