### PR TITLE
mcp: ship pre-formatted [Label](url) links in read tools

### DIFF
--- a/packages/arkeon/src/mcp/client.ts
+++ b/packages/arkeon/src/mcp/client.ts
@@ -140,6 +140,21 @@ export class ArkeonWikiClient {
       .join("/")}`;
   }
 
+  /**
+   * Pre-formatted markdown link the model can copy verbatim into its
+   * answer. Shipping `[Label](url)` directly in tool output is more
+   * reliable than handing the model `Label — path · url` and asking it
+   * to assemble the markdown itself — models routinely emit prose
+   * without the brackets unless the link arrives ready-made.
+   */
+  markdownLink(space: string, sourcePath: string, label?: string): string {
+    const displayLabel = label ?? sourcePath.replace(/^wiki\//, "").replace(/\.html$/, "");
+    // Escape `]` in the label so it can't break out of the markdown
+    // bracket syntax. Other special chars are fine inside link text.
+    const safe = displayLabel.replace(/\]/g, "\\]");
+    return `[${safe}](${this.entityUrl(space, sourcePath)})`;
+  }
+
   async health(): Promise<{ ok: boolean; status: number }> {
     try {
       const res = await fetch(this.config.apiUrl + "/health");

--- a/packages/arkeon/src/mcp/flows.ts
+++ b/packages/arkeon/src/mcp/flows.ts
@@ -73,13 +73,18 @@ If the corpus uses different vocabulary than the user's question, fall back to \
 
 Call \`read_article\` ONCE with a \`paths\` array containing all the candidates (e.g. \`paths: ["wiki/foo.html", "wiki/bar.html", "wiki/baz.html"]\`). The tool fetches them in parallel — batching is dramatically faster than calling read_article multiple times. Prefer fewer deeper reads to many shallow ones — the user wants an answer grounded in the wiki, not a headline summary.
 
-## Step 3 — Answer
+## Step 3 — Answer with REQUIRED clickable citations
 
-Lead with the claim. Cite each source inline using **clickable markdown links** to the frontend so the user can drill in:
+Lead with the claim. **Every reference to a wiki article must be a clickable markdown link.** Plain prose names, bare paths, or bare URLs are not acceptable — the user wants to drill into sources.
+
+The search_wiki, list_articles, list_redlinks, and read_article tools all ship ready-made \`[Label](url)\` markdown links in their output. **Copy those links into your answer verbatim** — do not rewrite them, do not strip the bracket syntax, do not paraphrase them into prose. If you mention an article, it must arrive as a clickable link.
 
 \`\`\`markdown
-- The current empirical state is **rough parity** ([current-state-kg-vs-rag](http://localhost:<port>/<space>/wiki/current-state-kg-vs-rag.html)).
-- That picture started shifting after the 49/53 finding ([kg-vs-rag-belief-arc](http://localhost:<port>/<space>/wiki/kg-vs-rag-belief-arc.html)).
+✓ The current empirical state is **rough parity** ([current-state-kg-vs-rag](http://localhost:8186/iarpa/wiki/current-state-kg-vs-rag.html)).
+✓ That picture shifted after the 49/53 finding ([KG vs RAG belief arc](http://localhost:8186/iarpa/wiki/kg-vs-rag-belief-arc.html)).
+
+✗ The current empirical state is rough parity — see the kg-vs-rag article.
+✗ That shifted after the 49/53 finding (wiki/kg-vs-rag-belief-arc.html).
 \`\`\`
 
 If the wiki doesn't have the answer, **say so honestly**. Don't hallucinate from general knowledge. Offer to capture the user's framing as a thought (transitions to capture) or fetch a source on the topic (transitions to fetch).

--- a/packages/arkeon/src/mcp/server.ts
+++ b/packages/arkeon/src/mcp/server.ts
@@ -47,7 +47,9 @@ Nine tools wrap the daemon's HTTP API (search_wiki, read_article, capture_though
 
 The space + API URL are bound via env (ARKEON_WIKI_SPACE, ARKEON_WIKI_URL) so the user doesn't have to thread them through every call.
 
-CRITICAL: when capturing thoughts or saving conversations, preserve content verbatim. Do not summarize, paraphrase, or tighten what the user (or their attachments / pasted sources) says. The wiki's value comes from raw source material reaching the editor agent intact.`;
+CRITICAL: when capturing thoughts or saving conversations, preserve content verbatim. Do not summarize, paraphrase, or tighten what the user (or their attachments / pasted sources) says. The wiki's value comes from raw source material reaching the editor agent intact.
+
+REQUIRED OUTPUT SHAPE: every reference to a wiki article in your answer must be a clickable markdown link of the form [Label](url). The read tools ship ready-made [Label](url) links — copy them verbatim. Never write a bare path, a bare URL, or just the article's name in prose. The user clicks these links to drill into the source.`;
 
 export function buildServer(client: ArkeonWikiClient = new ArkeonWikiClient(loadConfig())): McpServer {
   const server = new McpServer(

--- a/packages/arkeon/src/mcp/tools/list-articles.ts
+++ b/packages/arkeon/src/mcp/tools/list-articles.ts
@@ -43,8 +43,8 @@ export function registerListArticles(server: McpServer, client: ArkeonWikiClient
         ? data.entities
             .map((e) => {
               const desc = (e.properties?.short_description as string | undefined) ?? "";
-              const url = client.entityUrl(targetSpace, e.source_path);
-              return `- ${e.label ?? e.source_path} — ${e.source_path} · ${url}${desc ? `\n    ${desc}` : ""}`;
+              const link = client.markdownLink(targetSpace, e.source_path, e.label);
+              return `- ${link} — \`${e.source_path}\`${desc ? `\n    ${desc}` : ""}`;
             })
             .join("\n")
         : "No matching articles. Try search_wiki with a different query, or check list_redlinks for what the corpus wants written next.";

--- a/packages/arkeon/src/mcp/tools/list-redlinks.ts
+++ b/packages/arkeon/src/mcp/tools/list-redlinks.ts
@@ -29,9 +29,23 @@ export function registerListRedlinks(server: McpServer, client: ArkeonWikiClient
     async ({ limit, space }) => {
       const targetSpace = client.resolveSpace(space ?? undefined);
       const data = await client.getJson<RedlinksResponse>(`/${targetSpace}/redlinks`, { limit });
+      // Red links are by definition articles that don't exist yet, so
+      // the `[label](url)` link will be a 404 — but the URL is still
+      // useful: it's where the article WOULD live, and clicking it in
+      // a browser is the user's signal-of-interest the writer agent
+      // already keys off (inbound_max=0 + demand). The `linked_from`
+      // articles do exist and should be clickable citations to where
+      // the demand came from.
       const text = data.redlinks.length
         ? data.redlinks
-            .map((r) => `- ${r.target_path} (demand: ${r.demand}; linked from: ${r.linked_from.slice(0, 3).join(", ")})`)
+            .map((r) => {
+              const target = client.markdownLink(targetSpace, r.target_path);
+              const sources = r.linked_from
+                .slice(0, 3)
+                .map((p) => client.markdownLink(targetSpace, p))
+                .join(", ");
+              return `- ${target} (demand: ${r.demand}; linked from: ${sources})`;
+            })
             .join("\n")
         : "No red links queued — the corpus has nothing in the writer's pipeline right now.";
       return {

--- a/packages/arkeon/src/mcp/tools/read-article.ts
+++ b/packages/arkeon/src/mcp/tools/read-article.ts
@@ -65,14 +65,15 @@ export function registerReadArticle(server: McpServer, client: ArkeonWikiClient)
       );
 
       // One text block per article — easier for the model to parse than a
-      // single concatenated dump. Each block carries the fully-qualified
-      // reader URL so the model can emit clickable citations without
-      // round-tripping to daemon_status to learn the port.
+      // single concatenated dump. Each block opens with a ready-made
+      // markdown link the model can copy verbatim into its citation, so
+      // it doesn't have to assemble `[Label](url)` from the path + URL
+      // itself (which it often skips, defaulting to prose).
       const content = results.map((r) => ({
         type: "text" as const,
         text: r.error
           ? `# ${r.path}\n\n(error reading: ${r.error})`
-          : `# ${r.label ?? r.path}\n_${r.path}_ · ${client.entityUrl(targetSpace, r.path)}\n\n${r.content}`,
+          : `# ${r.label ?? r.path}\n**Cite as:** ${client.markdownLink(targetSpace, r.path, r.label)} · path: \`${r.path}\`\n\n${r.content}`,
       }));
 
       return {

--- a/packages/arkeon/src/mcp/tools/search-wiki.ts
+++ b/packages/arkeon/src/mcp/tools/search-wiki.ts
@@ -49,16 +49,15 @@ export function registerSearchWiki(server: McpServer, client: ArkeonWikiClient):
         limit,
       });
       const hits = data.keyword?.hits ?? [];
-      // Emit fully-qualified reader URLs so the model can cite hits
-      // directly without first calling daemon_status to learn the port.
+      // Ship ready-made `[Label](url)` markdown so the model can copy
+      // links verbatim into its answer. Plain paths or bare URLs in the
+      // tool output get rendered as prose by the model — pre-formatted
+      // markdown survives the trip intact.
       const text = hits.length
         ? hits
             .map(
               (h) =>
-                `- ${h.label ?? h.source_path} — ${h.source_path} · ${client.entityUrl(
-                  targetSpace,
-                  h.source_path,
-                )} (matches: ${h.match_count})`,
+                `- ${client.markdownLink(targetSpace, h.source_path, h.label)} — \`${h.source_path}\` (matches: ${h.match_count})`,
             )
             .join("\n")
         : "No hits. Try list_articles with `label_contains` if the corpus uses different vocabulary than the query.";

--- a/packages/arkeon/test/unit/mcp.test.ts
+++ b/packages/arkeon/test/unit/mcp.test.ts
@@ -125,7 +125,7 @@ describe("MCP server", () => {
     expect(parsed.text).toBe(verbatim);
   });
 
-  it("search_wiki emits fully-qualified reader URLs in text output", async () => {
+  it("search_wiki emits ready-made [Label](url) markdown links in text output", async () => {
     stub = await startStub({
       "GET /test-space/search": {
         status: 200,
@@ -152,8 +152,18 @@ describe("MCP server", () => {
       content: Array<{ text: string }>;
     };
     const text = result.content[0].text;
-    expect(text).toContain(`http://127.0.0.1:${stub.port}/test-space/wiki/foo.html`);
-    expect(text).toContain(`http://127.0.0.1:${stub.port}/test-space/wiki/bar.html`);
+    expect(text).toContain(`[Foo](http://127.0.0.1:${stub.port}/test-space/wiki/foo.html)`);
+    expect(text).toContain(`[Bar](http://127.0.0.1:${stub.port}/test-space/wiki/bar.html)`);
+  });
+
+  it("markdownLink helper escapes brackets in label and percent-encodes path segments", () => {
+    const client = new ArkeonWikiClient({ apiUrl: "http://localhost:8000", caller: "test" });
+    const link = client.markdownLink("space", "wiki/foo bar.html", "Label] with ] brackets");
+    expect(link).toBe("[Label\\] with \\] brackets](http://localhost:8000/space/wiki/foo%20bar.html)");
+    // Without label, derives display text from path.
+    expect(client.markdownLink("space", "wiki/photosynthesis.html")).toBe(
+      "[photosynthesis](http://localhost:8000/space/wiki/photosynthesis.html)",
+    );
   });
 
   it("save_conversation auto-suffixes on 409 (typed HttpError detection)", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #164. The Adam Tooze test session showed the model writing prose-without-clickable-links even though the URLs were in the tool output. Models that aren't explicitly trained to wrap names in brackets default to prose unless the markdown arrives pre-assembled.

This PR ships `[Label](url)` markdown links directly from the read tools, so the model can copy them verbatim into its answer.

## Changes

- **`client.markdownLink(space, path, label?)`** centralizes the format. Escapes `]` so labels can't break out of bracket syntax; falls back to the slug as display text when no label exists (useful for red links).
- **`search_wiki`, `list_articles`, `read_article`** emit `[Label](url)` instead of `Label — path · url`.
- **`list_redlinks`** previously had no URLs at all — now emits clickable links for both the target and `linked_from` items.
- **ASK flow doc strengthened**: every wiki reference MUST be a `[Label](url)` link. Plain prose, bare paths, and bare URLs are explicitly called out as wrong. Server-level instructions field echoes the same rule.

## Sizes (chartbook corpus, default limits)

| Tool | Before | After |
|---|---|---|
| list_articles | 10.7 KB | 10.7 KB |
| list_redlinks | 6.8 KB | 8.9 KB *(+URLs)* |
| search_wiki | 4.4 KB | 4.5 KB |

All well under Claude Desktop's choke threshold.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 413/413 (one new: markdownLink bracket-escape + path-encoding round-trip)
- [x] `npm run build` clean
- [x] Live chartbook smoke: search_wiki, list_articles, list_redlinks all emit ready-to-copy `[Label](url)` markdown
- [ ] End-to-end: re-run the "what has Adam been thinking about" query in Claude Desktop and verify the answer renders clickable links

🤖 Generated with [Claude Code](https://claude.com/claude-code)