### PR TITLE
api+watcher: index assets, add stat-fingerprint cache, unify search filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,14 +60,22 @@ Parsing uses a real HTML parser (`node-html-parser`), not regex — apostrophe-i
 
 There is no YAML frontmatter on wikis, no `[[wikilink]]` syntax, no placeholder rows. A link to a target that doesn't exist on disk is a **red link** — a `relationships` row with no matching `entities` row. Resolution is a LEFT JOIN at query time; surfaced via `GET /{space}/redlinks` and the `list_redlinks` agent tool.
 
-Source files (anywhere outside `wiki/`) are indexed as `type='file'` with `{file_type: <ext>}`. Eligibility is a three-tier check in `src/server/lib/fs-watcher.ts`: (1) `BINARY_EXTENSIONS` denylist short-circuits known-binary formats (`.pdf`, `.docx`, `.png`, fonts, archives, etc.), (2) `TEXT_EXTENSIONS` allowlist short-circuits common text formats (`.txt`, `.html`, `.md`, `.json`, `.csv`, `.yaml`, source code, etc.), (3) anything else is decided by `sniffIsText()` — read the first 8 KB, look for NUL bytes. No NUL → text → indexed. This is the same heuristic `git`/`grep -I`/`file(1)` use; it lets us cover any text file (extensionless `README`/`LICENSE`, unfamiliar `.cfg` variants, etc.) without an ever-growing allowlist. Wikis themselves are still authored in HTML only — the eligibility rules above are for *source* material the agents read. Structured metadata lives in `<meta name="X" content="Y">` tags on the wiki itself.
+Files (anywhere outside `wiki/`) are indexed as `type='file'`. Eligibility is a small denylist (`SKIP_EXTENSIONS` for secrets and editor scratch — `.env`, `.pem`, `.swp`, `.tmp`, …; `SKIP_BASENAMES` for OS junk — `.DS_Store`, `Thumbs.db`). Everything else gets an entity row. Classification into kind happens in `classifyFile()` (`src/server/lib/fs-watcher.ts`): `TEXT_EXTENSIONS` allowlist → `kind='text'`; `ASSET_EXTENSIONS` allowlist → `kind='asset'`; unknown extension → sniff first 8 KB, no NUL → text, otherwise asset.
+
+`kind='text'` is what enters the agent queues. Wikis are always text. Source files classified as text get parsed (HTML wikis emit `<a href>` edges; other text files just record `file_type`). Queue queries in editor / proposer / connector pass `kind='text'` so attachments stay out of the work feed.
+
+`kind='asset'` covers everything binary — images, PDFs, audio, video, archives, fonts, office documents. Asset rows exist so `<a href="report.pdf">` and `<img src="chart.png">` inside wikis resolve as real links instead of red links — they're addressable but never feed the agents. Asset rows carry `{file_type, size_bytes}` in `properties`, no parsed metadata, no link extraction, no `entity_edits` audit rows. `properties.size_bytes` is the only column on an asset that isn't on a text row.
+
+**Change detection.** `source_hash` is canonical SHA-256 of content for both kinds — uniform meaning across the codebase. Alongside it, `stat_fingerprint` (`mtime_ms-size_bytes`) is a cheap cache: if the fingerprint matches the stored value, the bytes are guaranteed unchanged and `syncFile` skips the content read entirely. On a fingerprint miss it computes the real content hash (streaming for assets so multi-GB files don't try to fit in RAM); if the hash matches `source_hash`, the change was a touch (refresh fingerprint, no parse, no `updated_at` bump). This keeps `source_hash` semantically uniform while making syncs O(1) on unchanged files — particularly load-bearing for large assets during a reconcile walk.
+
+Wikis themselves are still authored in HTML only — the eligibility rules above are for *source* material the agents read. Structured metadata lives in `<meta name="X" content="Y">` tags on the wiki itself.
 
 ## Writing (three roles: `editor`, `proposer`, `writer`)
 
 Three bundled agent roles cooperate on a single-job-each pipeline. Each runs on its own cron, all three serialized per-space by the in-process mutex.
 
 **`editor`** (source-driven, runs first per source). Each tick:
-1. Picks one source the editor hasn't tagged at its current `source_hash` (`list_entities?type=file&not_has_tag=editor.processed_hash`).
+1. Picks one source the editor hasn't tagged at its current `source_hash` (`list_entities?type=file&kind=text&not_has_tag=editor.processed_hash`).
 2. Reads the source; surveys existing articles via `list_entities` (using `properties.short_description` for semantic matching).
 3. For each existing article the source bears on, applies one or both:
    - **Content edit** — `edit_file insert_at_line` adds a citation-bearing paragraph in Evidence, or `edit_file str_replace` revises Current Answer when the source reshapes the thesis. Always cites the source inline via `<a href="../sources/...">`.
@@ -77,7 +85,7 @@ Three bundled agent roles cooperate on a single-job-each pipeline. Each runs on 
 Editor never creates articles. Zero edits per tick is fine — many sources are tangential to existing articles and should be tagged-and-skipped.
 
 **`proposer`** (source-driven, runs SECOND per source by data dependency). Each tick:
-1. Picks one source the editor has tagged but the proposer hasn't (`list_entities?type=file&has_tag=editor.processed_hash&not_has_tag=proposer.processed_hash`).
+1. Picks one source the editor has tagged but the proposer hasn't (`list_entities?type=file&kind=text&has_tag=editor.processed_hash&not_has_tag=proposer.processed_hash`).
 2. Reads the source.
 3. **Calls `get_entity` on the source path** — `entity.inbound` lists every article that already cites this source (the editor's integration points). These tell the proposer which concepts the editor already integrated.
 4. **Searches the broader corpus** for thematically-adjacent material on the source's main themes — so the plan can seed cross-source citations the writer will follow later. Without this step plans tend to cite only their originating source, which biases the writer toward single-source articles.
@@ -128,7 +136,7 @@ The read-gate is orthogonal to `edit-context.ts`, which exists for **attribution
 Six tables in SQLite, fresh `001-foundation.sql`:
 
 - `spaces (name PK, watch_dir UNIQUE, created_at)`
-- `entities (space_name, source_path)` composite PK, `type` CHECK (`'wiki'|'file'`), `label`, `source_hash`, `properties` JSON (file-derived), `tags` JSON (agent-applied), timestamps
+- `entities (space_name, source_path)` composite PK, `type` CHECK (`'wiki'|'file'`), `kind` CHECK (`'text'|'asset'`) — text drives the agent queues, asset is link-resolution-only — `label`, `source_hash` (SHA-256 of content for both kinds), `stat_fingerprint` (mtime+size cache for skipping unchanged reads), `properties` JSON (file-derived), `tags` JSON (agent-applied), timestamps
 - `relationships (space_name, source_path, target_path)` composite PK, `link_text` — no FK on `target_path` (red links!)
 - `entity_edits (space_name, entity_path, at)` composite PK — `at` carries millisecond precision via `strftime('%f')` so same-second writes don't collide. Not FK'd; history survives entity deletion.
 - `conversations (id PK ULID, space_name, article_path NULLABLE, title)` — the **one** v0 table with an explicit ID, because conversations have no on-disk file to derive identity from. Phase 1 lays the schema; Phase 3 wires the routes.
@@ -156,7 +164,7 @@ Tags exist so multi-agent pipelines can track "has role X processed entity Y" wi
 - `src/server/lib/search.ts` — ripgrep adapter (`@vscode/ripgrep`), spawns per-space, parses `--json` events, joins back to entities by path.
 - `src/server/lib/reader.ts` — Phase 2 rendering primitives: `classifyAnchor`, `instrumentArticle`, `renderSpaceIndex`, `renderArticleIndex`. Pure functions; the route handlers in `routes/reader.ts` are thin glue.
 - `src/server/lib/inbox.ts` — `slugify`, `utcDateStamp`, `resolveInboxPath` (with collision auto-suffix), `buildInboxContent`. Pure helpers for the `POST /:space/inbox` route.
-- `src/server/lib/source-write-guards.ts` — `assertSourcePath` / `assertTextContent` / `sanitizeCaller`. Shared validation for both write-back endpoints. Reuses `BINARY_EXTENSIONS`/`TEXT_EXTENSIONS`/`sniffBufferIsText` from fs-watcher so HTTP-uploaded content is held to the same eligibility bar as watcher-detected files.
+- `src/server/lib/source-write-guards.ts` — `assertSourcePath` / `assertTextContent` / `sanitizeCaller`. Shared validation for both write-back endpoints. The HTTP write APIs are text-only — `assertTextContent` rejects SKIP_EXTENSIONS (secrets), ASSET_EXTENSIONS (binaries: drop them on disk instead, the watcher indexes them as kind='asset'), and content that sniffs binary. Reuses `sniffBufferIsText` from fs-watcher so the eligibility bar is the same one the watcher applies.
 - `src/server/routes/inbox.ts` — `POST /:space/inbox` + `PUT /:space/sources/*`. Both go through `applyEdit` so the sync is synchronous and the response carries the synced entity. New sources have no `*.processed_hash` tag, so the editor cron picks them up on the next tick.
 - `src/server/routes/reader.ts` — the four human-facing routes (`/`, `/:space`, `/:space/`, `/:space/wiki/*`, `/:space/*`). Mounted last so `/:space/*` is a true fallback.
 - `src/server/agents/` — declarative `.arkeon/agents.yaml` config (Zod-validated), bundled role templates (`templates/*.yaml`), role-builder, tool registry, `runAgent` loop (Vercel AI SDK), per-space cron scheduler.

--- a/SETUP.md
+++ b/SETUP.md
@@ -172,13 +172,15 @@ The `instructions:` text will appear under `defaults:` in the `config show` outp
 
 Drop text files anywhere in the directory (any subfolder is fine — `sources/`, `notes/`, top-level, doesn't matter). The watcher picks them up automatically.
 
-**What gets indexed**: any text file the watcher can read. The decision is three-tier:
+**What gets indexed**: nearly everything. Files split into two kinds:
 
-1. **Known-binary extensions are rejected outright** — `.pdf`, `.docx`, `.pptx`, `.xlsx`, `.png`, `.jpg`, `.mp3`, `.mp4`, `.zip`, fonts, native binaries, etc. (Full list: `BINARY_EXTENSIONS` in `src/server/lib/fs-watcher.ts`.)
-2. **Known-text extensions are accepted outright** — `.txt`, `.html`, `.md`, `.json`, `.csv`, `.tsv`, `.xml`, `.yaml`, `.toml`, `.log`, `.rst`, `.tex`, and most common source-code extensions. (Full list: `TEXT_EXTENSIONS`.)
-3. **Everything else** — extensionless files (`README`, `LICENSE`), unfamiliar extensions, etc. — is decided by a **content sniff**: the watcher reads the first 8 KB and checks for NUL bytes. No NUL → text → indexed. NUL → binary → ignored. Same rule `git`, `grep -I`, and `file(1)` use.
+- **`kind='text'`** — corpus material the agents read and process. Wikis (always text), plus source files classified as text: `.txt`, `.html`, `.md`, `.json`, `.csv`, `.yaml`, `.log`, `.rst`, `.tex`, and most source-code extensions. (Full list: `TEXT_EXTENSIONS`.) Unknown extensions get a content sniff — first 8 KB without a NUL byte → text. This is the queue-eligible kind.
 
-Net effect: drop any text file into the watch dir and it gets indexed, regardless of extension. Binaries (PDFs, DOCX, images) need conversion to text first — see below. Wikis themselves are still authored in HTML only; everything described here is for *source* material the agents read.
+- **`kind='asset'`** — binary attachments (PDFs, DOCX, images, audio, video, archives, fonts). Indexed so `<img src="chart.png">` and `<a href="report.pdf">` resolve to real entities instead of red links, but never enter the agent queues. Agents can still fetch and read them via the `fetch` tool (images and PDFs).
+
+The only files refused outright are **secrets and OS junk** — `.env`, `.envrc`, `.pem`/`.p12`/PGP keys, `.swp`/`.tmp`/`.bak`, `.DS_Store`, `Thumbs.db`. (Full lists: `SKIP_EXTENSIONS` and `SKIP_BASENAMES` in `src/server/lib/fs-watcher.ts`.)
+
+Wikis themselves are still authored in HTML only; everything described here is for *source* material the agents read or link to.
 
 > **Heads-up — source code is indexed too.** `.ts`, `.py`, `.go`, `.rs`, `.java`, `.sh`, `.sql`, CSS, and most other source-code extensions live in `TEXT_EXTENSIONS`. If you point arkeon-wiki at a project root (e.g. `~/projects/my-app`), expect every file outside `node_modules`/`.git`/etc. to land in the index — including the codebase itself. That's intentional (agents can reason over code-as-source), but it means a "personal knowledge base" watch dir and a "checked-out repo" watch dir behave very differently. Use `arkeon-wiki sources scan` to preview before letting the daemon loose.
 

--- a/packages/arkeon/src/schema/003-entity-kind.sql
+++ b/packages/arkeon/src/schema/003-entity-kind.sql
@@ -1,0 +1,41 @@
+-- Copyright (c) 2026 Arkeon Technologies, Inc.
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Asset indexing + stat-fingerprint cache.
+--
+-- (1) `kind` splits `entities` into:
+--       'text'  — corpus material the agents read and process.
+--                 Wikis (always text) and source files that the watcher
+--                 classified as text-shaped.
+--       'asset' — binary attachments (images, PDFs, audio, video,
+--                 archives, fonts...). Indexed so links to them resolve,
+--                 but never enter the agent queues.
+--     Existing rows are all text by definition (the prior denylist
+--     refused to index anything else), so DEFAULT 'text' fits without a
+--     backfill. Queue queries (editor / proposer / connector) gain a
+--     `kinds: ['text']` clause to keep assets out of the work feed.
+--
+-- (2) `stat_fingerprint` is a cheap change-detection cache, distinct
+--     from `source_hash` (which stays canonical SHA-256 of content for
+--     every kind). The sync path compares the file's current
+--     `mtime_ms-size_bytes` against the stored fingerprint; if they
+--     match, the bytes are guaranteed unchanged and we skip the
+--     content read AND the hash recomputation. On a miss, the real
+--     content hash is computed; if THAT matches the stored
+--     `source_hash`, the change was a touch (refresh the fingerprint,
+--     keep everything else). This makes large-asset sync ~free on
+--     unchanged files and keeps `source_hash` semantically uniform
+--     across text and asset rows. NULL is the bootstrap value; existing
+--     rows populate on their next sync tick.
+
+ALTER TABLE entities ADD COLUMN kind TEXT NOT NULL DEFAULT 'text'
+  CHECK (kind IN ('text', 'asset'));
+
+ALTER TABLE entities ADD COLUMN stat_fingerprint TEXT;
+
+-- Queue queries always include (space_name, kind, type) in their WHERE.
+-- The existing idx_entities_type covers (space_name, type); this index
+-- adds the kind dimension so the planner can use both columns as a
+-- composite key for queue filters.
+CREATE INDEX IF NOT EXISTS idx_entities_kind
+  ON entities(space_name, kind, type);

--- a/packages/arkeon/src/server/agents/templates/connector.yaml
+++ b/packages/arkeon/src/server/agents/templates/connector.yaml
@@ -39,6 +39,7 @@ system: |-
 
        list_entities(space="{{space_name}}",
                      type="wiki",
+                     kind="text",
                      tag_outdated="connector.processed_hash",
                      sort="updated_at",
                      limit=10,

--- a/packages/arkeon/src/server/agents/templates/editor.yaml
+++ b/packages/arkeon/src/server/agents/templates/editor.yaml
@@ -24,10 +24,15 @@ system: |-
      content hash:
 
        list_entities(type="file",
+                     kind="text",
                      tag_outdated="editor.processed_hash",
                      sort="updated_at",
                      limit=10,
                      include_counts=true)
+
+     `kind="text"` keeps assets out of the queue — images, PDFs, and
+     other attachments are indexed so links to them resolve, but
+     they're never corpus material the editor processes.
 
      `tag_outdated` returns entities whose tag is either ABSENT or
      has a value that doesn't match the entity's current

--- a/packages/arkeon/src/server/agents/templates/proposer.yaml
+++ b/packages/arkeon/src/server/agents/templates/proposer.yaml
@@ -43,11 +43,15 @@ system: |-
      content and you have NOT processed at the current content:
 
        list_entities(type="file",
+                     kind="text",
                      tag_current="editor.processed_hash",
                      tag_outdated="proposer.processed_hash",
                      sort="updated_at",
                      limit=10,
                      include_counts=true)
+
+     `kind="text"` keeps assets (images, PDFs) out of the queue —
+     they're indexed for link resolution but never processed.
 
      Two filters do the gate-plus-queue check in one query:
        - `tag_current="editor.processed_hash"` — the editor has

--- a/packages/arkeon/src/server/agents/tools.ts
+++ b/packages/arkeon/src/server/agents/tools.ts
@@ -33,9 +33,11 @@ import {
   getEntity,
   listEntities,
   listRedLinks,
+  parseEntityKinds,
   parseEntityTypes,
   setEntityTag,
   type EntityDetail,
+  type EntityKind,
   type EntityType,
 } from "../lib/entities.js";
 import { loadSpacesMap } from "../lib/spaces.js";
@@ -347,8 +349,15 @@ const listEntitiesTool = defineTool("list_entities", {
     "sources (type=file inbound_max=0 → 'nothing links to this file yet'), " +
     "or surface recently-updated articles. Each row carries `space_name`, " +
     "`source_path`, `space_url` (the canonical `/{space}/{path}` form — " +
-    "paste directly into an <a href>), `type`, `label`, `source_hash`, " +
-    "`properties`, `tags`, and optional `counts.inbound`/`counts.outbound`. " +
+    "paste directly into an <a href>), `type`, `kind`, `label`, " +
+    "`source_hash`, `properties`, `tags`, and optional " +
+    "`counts.inbound`/`counts.outbound`. " +
+    "`kind` is 'text' for parsed corpus material (wikis and indexed text " +
+    "sources — what enters the editor / proposer / connector queue) or " +
+    "'asset' for binary attachments (images, PDFs, audio, video) that get " +
+    "entity rows so links resolve but never feed the agents. Pass " +
+    "`kind='text'` on any queue query so attachments don't end up in your " +
+    "work feed. " +
     "`source_hash` is the " +
     "SHA-256 of the file content at last sync — pass it as the `value` to " +
     "`tag_entity` when marking 'I processed this' so content-change " +
@@ -365,6 +374,18 @@ const listEntitiesTool = defineTool("list_entities", {
       .optional()
       .describe(
         "Comma-separated entity types: 'wiki' or 'file'. Pass null (or omit) for both.",
+      ),
+    kind: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "Comma-separated kinds: 'text' (parsed corpus material — wikis " +
+          "and indexed text sources) or 'asset' (binary attachments — " +
+          "images, PDFs, audio, video, archives). Queue queries should " +
+          "pass `kind='text'` to keep assets out of the work feed; " +
+          "queries that look up what attachments an article references " +
+          "use `kind='asset'`. Pass null (or omit) for both.",
       ),
     label_contains: z
       .string()
@@ -512,8 +533,10 @@ const listEntitiesTool = defineTool("list_entities", {
   }),
   call: async (input, ctx) => {
     let types: EntityType[] | undefined;
+    let kinds: EntityKind[] | undefined;
     try {
       types = parseEntityTypes(input.type);
+      kinds = parseEntityKinds(input.kind);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       throw new Error(`list_entities: ${msg}`);
@@ -527,6 +550,7 @@ const listEntitiesTool = defineTool("list_entities", {
       const result = await listEntities({
         space_name: t.name,
         types,
+        kinds,
         label_contains: input.label_contains,
         path_contains: input.path_contains,
         inbound_min: input.inbound_min,

--- a/packages/arkeon/src/server/lib/entities.ts
+++ b/packages/arkeon/src/server/lib/entities.ts
@@ -21,6 +21,7 @@ import { ApiError } from "./errors.js";
 import { createSql } from "./sql.js";
 
 export type EntityType = "wiki" | "file";
+export type EntityKind = "text" | "asset";
 export type EntitySort = "updated_at" | "label" | "inbound" | "outbound";
 
 // All optional filters accept `null` as well as `undefined` — the AI SDK /
@@ -32,6 +33,12 @@ export interface ListEntitiesOptions {
   space_name?: string | null;
   /** Restrict to one or more entity types. */
   types?: EntityType[] | null;
+  /** Restrict to one or more kinds. `text` = parsed corpus material
+   *  (queue-eligible for the editor / proposer / connector).
+   *  `asset` = binary attachments indexed for link resolution only —
+   *  images, PDFs, audio, video, archives. Queue queries pass
+   *  `kinds: ['text']` to keep assets out of the work feed. */
+  kinds?: EntityKind[] | null;
   /** Case-insensitive substring match on `label`. */
   label_contains?: string | null;
   /** Case-insensitive substring match on `source_path`. */
@@ -75,6 +82,7 @@ export interface EntityListRow {
   space_name: string;
   source_path: string;
   type: EntityType;
+  kind: EntityKind;
   label: string | null;
   /** SHA-256 of the file content as of the last sync. Stable
    *  across reconciles unless the file's bytes change. Useful as a
@@ -137,6 +145,11 @@ export async function listEntities(
     const placeholders = opts.types.map(() => "?").join(",");
     innerConditions.push(`e.type IN (${placeholders})`);
     innerParams.push(...opts.types);
+  }
+  if (opts.kinds && opts.kinds.length > 0) {
+    const placeholders = opts.kinds.map(() => "?").join(",");
+    innerConditions.push(`e.kind IN (${placeholders})`);
+    innerParams.push(...opts.kinds);
   }
   if (opts.label_contains) {
     const escaped = opts.label_contains.replace(/[\\%_]/g, "\\$&");
@@ -231,7 +244,7 @@ export async function listEntities(
 
   const baseSelect = `
     SELECT
-      e.space_name, e.source_path, e.type, e.label, e.source_hash,
+      e.space_name, e.source_path, e.type, e.kind, e.label, e.source_hash,
       e.properties, e.tags, e.created_at, e.updated_at,
       (SELECT COUNT(*) FROM relationships r
         WHERE r.space_name = e.space_name AND r.target_path = e.source_path) AS inbound,
@@ -255,6 +268,7 @@ export async function listEntities(
     space_name: string;
     source_path: string;
     type: EntityType;
+    kind: EntityKind | null;
     label: string | null;
     source_hash: string;
     properties: Record<string, unknown> | string;
@@ -288,6 +302,10 @@ export async function listEntities(
         space_name: row.space_name,
         source_path: row.source_path,
         type: row.type,
+        // `kind` was added in migration 003. Pre-migration rows (and
+        // any future bootstrap edge case where the column is missing)
+        // default to 'text' to match the schema's DEFAULT clause.
+        kind: row.kind ?? "text",
         label: row.label,
         source_hash: row.source_hash,
         properties: row.properties,
@@ -449,6 +467,28 @@ export function parseEntityTypes(raw: string | null | undefined): EntityType[] |
 }
 
 /**
+ * Parse a comma-separated list of entity kinds, validating each one.
+ * Used by route handlers to coerce `?kind=text,asset` into the typed array.
+ */
+export function parseEntityKinds(raw: string | null | undefined): EntityKind[] | undefined {
+  if (!raw) return undefined;
+  const out: EntityKind[] = [];
+  for (const part of raw.split(",")) {
+    const k = part.trim();
+    if (!k) continue;
+    if (k !== "text" && k !== "asset") {
+      throw new ApiError(
+        400,
+        "validation_error",
+        `Invalid entity kind "${k}": must be one of text, asset`,
+      );
+    }
+    out.push(k);
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+/**
  * Fetch a single entity by (space_name, source_path) including outbound
  * relationships. Returns null if the entity does not exist.
  *
@@ -474,7 +514,7 @@ export async function getEntity(
 ): Promise<EntityDetail | null> {
   const sql = createSql();
   const rows = await sql`
-    SELECT space_name, source_path, type, label, source_hash, properties, tags,
+    SELECT space_name, source_path, type, kind, label, source_hash, properties, tags,
       created_at, updated_at,
       (SELECT by_role FROM entity_edits ed
         WHERE ed.space_name = entities.space_name AND ed.entity_path = entities.source_path
@@ -505,6 +545,9 @@ export async function getEntity(
     space_name: row.space_name as string,
     source_path: row.source_path as string,
     type: row.type as EntityType,
+    // `kind` was added in migration 003. Pre-migration rows default to
+    // 'text' to match the schema's DEFAULT clause.
+    kind: (row.kind as EntityKind | null) ?? "text",
     label: row.label as string | null,
     source_hash: row.source_hash as string,
     properties: row.properties as Record<string, unknown> | string,

--- a/packages/arkeon/src/server/lib/fs-watcher.ts
+++ b/packages/arkeon/src/server/lib/fs-watcher.ts
@@ -14,7 +14,7 @@
  */
 
 import { watch, type FSWatcher, existsSync, readdirSync, openSync, readSync, closeSync } from "node:fs";
-import { join, extname } from "node:path";
+import { join, extname, basename } from "node:path";
 
 import { startScheduler } from "../agents/scheduler.js";
 import { syncFile, syncDirectory, removeByPath, type Space } from "./sync.js";
@@ -24,33 +24,78 @@ type SchedulerHandle = Awaited<ReturnType<typeof startScheduler>>;
 // Directories to skip during walk + watch.
 const IGNORE_DIRS = new Set([".arkeon", ".git", "node_modules", ".claude", "__pycache__", ".venv"]);
 
-// Eligibility decision is three-tier:
+// Eligibility model (PR: asset indexing):
 //
-//   1. BINARY_EXTENSIONS — known-binary, never indexed (fast reject, no I/O).
-//   2. TEXT_EXTENSIONS — known-text, indexed without inspection (fast accept).
-//   3. Everything else — open the file, read the first SNIFF_BYTES, treat as
-//      text iff there's no NUL byte. Same rule `git`, `grep -I`, and `file(1)`
-//      use to decide "text vs binary."
+//   Most files get indexed. The rule is:
+//     - Hidden / ignore-dir paths → skip (never indexed).
+//     - SKIP_EXTENSIONS (secrets, junk, well-known scratch formats) → skip.
+//     - Everything else → indexed. Classified as kind='text' or
+//       kind='asset' by `classifyFile()`:
+//         · TEXT_EXTENSIONS allowlist → fast-path text.
+//         · ASSET_EXTENSIONS allowlist → fast-path asset.
+//         · Unknown extension → sniff first SNIFF_BYTES; text iff no NUL.
 //
-// This lets the agents reach files with unfamiliar extensions (custom configs,
-// random source code, README/LICENSE with no extension) without us having to
-// chase an ever-growing allowlist.
+// `kind='text'` files enter the agent queues (editor / proposer /
+// connector) and have their content parsed (wikis extract <a href> edges,
+// sources record file_type). `kind='asset'` files get an entity row with
+// metadata only — no parsing, no link extraction. They exist in the index
+// so links to them resolve (no red link on an `<img src>` or
+// `<a href="report.pdf">`), but they never become work for the agents.
 
-// "BINARY" here is a slight misnomer — the set is "extensions we refuse
-// to index, regardless of content." Most entries are literal binary
-// formats; a few (".svg", ".env", credentials) are text but excluded for
-// reasons noted inline.
-export const BINARY_EXTENSIONS = new Set([
+// Things we refuse to index at all, regardless of content. Two reasons
+// for an extension to be here:
+//   (1) it carries secrets (credentials, key material) and indexing
+//       would leak it through search / list / read tools;
+//   (2) it's local scratch noise that never represents corpus material
+//       (OS junk files, editor swap files).
+//
+// Compare against the prior (deprecated) "binary" denylist: that one
+// blocked everything binary-shaped — images, audio, video, PDFs,
+// archives — because the agents couldn't read them. Now they can (via
+// the fetch tool's image-injection path, plus the planned PDF
+// processor), so blocking them at the index level was the wrong layer.
+// The list below is only the truly-must-not-index entries.
+export const SKIP_EXTENSIONS = new Set([
+  // Secret-bearing extensions. These are often text (key=value, PEM,
+  // etc.) but the content sniff alone would auto-index them, defeating
+  // the purpose of having a "don't watch dotfiles" rule. Literal
+  // dotfiles (`.env`, `.envrc`) are also caught by shouldIgnorePath;
+  // this set covers the `*.env` suffix case (`production.env`,
+  // `staging.env`, etc.) the path-prefix rule misses.
+  ".env", ".envrc", ".secret",
+  ".pem", ".cer", ".crt", ".der", ".p7b", ".p7c", ".p8",
+  ".p12", ".pfx", ".jks", ".keystore", ".truststore",
+  ".asc", ".gpg", ".pgp", ".kdbx",
+  // Editor / OS scratch noise. Not corpus material, never worth indexing.
+  ".swp", ".swo", ".swn",      // vim swap
+  ".tmp", ".temp",
+  ".bak",                       // generic backup
+  ".lock",                      // bundler/yarn/pip lockfile (the *.lock
+                                // suffix; package-lock.json etc. are JSON
+                                // and stay indexable)
+]);
+
+// Junk basenames — never indexed regardless of extension. OS-level
+// noise that shows up next to real corpus files.
+const SKIP_BASENAMES = new Set([
+  ".DS_Store",
+  "Thumbs.db",
+  "desktop.ini",
+]);
+
+// Common image / document / media extensions get fast-path classification
+// as kind='asset'. Everything not on the text or asset allowlists falls
+// through to the content sniff in classifyFile().
+export const ASSET_EXTENSIONS = new Set([
   // Documents
   ".pdf", ".epub", ".mobi",
   // Office formats (zip-wrapped XML, not directly text). ".key" here is
-  // Apple Keynote; the cryptographic-key sense is covered in the
-  // credentials block below.
+  // Apple Keynote — the cryptographic-key sense is covered above in
+  // SKIP_EXTENSIONS.
   ".docx", ".doc", ".dotx", ".pptx", ".ppt", ".xlsx", ".xls",
   ".odt", ".ods", ".odp", ".pages", ".numbers", ".key",
-  // Images. ".svg" is technically text (XML) but treated as binary: its
-  // bytes are presentation data, not corpus material the agents would
-  // benefit from indexing.
+  // Images. ".svg" is XML but treated as an asset — it's presentation
+  // data, and rendering needs a rasterizer the agent can't drive.
   ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".ico", ".bmp",
   ".tiff", ".tif", ".heic", ".heif", ".avif", ".raw",
   // Audio / video
@@ -67,17 +112,6 @@ export const BINARY_EXTENSIONS = new Set([
   ".db", ".sqlite", ".sqlite3", ".mdb", ".pyc", ".pyo",
   // Disk images / installers
   ".dmg", ".iso", ".pkg", ".deb", ".rpm", ".msi", ".apk", ".ipa",
-  // Secret-bearing extensions. These are usually text (key=value, PEM,
-  // etc.) but the sniff alone would auto-index them, defeating the
-  // purpose of having a "don't watch dotfiles" rule. Listing them here
-  // makes rejection explicit and content-independent. Literal dotfiles
-  // (`.env`, `.envrc`) are also caught by shouldIgnorePath; this set
-  // covers the `*.env` suffix case (`production.env`, `staging.env`,
-  // etc.) the path-prefix rule misses.
-  ".env", ".envrc", ".secret",
-  ".pem", ".cer", ".crt", ".der", ".p7b", ".p7c", ".p8",
-  ".p12", ".pfx", ".jks", ".keystore", ".truststore",
-  ".asc", ".gpg", ".pgp", ".kdbx",
 ]);
 
 export const TEXT_EXTENSIONS = new Set([
@@ -87,7 +121,7 @@ export const TEXT_EXTENSIONS = new Set([
   ".json", ".jsonl", ".ndjson", ".csv", ".tsv", ".xml",
   // Config
   ".yaml", ".yml", ".toml", ".ini", ".conf", ".cfg", ".properties",
-  // ".env" / ".envrc" are in BINARY_EXTENSIONS (above) — text content but
+  // ".env" / ".envrc" are in SKIP_EXTENSIONS (above) — text content but
   // refused indexing because they're almost always secret-bearing.
   ".editorconfig",
   // Logs / output
@@ -101,6 +135,33 @@ export const TEXT_EXTENSIONS = new Set([
   ".css", ".scss", ".sass", ".less",
   ".lua", ".php", ".pl", ".r", ".jl", ".scala", ".clj", ".cljs", ".ex", ".exs", ".erl",
 ]);
+
+/**
+ * Ripgrep `--type-add` glob built from TEXT_EXTENSIONS so search and
+ * indexing always see the same set of files. Adding a new text extension
+ * above automatically widens search to match — no second list to sync.
+ *
+ * Form: `*.{ext1,ext2,...}` (no leading dots, alphabetized for stable
+ * diffs). Asset extensions are excluded by construction (they're not in
+ * TEXT_EXTENSIONS), and ripgrep's built-in binary detection is the
+ * second line of defense for anything that slips through (text-shaped
+ * binaries like SVG would otherwise be searchable).
+ *
+ * Lives in this module — not search.ts — to avoid a circular import:
+ * fs-watcher → scheduler → tools → search → fs-watcher would otherwise
+ * read TEXT_EXTENSIONS before the const initializer finished.
+ *
+ * Known gap: extensionless text files (README, LICENSE) are indexed
+ * as kind='text' but not searchable — ripgrep `--type` selects by
+ * extension only. Tracked separately.
+ */
+export const TEXT_EXTENSION_GLOB = (() => {
+  const exts = [...TEXT_EXTENSIONS]
+    .map((e) => e.slice(1)) // strip leading dot
+    .filter((e) => /^[a-z0-9_]+$/.test(e)) // drop anything brace-unsafe
+    .sort();
+  return `*.{${exts.join(",")}}`;
+})();
 
 const SNIFF_BYTES = 8192;
 
@@ -178,27 +239,64 @@ export function shouldIgnorePath(relativePath: string): boolean {
 }
 
 /**
- * Path-only eligibility (no I/O). Use to gate watcher events cheaply:
- * rejects hidden dirs and known-binary extensions, lets anything else
- * through. Pair with `isEligibleFile()` (which adds the content sniff)
- * before actually indexing.
+ * Path-only eligibility (no I/O). Drops paths that should never enter
+ * the index — hidden / ignore dirs, junk basenames, and known
+ * skip-extensions (secrets, editor scratch). Pair with `classifyFile()`
+ * to decide kind='text' vs kind='asset' for paths that pass.
+ *
+ * The old "is it text or binary by extension" decision is no longer
+ * here — both texts and assets are indexable now.
  */
 export function isPathPotentiallyEligible(relativePath: string): boolean {
   if (shouldIgnorePath(relativePath)) return false;
+  const name = basename(relativePath);
+  if (SKIP_BASENAMES.has(name)) return false;
   const ext = extname(relativePath).toLowerCase();
-  if (ext && BINARY_EXTENSIONS.has(ext)) return false;
+  if (ext && SKIP_EXTENSIONS.has(ext)) return false;
   return true;
 }
 
 /**
- * Full eligibility — applies the three-tier check. May open the file
- * for sniffing if the extension is unknown.
+ * Should this file get an entity row at all?
+ *
+ * Today this is just `isPathPotentiallyEligible` — every file the watcher
+ * sees and the path filter accepts becomes an entity (either kind='text'
+ * with parsed content or kind='asset' with metadata only). The function
+ * is kept as the public eligibility predicate so the routes / scan code
+ * has one canonical entry point and we can evolve the rules without
+ * threading them through every caller. Operators reading this: yes, this
+ * intentionally no longer opens the file — that work moves to
+ * `classifyFile`, which the sync path calls once the eligibility gate
+ * has passed.
  */
-export function isEligibleFile(relativePath: string, absPath: string): boolean {
-  if (!isPathPotentiallyEligible(relativePath)) return false;
+export function isEligibleFile(relativePath: string, _absPath: string): boolean {
+  return isPathPotentiallyEligible(relativePath);
+}
+
+/**
+ * Classify an eligible file as text or asset.
+ *
+ *   - TEXT_EXTENSIONS allowlist → text (no I/O).
+ *   - ASSET_EXTENSIONS allowlist → asset (no I/O).
+ *   - Otherwise → sniff the first SNIFF_BYTES; text iff no NUL byte.
+ *
+ * Callers should gate on `isPathPotentiallyEligible(relativePath)` first;
+ * `classifyFile` assumes the path has already passed eligibility.
+ *
+ * Returns `'asset'` on I/O errors so a momentarily-unreadable file
+ * doesn't get mis-parsed as text by `syncFile` (which would then call
+ * readFileSync(..., 'utf-8') and corrupt binary data into a UTF-8
+ * replacement-character soup). Asset-mode reads only metadata, which is
+ * the safe fallback.
+ */
+export function classifyFile(
+  relativePath: string,
+  absPath: string,
+): "text" | "asset" {
   const ext = extname(relativePath).toLowerCase();
-  if (ext && TEXT_EXTENSIONS.has(ext)) return true;
-  return sniffIsText(absPath);
+  if (ext && TEXT_EXTENSIONS.has(ext)) return "text";
+  if (ext && ASSET_EXTENSIONS.has(ext)) return "asset";
+  return sniffIsText(absPath) ? "text" : "asset";
 }
 
 /**

--- a/packages/arkeon/src/server/lib/html-links.ts
+++ b/packages/arkeon/src/server/lib/html-links.ts
@@ -2,10 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Walk every `<a href="...">` in an HTML wiki and resolve hrefs to
- * canonical `target_path` strings for the relationships table.
+ * Walk every `<a href="...">` and `<img src="...">` in an HTML wiki
+ * and resolve URLs to canonical `target_path` strings for the
+ * relationships table.
  *
- * Resolution rules:
+ * Two element shapes:
+ *   - `<a href>` — corpus links (article → article, article → source).
+ *     `text` carries the anchor body so the relationship row has
+ *     human-readable link text.
+ *   - `<img src>` — media references (article → indexed asset). These
+ *     produce relationship rows so an article that embeds a chart shows
+ *     up in the asset's `inbound`, and `<img>` to an indexed PNG/PDF
+ *     resolves as a real edge instead of a red link. `text` is the
+ *     `alt` attribute when present (or "" — there's no element body to
+ *     fall back to).
+ *
+ * Resolution rules (same for both attribute kinds):
  *   - External URLs (any scheme: `https://`, `mailto:`, `tel:`, …) → dropped.
  *   - Pure fragments (`#section`) → dropped (no edge to record).
  *   - Server-absolute paths (`/{space}/...`) → passed through as the
@@ -20,9 +32,12 @@
  *     (requires `opts.spaces`).
  *   - Resolved paths that escape into NO registered space → dropped.
  *
- * Returned links carry `href` (original attribute), `text` (anchor body),
- * and `resolved` (the canonical `target_path`, or `null` if the link is
- * external/unresolvable and should not produce a row).
+ * Returned links carry `href` (original attribute), `text` (anchor body
+ * or `alt`), and `resolved` (the canonical `target_path`, or `null` if
+ * the URL is external/unresolvable and should not produce a row).
+ *
+ * Not yet extracted: `<video src>`, `<audio src>`, `<source src>`,
+ * `<link href>`. Add when a real use case appears.
  */
 
 import { parse } from "node-html-parser";
@@ -55,6 +70,15 @@ export function extractHtmlLinks(
     if (!href) continue;
     const text = a.text.trim();
     out.push({ href, text, resolved: resolveHref(href, fromPath, opts) });
+  }
+  for (const img of root.querySelectorAll("img")) {
+    const src = img.getAttribute("src");
+    if (!src) continue;
+    // `alt` is the human-readable text for an image — closest analogue
+    // to an anchor's body. May be missing; empty string is fine for the
+    // relationships row (link_text is nullable downstream anyway).
+    const text = (img.getAttribute("alt") ?? "").trim();
+    out.push({ href: src, text, resolved: resolveHref(src, fromPath, opts) });
   }
   return out;
 }

--- a/packages/arkeon/src/server/lib/llms-txt.ts
+++ b/packages/arkeon/src/server/lib/llms-txt.ts
@@ -29,16 +29,33 @@ all rooted at the space: \`/{space}/...\`. Names match
 a daemon-level route name (\`health\`, \`ready\`, \`help\`, \`llms.txt\`,
 \`spaces\` are reserved). Multiple spaces can coexist on one daemon.
 
-**Entity**: a row in the index for one file. Two types:
-  - \`wiki\`  — an article under \`wiki/**/*.html\` with a \`<title>\` and
-            optional \`<meta name="X" content="Y">\` tags. Wiki bodies
-            should follow the four-section shape: \`Question\`,
-            \`Current answer\`, \`Evidence\`, \`Open threads\`.
-  - \`file\`  — any other text file in the watch dir (markdown, source,
-            CSV, JSON, plain text, extensionless README, etc.). Binary
-            files (PDF, DOCX, images, archives) are intentionally not
-            indexed; use the \`sources/scan\` endpoint to see what was
-            skipped.
+**Entity**: a row in the index for one file. Indexed files have a
+\`type\` and a \`kind\`:
+  - \`type\`: \`wiki\` (article under \`wiki/**/*.html\`) or \`file\`
+    (everything else).
+  - \`kind\`: \`text\` (parsed corpus material — what the agents read
+    and process) or \`asset\` (binary attachment — image, PDF, audio,
+    video, archive — indexed so links to it resolve but never
+    entering the agent queues).
+
+Wikis are always \`type='wiki', kind='text'\`, with a \`<title>\` and
+optional \`<meta name="X" content="Y">\` tags. Wiki bodies should follow
+the four-section shape: \`Question\`, \`Current answer\`, \`Evidence\`,
+\`Open threads\`.
+
+Source files are \`type='file', kind='text'\` (markdown, JSON, CSV,
+source code, extensionless README, anything passing the text sniff).
+Asset files are \`type='file', kind='asset'\` (images, PDFs, audio,
+video, archives, fonts, office documents). Asset rows carry
+\`{file_type, size_bytes}\` in \`properties\` and have no parsed content.
+
+Queue queries (editor / proposer / connector) pass \`kind='text'\` so
+attachments stay out of the work feed. Reverse queries — "what
+attachments does this article reference?" — pass \`kind='asset'\`.
+
+Only secrets (\`.env\`, \`.pem\`, …) and OS junk (\`.DS_Store\`, vim swap,
+\`.tmp\`) are refused indexing. Use the \`sources/scan\` endpoint to see
+what was skipped.
 
 **Relationship**: every internal \`<a href>\` in a wiki becomes an
 edge with \`source_path\` → \`target_path\`. Paths are resolved relative
@@ -134,12 +151,17 @@ Plans are real wikis — they appear in the index and you can read them.
 ### Operator tasks
   - \`GET /{space}/sources/scan\`              — every file in the watch
                                                 dir partitioned into
-                                                supported (indexed) vs
-                                                unsupported (binary,
-                                                skipped). Convert
-                                                unsupported files to
-                                                text to let the agents
-                                                read them.
+                                                supported (indexed —
+                                                includes both text and
+                                                asset kinds) vs
+                                                unsupported (junk and
+                                                secret-bearing extensions
+                                                that are refused). To
+                                                see text vs asset within
+                                                supported, hit
+                                                \`/{space}/entities\` with
+                                                \`?kind=text\` or
+                                                \`?kind=asset\`.
   - \`GET /{space}/recent\`                    — \`entity_edits\` feed
                                                 across humans and
                                                 agents.
@@ -201,6 +223,9 @@ them up on its next cron tick.
 \`GET  /{space}/entities\`
   Filterable listing. Query params:
     \`type\`                       — \`wiki\` | \`file\` | \`wiki,file\`
+    \`kind\`                       — \`text\` | \`asset\` | \`text,asset\`
+                                   Pass \`kind=text\` on queue queries
+                                   so attachments don't surface as work.
     \`label_contains\`             — substring on \`label\`
     \`path_contains\`              — substring on \`source_path\`
     \`inbound_min\` / \`inbound_max\`  — edge-count bounds
@@ -251,9 +276,13 @@ them up on its next cron tick.
 
 \`GET  /{space}/sources/scan\`
   Walks the watch dir and partitions every file into supported (will
-  be indexed) vs unsupported (binary, silently skipped). Response:
+  be indexed — text and asset kinds both count here) vs unsupported
+  (silently skipped — junk basenames and secret-bearing extensions).
+  Response:
     \`{space, watch_dir, total, supported: {count, by_ext}, unsupported:
-      {count, by_ext, examples: {".pdf": [paths]}}}\`.
+      {count, by_ext, examples: {".env": [paths]}}}\`.
+  To break "supported" down by kind, use
+  \`GET /{space}/entities?kind=text\` and \`?kind=asset\`.
 
 ### Write-back
 

--- a/packages/arkeon/src/server/lib/search.ts
+++ b/packages/arkeon/src/server/lib/search.ts
@@ -14,6 +14,7 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { rgPath } from "@vscode/ripgrep";
 
+import { TEXT_EXTENSION_GLOB } from "./fs-watcher.js";
 import { createSql } from "./sql.js";
 import type { EntityType } from "./entities.js";
 
@@ -179,8 +180,9 @@ export function runRipgrep(opts: {
     args.push("--glob", "!.arkeon");
     args.push("--glob", "!.git");
     args.push("--glob", "!node_modules");
-    // Restrict to the file types we index.
-    args.push("--type-add", "arkeon:*.{md,txt,json,csv,xml,html,rst}");
+    // Restrict to the same text extensions the watcher indexes (single
+    // source of truth: TEXT_EXTENSIONS in fs-watcher.ts).
+    args.push("--type-add", `arkeon:${TEXT_EXTENSION_GLOB}`);
     args.push("--type", "arkeon");
     for (const q of opts.queries) {
       args.push("-e", q);

--- a/packages/arkeon/src/server/lib/source-write-guards.ts
+++ b/packages/arkeon/src/server/lib/source-write-guards.ts
@@ -9,10 +9,13 @@
  *     `safeResolve` already enforces the traversal rule downstream;
  *     this catches the same class earlier so the error message is
  *     specific to the source-write endpoints.
- *   - `assertTextContent` — body must not look binary. Same heuristic
- *     the watcher uses: if the extension is in `TEXT_EXTENSIONS` we
- *     trust it; otherwise the first 8 KB must have no NUL byte, AND
- *     the extension must not be in `BINARY_EXTENSIONS`.
+ *   - `assertTextContent` — body must be text. The write-back APIs are
+ *     for corpus material (markdown, prose, JSON, etc.) — asset uploads
+ *     (images, PDFs, archives) need to go through the filesystem
+ *     directly, not the HTTP API. Reject if the extension is on the
+ *     SKIP set (secrets), on the ASSET set (binary attachments), or
+ *     if the body sniffs as binary (NUL byte in first 8 KB) and the
+ *     extension isn't on the explicit text allowlist.
  *   - `sanitizeCaller` — turns the `X-Caller` header into the value
  *     we write to `entity_edits.by_role`. Allowlist `[A-Za-z0-9._-]{1,40}`,
  *     silent fallback to `"api"` for missing/invalid.
@@ -21,7 +24,8 @@
 import { extname } from "node:path";
 import { ApiError } from "./errors.js";
 import {
-  BINARY_EXTENSIONS,
+  ASSET_EXTENSIONS,
+  SKIP_EXTENSIONS,
   TEXT_EXTENSIONS,
   sniffBufferIsText,
 } from "./fs-watcher.js";
@@ -63,18 +67,32 @@ export function assertSourcePath(relativePath: string): void {
 }
 
 /**
- * Throws if `buf` looks binary AND the extension isn't on the text
- * allowlist. Mirrors `isEligibleFile`: explicit text extensions short-
- * circuit; explicit binary extensions always reject; anything else
- * falls back to the NUL sniff.
+ * Throws if the upload isn't text. The write-back APIs are deliberately
+ * text-only — asset uploads go through the filesystem directly so the
+ * fs-watcher classifies them as kind='asset' on its own. This guard
+ * keeps the HTTP write surface focused on the corpus-material use case.
+ *
+ *   - SKIP_EXTENSIONS (`.env`, `.pem`, …) → reject. These are secret-
+ *     bearing or junk and never belong in the corpus.
+ *   - ASSET_EXTENSIONS (`.pdf`, `.png`, …) → reject with a hint to
+ *     drop the file on disk instead.
+ *   - TEXT_EXTENSIONS (`.md`, `.txt`, …) → accept without inspection.
+ *   - Otherwise sniff: NUL byte in first 8 KB → reject.
  */
 export function assertTextContent(buf: Buffer, relativePath: string): void {
   const ext = extname(relativePath).toLowerCase();
-  if (ext && BINARY_EXTENSIONS.has(ext)) {
+  if (ext && SKIP_EXTENSIONS.has(ext)) {
     throw new ApiError(
       400,
       "validation_error",
-      `extension '${ext}' is not indexable; upload as a text format`,
+      `extension '${ext}' is not indexable (secrets or scratch); pick a different filename`,
+    );
+  }
+  if (ext && ASSET_EXTENSIONS.has(ext)) {
+    throw new ApiError(
+      400,
+      "validation_error",
+      `extension '${ext}' is a binary asset; this endpoint is text-only — drop the file in the watch directory and the watcher will index it as an asset`,
     );
   }
   if (ext && TEXT_EXTENSIONS.has(ext)) return;

--- a/packages/arkeon/src/server/lib/sources-scan.ts
+++ b/packages/arkeon/src/server/lib/sources-scan.ts
@@ -5,11 +5,18 @@
  * Source inventory for a space's watch directory.
  *
  * Walks the directory once, partitions every regular file via
- * `isEligibleFile()` (the same three-tier check the watcher applies:
- * binary-ext denylist → text-ext allowlist → content sniff), and
+ * `isEligibleFile()` (the same eligibility check the watcher applies:
+ * not hidden, not a junk basename, not a SKIP_EXTENSIONS match), and
  * reports counts plus a handful of example paths per unsupported
- * extension so the operator (or an LLM agent) can decide what to
- * convert.
+ * extension so the operator (or an LLM agent) can see what's getting
+ * skipped (typically OS junk or secret-bearing files).
+ *
+ * Note: under the asset-indexing model, "supported" now includes
+ * binary attachments — images, PDFs, audio, video — because they
+ * receive entity rows as `kind='asset'`. "Unsupported" is just the
+ * SKIP set (secrets, scratch files). To distinguish text from asset
+ * within "supported," consume the entity index directly via
+ * `GET /{space}/entities?kind=text` or `?kind=asset`.
  *
  * The walk reuses the ignore rules from fs-watcher (shouldIgnorePath)
  * so what the scan reports lines up exactly with what the watcher

--- a/packages/arkeon/src/server/lib/sync.ts
+++ b/packages/arkeon/src/server/lib/sync.ts
@@ -299,6 +299,11 @@ async function syncSource(
  *     user dropped on disk, not edits the system performed, and an
  *     edit feed full of "image was added" noise would crowd out the
  *     wiki edits operators actually care about).
+ *
+ * Asymmetry with `syncWiki`: no `withTransaction` wrapper because the
+ * write is a single UPDATE or INSERT (no companion DELETE-and-rebuild
+ * of relationships rows). Wrapping would just add a transactional
+ * round-trip without affecting consistency.
  */
 async function syncAsset(
   space: Space,

--- a/packages/arkeon/src/server/lib/sync.ts
+++ b/packages/arkeon/src/server/lib/sync.ts
@@ -19,12 +19,13 @@
  * extract outbound edges.
  */
 
-import { readFileSync } from "node:fs";
+import { createReadStream, readFileSync, statSync } from "node:fs";
 import { join, basename, extname } from "node:path";
 import { createHash } from "node:crypto";
 
 import { createSql, withTransaction, type SqlClient } from "./sql.js";
 import { getEditContext, type EditKind } from "./edit-context.js";
+import { classifyFile } from "./fs-watcher.js";
 import { parseHtmlMeta } from "./html-meta.js";
 import { extractHtmlLinks } from "./html-links.js";
 import { loadSpacesMap } from "./spaces.js";
@@ -34,9 +35,12 @@ export interface Space {
   watch_dir: string;
 }
 
+export type EntityKind = "text" | "asset";
+
 export interface SyncResult {
   action: "created" | "updated" | "unchanged" | "noop";
   type: "wiki" | "file";
+  kind: EntityKind;
   label: string;
   linksExtracted: number;
 }
@@ -45,8 +49,45 @@ function contentHash(content: string): string {
   return createHash("sha256").update(content).digest("hex");
 }
 
+/**
+ * SHA-256 of a file's bytes, computed by streaming so a multi-GB video
+ * doesn't try to fit in RAM. Used for asset entities — text files
+ * already load the full content (we need to parse it), so they keep the
+ * cheaper in-memory hash.
+ */
+async function fileContentHash(absPath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash("sha256");
+    const stream = createReadStream(absPath);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolve(hash.digest("hex")));
+    stream.on("error", reject);
+  });
+}
+
 export function isWikiPath(relativePath: string): boolean {
   return relativePath.startsWith("wiki/") && relativePath.endsWith(".html");
+}
+
+/**
+ * Cheap change-detection fingerprint stored alongside `source_hash`.
+ *
+ * `source_hash` is canonical SHA-256 of content. `stat_fingerprint` is
+ * `${mtimeMs}-${size}` — the same heuristic rsync / make / git status
+ * use. When the fingerprint matches the stored value the file's bytes
+ * are guaranteed identical to last sync, so we skip the content read
+ * AND the hash recomputation. On a fingerprint miss we still compute
+ * the real content hash; if it matches `source_hash`, the change was
+ * a touch (refresh fingerprint, keep everything else); only a
+ * genuine content change goes through the parse / relationship rebuild.
+ *
+ * This keeps `source_hash` semantically uniform across text and asset
+ * rows while making syncs on unchanged files O(1) — particularly load-
+ * bearing for large assets (GB-sized videos) where re-hashing on every
+ * watcher debounce would be wasteful.
+ */
+function statFingerprint(stats: { mtimeMs: number; size: number }): string {
+  return `${stats.mtimeMs}-${stats.size}`;
 }
 
 /**
@@ -58,28 +99,66 @@ export function isWikiPath(relativePath: string): boolean {
  */
 export async function syncFile(space: Space, relativePath: string): Promise<SyncResult> {
   const absPath = join(space.watch_dir, relativePath);
-  const content = readFileSync(absPath, "utf-8");
-  const hash = contentHash(content);
+
+  // (1) Stat-fingerprint fast path. Skips content I/O entirely on
+  // unchanged files — the common case during a reconcile walk.
+  const stats = statSync(absPath);
+  const fingerprint = statFingerprint(stats);
 
   const sql = createSql();
   const existing = await sql`
-    SELECT source_hash, type, label
+    SELECT source_hash, stat_fingerprint, type, kind, label
     FROM entities
     WHERE space_name = ${space.name} AND source_path = ${relativePath}
   `;
 
-  if (existing.length > 0 && existing[0].source_hash === hash) {
+  if (
+    existing.length > 0 &&
+    existing[0].stat_fingerprint != null &&
+    existing[0].stat_fingerprint === fingerprint
+  ) {
     return {
       action: "unchanged",
       type: existing[0].type as "wiki" | "file",
+      kind: (existing[0].kind as EntityKind) ?? "text",
       label: existing[0].label as string,
       linksExtracted: 0,
     };
   }
 
+  // (2) Stat shifted — bytes might have changed, or it might just be
+  // a touch. Classify and compute the real content hash to decide.
+  const kind = classifyFile(relativePath, absPath);
+
+  if (kind === "asset") {
+    return syncAsset(space, relativePath, absPath, stats, fingerprint, existing[0] ?? null);
+  }
+
+  const content = readFileSync(absPath, "utf-8");
+  const hash = contentHash(content);
+
+  // (3) Touch-without-change: refresh the cache, but the row's
+  // content-derived columns (label, properties, relationships) are
+  // already correct. No parse, no updated_at bump.
+  if (existing.length > 0 && existing[0].source_hash === hash) {
+    await sql`
+      UPDATE entities
+      SET stat_fingerprint = ${fingerprint}
+      WHERE space_name = ${space.name} AND source_path = ${relativePath}
+    `;
+    return {
+      action: "unchanged",
+      type: existing[0].type as "wiki" | "file",
+      kind: (existing[0].kind as EntityKind) ?? "text",
+      label: existing[0].label as string,
+      linksExtracted: 0,
+    };
+  }
+
+  // (4) Real content change.
   const result = isWikiPath(relativePath)
-    ? await syncWiki(space, relativePath, content, hash, existing[0] ?? null)
-    : await syncSource(space, relativePath, content, hash, existing[0] ?? null);
+    ? await syncWiki(space, relativePath, content, hash, fingerprint, existing[0] ?? null)
+    : await syncSource(space, relativePath, content, hash, fingerprint, existing[0] ?? null);
 
   await recordEntityEdit(space.name, relativePath, hash);
 
@@ -91,6 +170,7 @@ async function syncWiki(
   relativePath: string,
   content: string,
   hash: string,
+  fingerprint: string,
   existing: Record<string, unknown> | null,
 ): Promise<SyncResult> {
   const meta = parseHtmlMeta(content);
@@ -114,7 +194,9 @@ async function syncWiki(
         UPDATE entities
         SET label = ${label},
             source_hash = ${hash},
+            stat_fingerprint = ${fingerprint},
             properties = ${propsJson},
+            kind = 'text',
             updated_at = strftime('%Y-%m-%d %H:%M:%f', 'now')
         WHERE space_name = ${space.name} AND source_path = ${relativePath}
       `;
@@ -123,8 +205,8 @@ async function syncWiki(
       // branch) so the "latest first" sort in the article index can break
       // ties on entities created in the same second.
       await tx`
-        INSERT INTO entities (space_name, source_path, type, label, source_hash, properties, updated_at)
-        VALUES (${space.name}, ${relativePath}, 'wiki', ${label}, ${hash}, ${propsJson}, strftime('%Y-%m-%d %H:%M:%f', 'now'))
+        INSERT INTO entities (space_name, source_path, type, kind, label, source_hash, stat_fingerprint, properties, updated_at)
+        VALUES (${space.name}, ${relativePath}, 'wiki', 'text', ${label}, ${hash}, ${fingerprint}, ${propsJson}, strftime('%Y-%m-%d %H:%M:%f', 'now'))
       `;
     }
 
@@ -149,6 +231,7 @@ async function syncWiki(
   return {
     action: existing ? "updated" : "created",
     type: "wiki",
+    kind: "text",
     label,
     linksExtracted: resolvedLinks.length,
   };
@@ -159,6 +242,7 @@ async function syncSource(
   relativePath: string,
   content: string,
   hash: string,
+  fingerprint: string,
   existing: Record<string, unknown> | null,
 ): Promise<SyncResult> {
   const label = basename(relativePath, extname(relativePath));
@@ -175,18 +259,102 @@ async function syncSource(
       UPDATE entities
       SET label = ${label},
           source_hash = ${hash},
+          stat_fingerprint = ${fingerprint},
           properties = ${propsJson},
+          kind = 'text',
           updated_at = strftime('%Y-%m-%d %H:%M:%f', 'now')
       WHERE space_name = ${space.name} AND source_path = ${relativePath}
     `;
-    return { action: "updated", type: "file", label, linksExtracted: 0 };
+    return { action: "updated", type: "file", kind: "text", label, linksExtracted: 0 };
   }
 
   await sql`
-    INSERT INTO entities (space_name, source_path, type, label, source_hash, properties, updated_at)
-    VALUES (${space.name}, ${relativePath}, 'file', ${label}, ${hash}, ${propsJson}, strftime('%Y-%m-%d %H:%M:%f', 'now'))
+    INSERT INTO entities (space_name, source_path, type, kind, label, source_hash, stat_fingerprint, properties, updated_at)
+    VALUES (${space.name}, ${relativePath}, 'file', 'text', ${label}, ${hash}, ${fingerprint}, ${propsJson}, strftime('%Y-%m-%d %H:%M:%f', 'now'))
   `;
-  return { action: "created", type: "file", label, linksExtracted: 0 };
+  return { action: "created", type: "file", kind: "text", label, linksExtracted: 0 };
+}
+
+/**
+ * Sync a binary asset (image, PDF, audio, video, archive, font...).
+ *
+ * Asset rows exist so `<a href="report.pdf">` and `<img src="chart.png">`
+ * inside wikis resolve as real links instead of red links — they're
+ * addressable but never enter the agent queues. The kind='text' filter
+ * in editor/proposer/connector queue queries excludes them.
+ *
+ * Called after `syncFile`'s stat-cache miss, so `existing.stat_fingerprint`
+ * (if any) does NOT match the current fingerprint — either it's a new
+ * row or the file's mtime/size shifted. We compute the real content hash
+ * (streaming, so multi-GB videos don't try to fit in RAM); if it matches
+ * the stored `source_hash`, the change was a touch — refresh the stat
+ * fingerprint and keep everything else.
+ *
+ * `properties` carries `file_type` and `size_bytes` only — no parsed
+ * metadata, no HTML structure, no <a href> link extraction.
+ *
+ * Asset rows:
+ *   - never emit relationships rows (assets don't link to anything);
+ *   - never get an entity_edits row (these are typically content the
+ *     user dropped on disk, not edits the system performed, and an
+ *     edit feed full of "image was added" noise would crowd out the
+ *     wiki edits operators actually care about).
+ */
+async function syncAsset(
+  space: Space,
+  relativePath: string,
+  absPath: string,
+  stats: { mtimeMs: number; size: number },
+  fingerprint: string,
+  existing: Record<string, unknown> | null,
+): Promise<SyncResult> {
+  const label = basename(relativePath, extname(relativePath));
+  const sql = createSql();
+
+  const hash = await fileContentHash(absPath);
+
+  // Touch-without-change: stat shifted but bytes didn't. Refresh the
+  // cache so the next sync takes the fast path again.
+  if (existing && existing.source_hash === hash) {
+    await sql`
+      UPDATE entities
+      SET stat_fingerprint = ${fingerprint}
+      WHERE space_name = ${space.name} AND source_path = ${relativePath}
+    `;
+    return {
+      action: "unchanged",
+      type: "file",
+      kind: "asset",
+      label,
+      linksExtracted: 0,
+    };
+  }
+
+  const properties = {
+    file_type: extname(relativePath).slice(1).toLowerCase() || "unknown",
+    size_bytes: stats.size,
+  };
+  const propsJson = JSON.stringify(properties);
+
+  if (existing) {
+    await sql`
+      UPDATE entities
+      SET label = ${label},
+          source_hash = ${hash},
+          stat_fingerprint = ${fingerprint},
+          properties = ${propsJson},
+          kind = 'asset',
+          updated_at = strftime('%Y-%m-%d %H:%M:%f', 'now')
+      WHERE space_name = ${space.name} AND source_path = ${relativePath}
+    `;
+    return { action: "updated", type: "file", kind: "asset", label, linksExtracted: 0 };
+  }
+
+  await sql`
+    INSERT INTO entities (space_name, source_path, type, kind, label, source_hash, stat_fingerprint, properties, updated_at)
+    VALUES (${space.name}, ${relativePath}, 'file', 'asset', ${label}, ${hash}, ${fingerprint}, ${propsJson}, strftime('%Y-%m-%d %H:%M:%f', 'now'))
+  `;
+  return { action: "created", type: "file", kind: "asset", label, linksExtracted: 0 };
 }
 
 async function recordEntityEdit(

--- a/packages/arkeon/src/server/lib/sync.ts
+++ b/packages/arkeon/src/server/lib/sync.ts
@@ -19,7 +19,7 @@
  * extract outbound edges.
  */
 
-import { createReadStream, readFileSync, statSync } from "node:fs";
+import { createReadStream, existsSync, readFileSync, statSync } from "node:fs";
 import { join, basename, extname } from "node:path";
 import { createHash } from "node:crypto";
 
@@ -427,8 +427,12 @@ export async function removeByPath(space: Space, relativePath: string): Promise<
  * that resolves implicitly once the target file syncs.
  *
  * After sync'ing every supplied file, removes any entities whose
- * source_path is no longer in the file list (i.e. files deleted while
- * the watcher was offline).
+ * source_path no longer exists on disk (i.e. files deleted while the
+ * watcher was offline). The "exists on disk" check happens at the
+ * moment of deletion, NOT against the (stale) `files` snapshot —
+ * otherwise any file written between the walk and this cleanup loop
+ * (a concurrent applyEdit, a fresh drop by the user, ...) would be
+ * mistakenly removed because it isn't in the snapshot.
  */
 export async function syncDirectory(
   space: Space,
@@ -451,10 +455,10 @@ export async function syncDirectory(
   const dbEntities = await sql`
     SELECT source_path FROM entities WHERE space_name = ${space.name}
   `;
-  const fileSet = new Set(files);
   for (const row of dbEntities) {
     const p = row.source_path as string;
-    if (!fileSet.has(p)) {
+    const absPath = join(space.watch_dir, p);
+    if (!existsSync(absPath)) {
       const removed = await removeByPath(space, p);
       if (removed) summary.removed++;
     }

--- a/packages/arkeon/src/server/routes/space-scoped.ts
+++ b/packages/arkeon/src/server/routes/space-scoped.ts
@@ -30,6 +30,7 @@ import {
   getEntity,
   listEntities,
   listRedLinks,
+  parseEntityKinds,
   parseEntityTypes,
 } from "../lib/entities.js";
 import {
@@ -76,6 +77,7 @@ spaceScopedRouter.get("/:space/entities", async (c) => {
   const result = await listEntities({
     space_name: space,
     types: parseEntityTypes(c.req.query("type")),
+    kinds: parseEntityKinds(c.req.query("kind")),
     label_contains: c.req.query("label_contains"),
     path_contains: c.req.query("path_contains"),
     inbound_min: parseNumQuery(c.req.query("inbound_min"), "inbound_min"),

--- a/packages/arkeon/src/server/routes/spaces.ts
+++ b/packages/arkeon/src/server/routes/spaces.ts
@@ -87,9 +87,14 @@ spacesRouter.post("/", async (c) => {
   `;
   const space = { name: body.name, watch_dir: body.watch_dir };
 
-  startWatching(space).catch((err) => {
-    console.error(`[spaces] Failed to start watcher for "${body.name}":`, err.message);
-  });
+  // Await the full reconcile + watcher startup before returning.
+  // Fire-and-forget here used to race with concurrent writes: callers
+  // would POST /spaces and then immediately POST /inbox, and the
+  // background reconcile's "delete rows whose files aren't in the
+  // walk snapshot" pass would nuke the inbox row created between the
+  // walk and the cleanup query. Awaiting closes that window — by the
+  // time we 201, the watcher is live and the snapshot is consistent.
+  await startWatching(space);
 
   return c.json(space, 201);
 });

--- a/packages/arkeon/test/e2e/asset-indexing.test.ts
+++ b/packages/arkeon/test/e2e/asset-indexing.test.ts
@@ -1,0 +1,291 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * E2e tests for the asset-indexing model:
+ *
+ *   - Binary files (images, PDFs, archives) get entity rows with
+ *     kind='asset' instead of being skipped.
+ *   - Asset rows carry {file_type, size_bytes} in properties, no
+ *     parsed metadata, no link extraction.
+ *   - Links from wikis to assets resolve (no red link) once the asset
+ *     is indexed.
+ *   - listEntities `kinds` filter scopes queue queries: kind='text'
+ *     excludes assets, kind='asset' returns only attachments.
+ *   - listRedLinks naturally drops assets once they have entity rows.
+ *   - The stat-fingerprint cache short-circuits unchanged files
+ *     (action='unchanged' without recomputing the content hash).
+ *   - A touch-without-content-change refreshes the fingerprint but
+ *     keeps source_hash unchanged.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runMigrations } from "../../src/schema/migrate.js";
+import { closeDb, createSql, initDb } from "../../src/server/lib/sql.js";
+import { syncFile, type Space } from "../../src/server/lib/sync.js";
+import {
+  listEntities,
+  listRedLinks,
+  getEntity,
+} from "../../src/server/lib/entities.js";
+
+let workdir: string;
+let dbPath: string;
+const SPACE: Space = { name: "asset-test", watch_dir: "" };
+
+// A 4-byte stub PNG header. Not a valid image, but the fs-watcher
+// classifies by extension so this is enough to test asset-mode sync.
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+beforeEach(async () => {
+  workdir = mkdtempSync(join(tmpdir(), "arkeon-asset-"));
+  dbPath = join(workdir, "arke.db");
+  SPACE.watch_dir = workdir;
+
+  mkdirSync(join(workdir, "wiki"), { recursive: true });
+  mkdirSync(join(workdir, "sources"), { recursive: true });
+  mkdirSync(join(workdir, "images"), { recursive: true });
+
+  await runMigrations({ dbPath });
+  initDb(dbPath);
+
+  const sql = createSql();
+  await sql`INSERT INTO spaces(name, watch_dir) VALUES(${SPACE.name}, ${workdir})`;
+});
+
+afterEach(() => {
+  closeDb();
+  if (workdir) rmSync(workdir, { recursive: true, force: true });
+});
+
+describe("syncFile asset-mode", () => {
+  it("creates an entity row with kind='asset' for a PNG", async () => {
+    writeFileSync(join(workdir, "images/chart.png"), PNG_BYTES);
+
+    const result = await syncFile(SPACE, "images/chart.png");
+
+    expect(result.action).toBe("created");
+    expect(result.type).toBe("file");
+    expect(result.kind).toBe("asset");
+    expect(result.label).toBe("chart");
+    expect(result.linksExtracted).toBe(0);
+  });
+
+  it("populates properties with file_type and size_bytes", async () => {
+    writeFileSync(join(workdir, "images/chart.png"), PNG_BYTES);
+    await syncFile(SPACE, "images/chart.png");
+
+    const entity = await getEntity(SPACE.name, "images/chart.png");
+    expect(entity).not.toBeNull();
+    expect(entity!.kind).toBe("asset");
+    const props =
+      typeof entity!.properties === "string"
+        ? JSON.parse(entity!.properties)
+        : entity!.properties;
+    expect(props).toEqual({ file_type: "png", size_bytes: PNG_BYTES.length });
+  });
+
+  it("does not extract relationships for asset files", async () => {
+    writeFileSync(join(workdir, "sources/doc.pdf"), Buffer.from("%PDF-1.4 fake"));
+    await syncFile(SPACE, "sources/doc.pdf");
+
+    const entity = await getEntity(SPACE.name, "sources/doc.pdf");
+    expect(entity).not.toBeNull();
+    expect(entity!.outbound).toEqual([]);
+  });
+
+  it("does NOT write an entity_edits audit row for assets", async () => {
+    writeFileSync(join(workdir, "images/chart.png"), PNG_BYTES);
+    await syncFile(SPACE, "images/chart.png");
+
+    const sql = createSql();
+    const edits = await sql`
+      SELECT entity_path FROM entity_edits WHERE space_name = ${SPACE.name}
+    `;
+    expect(edits).toHaveLength(0);
+  });
+
+  it("text-mode source still gets a kind='text' row + entity_edits audit", async () => {
+    writeFileSync(join(workdir, "sources/notes.txt"), "hello world");
+    await syncFile(SPACE, "sources/notes.txt");
+
+    const entity = await getEntity(SPACE.name, "sources/notes.txt");
+    expect(entity!.kind).toBe("text");
+
+    const sql = createSql();
+    const edits = await sql`
+      SELECT entity_path FROM entity_edits WHERE space_name = ${SPACE.name}
+    `;
+    expect(edits).toHaveLength(1);
+  });
+});
+
+describe("link resolution: asset → no red link", () => {
+  it("a wiki <a href> to an indexed asset resolves (no red-link row)", async () => {
+    // The link extractor today only walks <a href>, not <img src> — so
+    // the asset-resolution invariant gets tested via an anchor link to
+    // the PDF. Same invariant: if the target has an entity row (of
+    // either kind), it isn't a red link.
+    writeFileSync(join(workdir, "sources/doc.pdf"), Buffer.from("%PDF-1.4 fake"));
+    writeFileSync(
+      join(workdir, "wiki/article.html"),
+      `<!doctype html>
+<html><head><meta charset="utf-8"><title>A</title></head>
+<body><a href="../sources/doc.pdf">report</a></body></html>`,
+    );
+
+    await syncFile(SPACE, "sources/doc.pdf");
+    await syncFile(SPACE, "wiki/article.html");
+
+    const red = await listRedLinks({ space_name: SPACE.name });
+    expect(red.redlinks).toHaveLength(0);
+
+    // The relationship row exists (the wiki linked to the PDF), but
+    // it isn't a red link because the asset now has an entity row.
+    const sql = createSql();
+    const rels = await sql`
+      SELECT source_path, target_path FROM relationships
+      WHERE space_name = ${SPACE.name}
+    `;
+    expect(rels).toHaveLength(1);
+    expect(rels[0].target_path).toBe("sources/doc.pdf");
+  });
+
+  it("a wiki link to a never-synced asset IS a red link", async () => {
+    writeFileSync(
+      join(workdir, "wiki/article.html"),
+      `<!doctype html>
+<html><head><meta charset="utf-8"><title>A</title></head>
+<body><a href="../sources/missing.pdf">ref</a></body></html>`,
+    );
+    await syncFile(SPACE, "wiki/article.html");
+
+    const red = await listRedLinks({ space_name: SPACE.name });
+    expect(red.redlinks).toHaveLength(1);
+    expect(red.redlinks[0].target_path).toBe("sources/missing.pdf");
+  });
+});
+
+describe("listEntities kinds filter", () => {
+  beforeEach(async () => {
+    writeFileSync(join(workdir, "sources/a.txt"), "alpha");
+    writeFileSync(join(workdir, "sources/b.md"), "# beta");
+    writeFileSync(join(workdir, "images/c.png"), PNG_BYTES);
+    writeFileSync(join(workdir, "sources/d.pdf"), Buffer.from("%PDF"));
+    await syncFile(SPACE, "sources/a.txt");
+    await syncFile(SPACE, "sources/b.md");
+    await syncFile(SPACE, "images/c.png");
+    await syncFile(SPACE, "sources/d.pdf");
+  });
+
+  it("kinds=['text'] returns only text rows", async () => {
+    const r = await listEntities({
+      space_name: SPACE.name,
+      kinds: ["text"],
+    });
+    const paths = r.entities.map((e) => e.source_path).sort();
+    expect(paths).toEqual(["sources/a.txt", "sources/b.md"]);
+    for (const e of r.entities) expect(e.kind).toBe("text");
+  });
+
+  it("kinds=['asset'] returns only asset rows", async () => {
+    const r = await listEntities({
+      space_name: SPACE.name,
+      kinds: ["asset"],
+    });
+    const paths = r.entities.map((e) => e.source_path).sort();
+    expect(paths).toEqual(["images/c.png", "sources/d.pdf"]);
+    for (const e of r.entities) expect(e.kind).toBe("asset");
+  });
+
+  it("no kind filter returns both", async () => {
+    const r = await listEntities({ space_name: SPACE.name });
+    expect(r.entities).toHaveLength(4);
+  });
+
+  it("kinds=['text','asset'] is equivalent to no filter", async () => {
+    const r = await listEntities({
+      space_name: SPACE.name,
+      kinds: ["text", "asset"],
+    });
+    expect(r.entities).toHaveLength(4);
+  });
+});
+
+describe("stat-fingerprint cache", () => {
+  it("returns action='unchanged' on second sync of a never-touched file", async () => {
+    writeFileSync(join(workdir, "sources/a.md"), "# alpha");
+    const first = await syncFile(SPACE, "sources/a.md");
+    expect(first.action).toBe("created");
+
+    const second = await syncFile(SPACE, "sources/a.md");
+    expect(second.action).toBe("unchanged");
+  });
+
+  it("returns action='unchanged' on second sync of an unchanged asset", async () => {
+    writeFileSync(join(workdir, "images/c.png"), PNG_BYTES);
+    const first = await syncFile(SPACE, "images/c.png");
+    expect(first.action).toBe("created");
+
+    const second = await syncFile(SPACE, "images/c.png");
+    expect(second.action).toBe("unchanged");
+  });
+
+  it("touch without content change: returns unchanged, refreshes fingerprint, doesn't bump updated_at", async () => {
+    writeFileSync(join(workdir, "sources/a.md"), "# alpha");
+    await syncFile(SPACE, "sources/a.md");
+    const before = await getEntity(SPACE.name, "sources/a.md");
+    const beforeUpdatedAt = before!.updated_at;
+    const beforeHash = before!.source_hash;
+
+    // Touch: bump mtime forward 5 seconds while keeping bytes identical.
+    const newTime = new Date(Date.now() + 5_000);
+    utimesSync(join(workdir, "sources/a.md"), newTime, newTime);
+
+    const result = await syncFile(SPACE, "sources/a.md");
+    expect(result.action).toBe("unchanged");
+
+    const after = await getEntity(SPACE.name, "sources/a.md");
+    expect(after!.source_hash).toBe(beforeHash);
+    expect(after!.updated_at).toBe(beforeUpdatedAt);
+  });
+
+  it("real content change: returns updated, source_hash shifts", async () => {
+    writeFileSync(join(workdir, "sources/a.md"), "# alpha");
+    await syncFile(SPACE, "sources/a.md");
+    const before = await getEntity(SPACE.name, "sources/a.md");
+    const beforeHash = before!.source_hash;
+
+    writeFileSync(join(workdir, "sources/a.md"), "# alpha changed");
+    const result = await syncFile(SPACE, "sources/a.md");
+    expect(result.action).toBe("updated");
+
+    const after = await getEntity(SPACE.name, "sources/a.md");
+    expect(after!.source_hash).not.toBe(beforeHash);
+  });
+
+  it("real asset content change: returns updated, source_hash shifts", async () => {
+    writeFileSync(join(workdir, "images/c.png"), PNG_BYTES);
+    await syncFile(SPACE, "images/c.png");
+    const before = await getEntity(SPACE.name, "images/c.png");
+    const beforeHash = before!.source_hash;
+
+    const altered = Buffer.concat([PNG_BYTES, Buffer.from([0xff])]);
+    writeFileSync(join(workdir, "images/c.png"), altered);
+    const result = await syncFile(SPACE, "images/c.png");
+    expect(result.action).toBe("updated");
+
+    const after = await getEntity(SPACE.name, "images/c.png");
+    expect(after!.source_hash).not.toBe(beforeHash);
+  });
+});

--- a/packages/arkeon/test/e2e/asset-indexing.test.ts
+++ b/packages/arkeon/test/e2e/asset-indexing.test.ts
@@ -131,11 +131,34 @@ describe("syncFile asset-mode", () => {
 });
 
 describe("link resolution: asset → no red link", () => {
-  it("a wiki <a href> to an indexed asset resolves (no red-link row)", async () => {
-    // The link extractor today only walks <a href>, not <img src> — so
-    // the asset-resolution invariant gets tested via an anchor link to
-    // the PDF. Same invariant: if the target has an entity row (of
-    // either kind), it isn't a red link.
+  it("a wiki <img src> to an indexed asset resolves (no red-link row)", async () => {
+    writeFileSync(join(workdir, "images/chart.png"), PNG_BYTES);
+    writeFileSync(
+      join(workdir, "wiki/article.html"),
+      `<!doctype html>
+<html><head><meta charset="utf-8"><title>A</title></head>
+<body><img src="../images/chart.png" alt="Chart"></body></html>`,
+    );
+
+    await syncFile(SPACE, "images/chart.png");
+    await syncFile(SPACE, "wiki/article.html");
+
+    const red = await listRedLinks({ space_name: SPACE.name });
+    expect(red.redlinks).toHaveLength(0);
+
+    // The relationship row exists (extractHtmlLinks walks <img src>),
+    // but it isn't a red link because the asset has an entity row.
+    const sql = createSql();
+    const rels = await sql`
+      SELECT source_path, target_path, link_text FROM relationships
+      WHERE space_name = ${SPACE.name}
+    `;
+    expect(rels).toHaveLength(1);
+    expect(rels[0].target_path).toBe("images/chart.png");
+    expect(rels[0].link_text).toBe("Chart");
+  });
+
+  it("a wiki <a href> to an indexed asset also resolves (regression — non-image asset)", async () => {
     writeFileSync(join(workdir, "sources/doc.pdf"), Buffer.from("%PDF-1.4 fake"));
     writeFileSync(
       join(workdir, "wiki/article.html"),
@@ -149,16 +172,6 @@ describe("link resolution: asset → no red link", () => {
 
     const red = await listRedLinks({ space_name: SPACE.name });
     expect(red.redlinks).toHaveLength(0);
-
-    // The relationship row exists (the wiki linked to the PDF), but
-    // it isn't a red link because the asset now has an entity row.
-    const sql = createSql();
-    const rels = await sql`
-      SELECT source_path, target_path FROM relationships
-      WHERE space_name = ${SPACE.name}
-    `;
-    expect(rels).toHaveLength(1);
-    expect(rels[0].target_path).toBe("sources/doc.pdf");
   });
 
   it("a wiki link to a never-synced asset IS a red link", async () => {

--- a/packages/arkeon/test/e2e/reader.test.ts
+++ b/packages/arkeon/test/e2e/reader.test.ts
@@ -91,11 +91,11 @@ beforeAll(async () => {
     `A mathematical theory of communication.\n`,
   );
 
-  // Deliberately NOT indexed (PDF is in BINARY_EXTENSIONS — fast-rejected).
-  // Still exists on disk and gets served raw by the static-file fallback
-  // with the MIME table's `application/pdf` content type — exercises the
-  // passthrough path for any non-indexed file type. From the wiki's
-  // perspective it's a red link because no entity row exists.
+  // Indexed as kind='asset' (PDFs are in ASSET_EXTENSIONS). Has an
+  // entity row so links to it resolve (no red-link class), and the
+  // static-file fallback still serves the bytes with application/pdf
+  // — exercises the passthrough path for any file the reader doesn't
+  // own (everything that isn't wiki/**/*.html).
   writeFileSync(
     join(workdir, "sources/notes.pdf"),
     `%PDF-1.4\nPretend bytes, served raw.\n`,
@@ -207,12 +207,10 @@ describe("Phase 2 reader", () => {
     expect(body).toContain(
       `<a href="../sources/missing.txt" class="arkeon-file arkeon-redlink">`,
     );
-    // Non-indexed file type (PDF is in BINARY_EXTENSIONS) — the file
-    // exists on disk but there's no entity row, so the reader classifies it
-    // as a red link. The static-file route below verifies the bytes still
-    // come through.
+    // Indexed asset (PDF) — has an entity row with kind='asset', so the
+    // link resolves (no redlink class). Style is plain `arkeon-file`.
     expect(body).toContain(
-      `<a href="../sources/notes.pdf" class="arkeon-file arkeon-redlink">`,
+      `<a href="../sources/notes.pdf" class="arkeon-file">`,
     );
     // External link untouched
     expect(body).toContain(`<a href="https://wikipedia.org">wikipedia</a>`);
@@ -228,11 +226,12 @@ describe("Phase 2 reader", () => {
     expect(body).not.toContain("arkeon-chrome");
   });
 
-  it("GET /:space/sources/*.pdf serves non-indexed binaries raw via MIME table passthrough", async () => {
-    // PDFs aren't indexed but the static-file fallback still serves them
-    // with application/pdf so browsers display them natively. Same
-    // principle covers images, video, archives — the MIME table is the
-    // contract for any non-indexed extension.
+  it("GET /:space/sources/*.pdf serves asset bytes raw via MIME table passthrough", async () => {
+    // PDFs are now indexed as kind='asset' (link resolution works), but
+    // the actual bytes still flow through the static-file fallback —
+    // the reader only owns wiki/**/*.html. Same principle covers
+    // images, video, archives — MIME table is the contract for any
+    // non-wiki path.
     const res = await fetch(`${baseUrl}/${SPACE}/sources/notes.pdf`);
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toMatch(/application\/pdf/);

--- a/packages/arkeon/test/unit/fs-watcher-eligibility.test.ts
+++ b/packages/arkeon/test/unit/fs-watcher-eligibility.test.ts
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Focused tests for the three-tier eligibility check in fs-watcher.
- * scanSources and the e2e watcher cover this transitively, but a direct
- * test for walkEligibleFiles + sniffIsText keeps the contract explicit
- * (and fast to run when iterating on the rules).
+ * Focused tests for fs-watcher's eligibility + classification. Under
+ * the asset-indexing model, eligibility is "is this a non-junk file"
+ * and classification (text vs asset) is a separate decision. Both
+ * surfaces are tested here directly so the contract stays explicit
+ * (and fast to iterate on when the rules change).
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -14,6 +15,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  classifyFile,
   isEligibleFile,
   isPathPotentiallyEligible,
   sniffIsText,
@@ -66,68 +68,105 @@ describe("eligibility", () => {
       expect(isPathPotentiallyEligible(".arkeon/state.json")).toBe(false);
     });
 
-    it("rejects known-binary extensions", () => {
-      expect(isPathPotentiallyEligible("doc.pdf")).toBe(false);
-      expect(isPathPotentiallyEligible("img.png")).toBe(false);
-      expect(isPathPotentiallyEligible("archive.zip")).toBe(false);
+    it("rejects SKIP_EXTENSIONS (secrets + editor scratch)", () => {
+      // Suffix-form .env (without leading dot) is the case shouldIgnorePath
+      // misses — only SKIP_EXTENSIONS catches it.
+      expect(isPathPotentiallyEligible("production.env")).toBe(false);
+      expect(isPathPotentiallyEligible("staging.env")).toBe(false);
+      expect(isPathPotentiallyEligible("server.pem")).toBe(false);
+      expect(isPathPotentiallyEligible("notes.swp")).toBe(false);
+      expect(isPathPotentiallyEligible("draft.tmp")).toBe(false);
     });
 
-    it("passes through text extensions and unknowns (sniff happens later)", () => {
+    it("rejects junk basenames (.DS_Store, Thumbs.db)", () => {
+      expect(isPathPotentiallyEligible(".DS_Store")).toBe(false);
+      expect(isPathPotentiallyEligible("Thumbs.db")).toBe(false);
+      expect(isPathPotentiallyEligible("nested/sub/.DS_Store")).toBe(false);
+    });
+
+    it("accepts text-extension files", () => {
       expect(isPathPotentiallyEligible("notes.md")).toBe(true);
       expect(isPathPotentiallyEligible("README")).toBe(true);
       expect(isPathPotentiallyEligible("config.xyz")).toBe(true);
     });
+
+    it("accepts asset-extension files (now indexable as kind='asset')", () => {
+      // Pre-asset-indexing, the BINARY_EXTENSIONS denylist refused
+      // these; now they're eligible (classification picks kind='asset').
+      expect(isPathPotentiallyEligible("doc.pdf")).toBe(true);
+      expect(isPathPotentiallyEligible("img.png")).toBe(true);
+      expect(isPathPotentiallyEligible("archive.zip")).toBe(true);
+      expect(isPathPotentiallyEligible("song.mp3")).toBe(true);
+      expect(isPathPotentiallyEligible("video.mp4")).toBe(true);
+    });
   });
 
   describe("isEligibleFile", () => {
-    it("indexes known-text extensions without inspecting content", () => {
+    // isEligibleFile is now just a path-based check (the content sniff
+    // moved to classifyFile). It accepts assets too.
+
+    it("indexes text-extension files", () => {
       touch("notes.md", "# Hello");
       expect(isEligibleFile("notes.md", join(dir, "notes.md"))).toBe(true);
     });
 
-    it("rejects known-binary extensions without inspecting content", () => {
-      // Even text-looking content can't override a binary extension —
-      // it's the user's signal of intent.
-      touch("fake.pdf", "totally not a pdf, but the extension says it is");
-      expect(isEligibleFile("fake.pdf", join(dir, "fake.pdf"))).toBe(false);
+    it("indexes asset-extension files (kind classification happens separately)", () => {
+      touch("img.png", Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+      expect(isEligibleFile("img.png", join(dir, "img.png"))).toBe(true);
     });
 
-    it("sniffs extensionless files: text → eligible", () => {
-      touch("README", "# Project\n\nDocs go here.\n");
-      expect(isEligibleFile("README", join(dir, "README"))).toBe(true);
+    it("refuses to index *.env files even though content is text", () => {
+      touch("production.env", "DATABASE_URL=postgres://user:secret@host/db\n");
+      expect(isEligibleFile("production.env", join(dir, "production.env"))).toBe(false);
     });
 
-    it("sniffs extensionless files: binary → not eligible", () => {
+    it("refuses to index credential / key files", () => {
+      touch("server.pem", "-----BEGIN PRIVATE KEY-----\n...\n");
+      expect(isEligibleFile("server.pem", join(dir, "server.pem"))).toBe(false);
+    });
+
+    it("refuses to index junk basenames regardless of subdir", () => {
+      touch(".DS_Store", "");
+      touch("nested/.DS_Store", "");
+      expect(isEligibleFile(".DS_Store", join(dir, ".DS_Store"))).toBe(false);
+      expect(isEligibleFile("nested/.DS_Store", join(dir, "nested/.DS_Store"))).toBe(false);
+    });
+  });
+
+  describe("classifyFile", () => {
+    it("returns 'text' for TEXT_EXTENSIONS without inspecting content", () => {
+      touch("notes.md", "# Hello");
+      expect(classifyFile("notes.md", join(dir, "notes.md"))).toBe("text");
+    });
+
+    it("returns 'asset' for ASSET_EXTENSIONS without inspecting content", () => {
+      touch("img.png", Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+      touch("doc.pdf", Buffer.from([0x25, 0x50, 0x44, 0x46]));
+      touch("archive.zip", Buffer.from([0x50, 0x4b, 0x03, 0x04]));
+      expect(classifyFile("img.png", join(dir, "img.png"))).toBe("asset");
+      expect(classifyFile("doc.pdf", join(dir, "doc.pdf"))).toBe("asset");
+      expect(classifyFile("archive.zip", join(dir, "archive.zip"))).toBe("asset");
+    });
+
+    it("sniffs extensionless files: text → 'text'", () => {
+      touch("README", "# Project\n");
+      expect(classifyFile("README", join(dir, "README"))).toBe("text");
+    });
+
+    it("sniffs extensionless files: binary → 'asset'", () => {
       touch("blob", Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x00, 0x01]));
-      expect(isEligibleFile("blob", join(dir, "blob"))).toBe(false);
+      expect(classifyFile("blob", join(dir, "blob"))).toBe("asset");
     });
 
     it("sniffs unknown extensions both ways", () => {
       touch("config.xyz", "key=value\n");
       touch("opaque.xyz", Buffer.from([0x01, 0x00, 0x02]));
-      expect(isEligibleFile("config.xyz", join(dir, "config.xyz"))).toBe(true);
-      expect(isEligibleFile("opaque.xyz", join(dir, "opaque.xyz"))).toBe(false);
+      expect(classifyFile("config.xyz", join(dir, "config.xyz"))).toBe("text");
+      expect(classifyFile("opaque.xyz", join(dir, "opaque.xyz"))).toBe("asset");
     });
 
-    it("refuses to index *.env files even though their content is text", () => {
-      // Files like `production.env` / `staging.env` have no dot prefix,
-      // so shouldIgnorePath misses them. Their content is text, so the
-      // sniff alone would let them through. BINARY_EXTENSIONS gates
-      // them out explicitly — that's the only durable defense.
-      touch("production.env", "DATABASE_URL=postgres://user:secret@host/db\n");
-      touch("staging.env", "API_KEY=sk-redacted-but-still-text\n");
-      expect(isEligibleFile("production.env", join(dir, "production.env"))).toBe(false);
-      expect(isEligibleFile("staging.env", join(dir, "staging.env"))).toBe(false);
-    });
-
-    it("refuses to index credential / key files even though their content is text", () => {
-      touch(
-        "server.pem",
-        "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBg...\n-----END PRIVATE KEY-----\n",
-      );
-      touch("backup.kdbx", "fake keepass bytes but legible as text");
-      expect(isEligibleFile("server.pem", join(dir, "server.pem"))).toBe(false);
-      expect(isEligibleFile("backup.kdbx", join(dir, "backup.kdbx"))).toBe(false);
+    it("falls back to 'asset' on unreadable files (safe default — asset-mode reads no content)", () => {
+      expect(classifyFile("missing", join(dir, "missing"))).toBe("asset");
     });
   });
 
@@ -139,11 +178,16 @@ describe("eligibility", () => {
       expect(files.sort()).toEqual(["LICENSE", "README"]);
     });
 
-    it("skips extensionless binary files via sniff", () => {
+    it("walks return extensionless binary files (eligibility is path-only now)", () => {
+      // Under the old three-tier check, an extensionless binary was
+      // rejected by the sniff. Under the asset-indexing model, eligibility
+      // is path-only — the sniff happens inside classifyFile, NOT here.
+      // The walk surfaces every non-junk file; classification decides
+      // text vs asset later.
       touch("README", "# Hello\n");
       touch("opaque", Buffer.from([0x00, 0x01, 0x02]));
-      const files = walkEligibleFiles(dir);
-      expect(files).toEqual(["README"]);
+      const files = walkEligibleFiles(dir).sort();
+      expect(files).toEqual(["README", "opaque"]);
     });
 
     it("skips ignored directories", () => {
@@ -162,8 +206,17 @@ describe("eligibility", () => {
       expect(files).toEqual(["a/b/c/deep.md", "top.md"]);
     });
 
-    it("excludes known-binary extensions even when their bytes are text-shaped", () => {
+    it("includes asset-extension files (now eligible as kind='asset')", () => {
       touch("fake.pdf", "this looks like text but the ext says binary");
+      touch("real.md", "# real");
+      const files = walkEligibleFiles(dir).sort();
+      expect(files).toEqual(["fake.pdf", "real.md"]);
+    });
+
+    it("skips junk basenames", () => {
+      touch(".DS_Store", "");
+      touch("Thumbs.db", "");
+      touch("nested/.DS_Store", "");
       touch("real.md", "# real");
       const files = walkEligibleFiles(dir);
       expect(files).toEqual(["real.md"]);

--- a/packages/arkeon/test/unit/html-links.test.ts
+++ b/packages/arkeon/test/unit/html-links.test.ts
@@ -156,4 +156,48 @@ describe("extractHtmlLinks", () => {
     expect(links).toHaveLength(1);
     expect(links[0].text).toBe("x");
   });
+
+  it("walks <img src> and emits resolved relationships using `alt` as link text", () => {
+    const html = `<!doctype html><title>X</title>
+<body>
+  <p>See the chart:</p>
+  <img src="../images/chart.png" alt="Trade openness chart">
+  <img src="../images/no-alt.jpg">
+  <img src="https://cdn.example.com/external.png" alt="ext">
+</body>`;
+    const links = extractHtmlLinks(html, "wiki/foo.html");
+    expect(links).toHaveLength(3);
+
+    const resolved = links.filter((l) => l.resolved !== null);
+    expect(resolved.map((l) => ({ resolved: l.resolved, text: l.text }))).toEqual([
+      { resolved: "images/chart.png", text: "Trade openness chart" },
+      { resolved: "images/no-alt.jpg", text: "" },
+    ]);
+
+    const external = links.find((l) => l.href.startsWith("https://"));
+    expect(external?.resolved).toBeNull();
+  });
+
+  it("skips <img> elements without a src attribute", () => {
+    const html = `<img alt="nothing"><img src="x.png">`;
+    const links = extractHtmlLinks(html, "wiki/foo.html");
+    expect(links).toHaveLength(1);
+    expect(links[0].href).toBe("x.png");
+  });
+
+  it("emits both <a> and <img> relationships in a mixed document", () => {
+    const html = `<a href="other.html">other</a>
+                  <img src="../images/x.png" alt="x">
+                  <a href="../sources/notes.md">notes</a>`;
+    const links = extractHtmlLinks(html, "wiki/foo.html");
+    const resolved = links
+      .filter((l) => l.resolved !== null)
+      .map((l) => l.resolved)
+      .sort();
+    expect(resolved).toEqual([
+      "images/x.png",
+      "sources/notes.md",
+      "wiki/other.html",
+    ]);
+  });
 });

--- a/packages/arkeon/test/unit/inbox-lib.test.ts
+++ b/packages/arkeon/test/unit/inbox-lib.test.ts
@@ -182,10 +182,18 @@ describe("assertTextContent", () => {
     expect(() => assertTextContent(buf, "sources/foo.md")).not.toThrow();
   });
 
-  it("rejects binary extensions even with text body", () => {
+  it("rejects asset extensions even with text body (asset uploads go through disk)", () => {
+    // PNGs are kind='asset' — they ARE indexable, just not via the HTTP
+    // text write-back. Drop them in the watch dir directly.
     expect(() =>
       assertTextContent(Buffer.from("PNG"), "sources/foo.png"),
-    ).toThrow(/not indexable/);
+    ).toThrow(/binary asset/);
+  });
+
+  it("rejects secret-bearing extensions", () => {
+    expect(() =>
+      assertTextContent(Buffer.from("KEY=value"), "sources/prod.env"),
+    ).toThrow(/secrets or scratch/);
   });
 
   it("rejects buffers with NUL bytes when extension is unknown", () => {

--- a/packages/arkeon/test/unit/search-text-glob.test.ts
+++ b/packages/arkeon/test/unit/search-text-glob.test.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Drift guard: the search tool's ripgrep `--type-add` glob is built
+ * from TEXT_EXTENSIONS at module load. If someone adds a new text
+ * extension to fs-watcher and forgets that search uses a separate
+ * filter, the lists would drift — except they're now derived from
+ * the same source. This test asserts that derivation directly so a
+ * future refactor can't silently break the alignment.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ASSET_EXTENSIONS,
+  TEXT_EXTENSIONS,
+  TEXT_EXTENSION_GLOB,
+} from "../../src/server/lib/fs-watcher.js";
+
+describe("search ↔ TEXT_EXTENSIONS alignment", () => {
+  it("covers every brace-safe TEXT_EXTENSIONS entry", () => {
+    for (const ext of TEXT_EXTENSIONS) {
+      const bare = ext.slice(1);
+      if (!/^[a-z0-9_]+$/.test(bare)) continue; // filter applied at build time
+      // The glob is `*.{a,b,c,...}`; assert the bare extension appears
+      // surrounded by either `{` `,` or `,` `}` (or `{` `}` for single).
+      const inGroup = new RegExp(`[{,]${bare}[,}]`);
+      expect(TEXT_EXTENSION_GLOB).toMatch(inGroup);
+    }
+  });
+
+  it("excludes every ASSET_EXTENSIONS entry", () => {
+    for (const ext of ASSET_EXTENSIONS) {
+      const bare = ext.slice(1);
+      const inGroup = new RegExp(`[{,]${bare}[,}]`);
+      expect(TEXT_EXTENSION_GLOB).not.toMatch(inGroup);
+    }
+  });
+
+  it("has the expected glob shape", () => {
+    expect(TEXT_EXTENSION_GLOB.startsWith("*.{")).toBe(true);
+    expect(TEXT_EXTENSION_GLOB.endsWith("}")).toBe(true);
+  });
+});

--- a/packages/arkeon/test/unit/sources-scan.test.ts
+++ b/packages/arkeon/test/unit/sources-scan.test.ts
@@ -34,7 +34,10 @@ describe("scanSources", () => {
     expect(result.unsupported.by_ext).toEqual({});
   });
 
-  it("partitions supported and unsupported by extension", () => {
+  it("partitions supported and unsupported by extension (assets are now supported)", () => {
+    // Under the asset-indexing model, PDFs / PNGs are eligible — they
+    // get entity rows with kind='asset'. Only secrets and junk land in
+    // unsupported. Use a .env file to exercise the unsupported bucket.
     touch("a.txt");
     touch("b.txt");
     touch("c.json");
@@ -42,13 +45,20 @@ describe("scanSources", () => {
     touch("binary.pdf");
     touch("photo.png");
     touch("photo2.png");
+    touch("production.env", "SECRET=hidden");
 
     const result = scanSources(dir);
-    expect(result.total).toBe(7);
-    expect(result.supported.count).toBe(4);
-    expect(result.supported.by_ext).toEqual({ ".txt": 2, ".json": 1, ".html": 1 });
-    expect(result.unsupported.count).toBe(3);
-    expect(result.unsupported.by_ext).toEqual({ ".png": 2, ".pdf": 1 });
+    expect(result.total).toBe(8);
+    expect(result.supported.count).toBe(7);
+    expect(result.supported.by_ext).toEqual({
+      ".txt": 2,
+      ".png": 2,
+      ".json": 1,
+      ".html": 1,
+      ".pdf": 1,
+    });
+    expect(result.unsupported.count).toBe(1);
+    expect(result.unsupported.by_ext).toEqual({ ".env": 1 });
   });
 
   it("indexes extensionless text files (README, LICENSE) via content sniff", () => {
@@ -65,28 +75,32 @@ describe("scanSources", () => {
     expect(result.unsupported.by_ext).toEqual({});
   });
 
-  it("rejects extensionless binaries via content sniff (NUL bytes present)", () => {
-    // A file with a single NUL byte is unambiguously binary —
-    // the sniff catches it even without an extension hint.
-    const binary = Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x00, 0x01]); // ELF header start
+  it("includes extensionless binaries as supported (eligibility is path-only now)", () => {
+    // Under the asset-indexing model, scanSources reports "supported"
+    // for anything that will get an entity row — text or asset. The
+    // text-vs-asset distinction is the watcher's classification step,
+    // not the scan's responsibility. An extensionless binary just gets
+    // kind='asset' on classification.
+    const binary = Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x00, 0x01]); // ELF header
     touch("opaque-bin", binary.toString("binary"));
     touch("readme.txt", "text");
 
     const result = scanSources(dir);
-    expect(result.supported.by_ext).toEqual({ ".txt": 1 });
-    expect(result.unsupported.by_ext).toEqual({ "(none)": 1 });
+    expect(result.supported.by_ext).toEqual({ ".txt": 1, "(none)": 1 });
+    expect(result.unsupported.by_ext).toEqual({});
   });
 
-  it("rejects unknown-extension files containing NUL bytes via content sniff", () => {
-    // An unknown extension (.xyz) is neither denylisted nor allowlisted;
-    // the sniff is what gates it. NUL byte → binary → unsupported.
+  it("includes unknown-extension files (text and binary) as supported", () => {
+    // Unknown extensions aren't denylisted, so they're eligible. The
+    // sniff happens later inside classifyFile to decide text vs asset
+    // — irrelevant to the scan's supported/unsupported partition.
     const binary = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00]);
     touch("opaque.xyz", binary.toString("binary"));
     touch("text.xyz", "no nulls here, just text");
 
     const result = scanSources(dir);
-    expect(result.supported.by_ext).toEqual({ ".xyz": 1 });
-    expect(result.unsupported.by_ext).toEqual({ ".xyz": 1 });
+    expect(result.supported.by_ext).toEqual({ ".xyz": 2 });
+    expect(result.unsupported.by_ext).toEqual({});
   });
 
   it("skips ignored directories (.git, node_modules, .arkeon, hidden)", () => {
@@ -102,13 +116,14 @@ describe("scanSources", () => {
   });
 
   it("limits unsupported examples to 5 per extension", () => {
-    for (let i = 0; i < 7; i++) touch(`doc-${i}.pdf`);
+    // .env is SKIP_EXTENSIONS — unsupported. Need 7+ to exercise the cap.
+    for (let i = 0; i < 7; i++) touch(`stage-${i}.env`);
     const result = scanSources(dir);
-    expect(result.unsupported.by_ext[".pdf"]).toBe(7);
-    expect(result.unsupported.examples[".pdf"]).toHaveLength(5);
+    expect(result.unsupported.by_ext[".env"]).toBe(7);
+    expect(result.unsupported.examples[".env"]).toHaveLength(5);
   });
 
-  it("sorts by_ext by count descending", () => {
+  it("sorts supported by_ext by count descending", () => {
     touch("a.png");
     touch("b.pdf");
     touch("c.pdf");
@@ -117,18 +132,17 @@ describe("scanSources", () => {
     touch("f.docx");
 
     const result = scanSources(dir);
-    expect(Object.keys(result.unsupported.by_ext)).toEqual([".pdf", ".docx", ".png"]);
+    expect(Object.keys(result.supported.by_ext)).toEqual([".pdf", ".docx", ".png"]);
   });
 
   it("normalizes extensions to lowercase", () => {
+    // .PDF and .pdf both normalize to .pdf — both supported as assets.
+    // .TXT normalizes to .txt — supported as text.
     touch("a.PDF");
     touch("b.pdf");
     touch("c.TXT");
     const result = scanSources(dir);
-    // Extension sets only have lowercase entries; uppercased .TXT
-    // becomes ".txt" via the lowercase normalization and lands in
-    // supported.
-    expect(result.supported.by_ext).toEqual({ ".txt": 1 });
-    expect(result.unsupported.by_ext).toEqual({ ".pdf": 2 });
+    expect(result.supported.by_ext).toEqual({ ".pdf": 2, ".txt": 1 });
+    expect(result.unsupported.by_ext).toEqual({});
   });
 });


### PR DESCRIPTION
## Summary

Splits the entity model into two kinds so binary files (images, PDFs, audio, video, archives) can be **linked to** without being **processed by** the agents:

- `kind='text'` — parsed corpus material the agents read and process. Wikis (always text) and source files that classify as text. What enters the editor / proposer / connector queue.
- `kind='asset'` — binary attachments indexed for link resolution only. `<a href=\"report.pdf\">` and `<img src=\"chart.png\">` now resolve to real entities instead of red links. Never feed the agents.

The prior `BINARY_EXTENSIONS` denylist shrinks to `SKIP_EXTENSIONS` (secrets + editor scratch) — everything else gets an entity row.

## What changed

- **Schema migration 003** adds `entities.kind` (`'text'|'asset'` CHECK, default `'text'`) and `entities.stat_fingerprint`.
- **`syncFile`** now stat-fingerprints first (`mtime_ms-size_bytes`). On a fingerprint match → return `unchanged` with zero I/O. On a miss → compute the real SHA-256 (streaming for assets so multi-GB videos don't load into memory). If the content hash matches the stored `source_hash`, the change was a touch — refresh the fingerprint without bumping `updated_at`. `source_hash` stays canonical SHA-256 of content for both kinds — uniform semantics across the codebase.
- **Asset rows** carry `{file_type, size_bytes}` only — no parsed metadata, no link extraction, no `entity_edits` audit row (image churn would crowd out the wiki edits operators care about).
- **`fs-watcher.ts`** collapses the old three-tier check. New `classifyFile()` returns `'text'|'asset'`; `isEligibleFile()` is now path-only (the sniff moved into `classifyFile`).
- **`list_entities`** gains a `kinds` filter; new `parseEntityKinds` helper drives `?kind=text|asset` on the HTTP endpoint and the agent tool's `kind` parameter.
- **Bundled agent templates** (editor / proposer / connector) pass `kind=\"text\"` on queue queries so assets stay out of the work feed.
- **Search consistency.** Ripgrep's `--type-add` glob is now derived from `TEXT_EXTENSIONS` via the new `TEXT_EXTENSION_GLOB` constant (exported from fs-watcher.ts to avoid a circular import). Adding a new text extension automatically widens search to match — no second list to keep in sync. Side benefit: search now covers all 60+ text extensions (source code, configs, logs) instead of the prior 7-extension subset.
- **Write-back guards** (`POST /inbox`, `PUT /sources/*`) reject asset uploads with a \"drop on disk instead\" hint and secrets with a separate \"secrets or scratch\" error. HTTP write surface stays text-only; assets go through the watcher.
- **Docs updated:** `CLAUDE.md`, `SETUP.md`, `llms.txt` all describe the new model.

## Test plan

- [x] `npm run typecheck -w packages/arkeon` — clean
- [x] `npm test -w packages/arkeon` — 435/435 pass (added 3 in search-text-glob.test.ts; updated fs-watcher-eligibility, sources-scan, inbox-lib for new semantics)
- [x] `npm run test:e2e -w packages/arkeon` — 100/100 pass (added 16 in `asset-indexing.test.ts` covering create, properties, no-relationships, no-audit, kind filters, stat-cache fast path, touch-without-change preservation, real content change)
- [x] **Live smoke** against a tmp dir confirmed:
  - PDF + PNG indexed as `kind='asset'` with `file_type` + `size_bytes`
  - Markdown indexed as `kind='text'`
  - `.env` and `.DS_Store` correctly skipped
  - `type=file&kind=text` queue query returns only text sources
  - Red-link list empty (asset links resolve)
  - `PUT /sources/foo.pdf` → 400 \"binary asset, drop on disk\"
  - `PUT /sources/foo.env` → 400 \"secrets or scratch\"
  - `PUT /sources/foo.md` → 201 with synced `kind='text'` entity

## Migration notes

- Existing rows are all text (the prior denylist refused to index anything else) — the `DEFAULT 'text'` clause covers them without a backfill.
- `stat_fingerprint` is NULL on pre-migration rows; the fast path's equality check misses on NULL and falls through to the hash, then populates on first sync. No special bootstrap needed.
- On the first daemon start after the migration, asset files that were previously ignored will appear in the index (operators pointing arkeon-wiki at a directory with images / PDFs will see new entity rows). Use `?kind=text` to scope to the prior set.

## What this unblocks

PR 2 (separate, follow-up): a `fetch` tool that lets agents view local + remote images via the AI SDK user-message-injection pattern we validated across providers (Anthropic, OpenAI direct, Gemini, Qwen, Mistral, Llama 3.2 Vision). With asset rows in the index, the writer can reference `<img src=\"../images/chart.png\">` in articles and the link resolves end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)