### PR TITLE
mcp: namespace tool names by bound space

### DIFF
--- a/packages/arkeon/src/mcp/tools/add-source.ts
+++ b/packages/arkeon/src/mcp/tools/add-source.ts
@@ -17,9 +17,9 @@ interface AddSourceResponse {
   entity: { source_hash: string; created_at: string; kind: string };
 }
 
-export function registerAddSource(server: McpServer, client: ArkeonWikiClient): void {
+export function registerAddSource(server: McpServer, client: ArkeonWikiClient, namePrefix = ""): void {
   server.registerTool(
-    "add_source",
+    `${namePrefix}add_source`,
     {
       title: "Add source from URL",
       description: TOOL_DESCRIPTIONS.add_source,

--- a/packages/arkeon/src/mcp/tools/capture-thought.ts
+++ b/packages/arkeon/src/mcp/tools/capture-thought.ts
@@ -13,9 +13,9 @@ interface InboxResponse {
   entity: { source_hash: string; created_at: string };
 }
 
-export function registerCaptureThought(server: McpServer, client: ArkeonWikiClient): void {
+export function registerCaptureThought(server: McpServer, client: ArkeonWikiClient, namePrefix = ""): void {
   server.registerTool(
-    "capture_thought",
+    `${namePrefix}capture_thought`,
     {
       title: "Capture thought",
       description: TOOL_DESCRIPTIONS.capture_thought,

--- a/packages/arkeon/src/mcp/tools/create-space.ts
+++ b/packages/arkeon/src/mcp/tools/create-space.ts
@@ -6,9 +6,9 @@ import { z } from "zod";
 
 import type { ArkeonWikiClient } from "../client.js";
 
-export function registerCreateSpace(server: McpServer, client: ArkeonWikiClient): void {
+export function registerCreateSpace(server: McpServer, client: ArkeonWikiClient, namePrefix = ""): void {
   server.registerTool(
-    "create_space",
+    `${namePrefix}create_space`,
     {
       title: "Create space",
       description:

--- a/packages/arkeon/src/mcp/tools/daemon-status.ts
+++ b/packages/arkeon/src/mcp/tools/daemon-status.ts
@@ -5,9 +5,9 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import type { ArkeonWikiClient } from "../client.js";
 
-export function registerDaemonStatus(server: McpServer, client: ArkeonWikiClient): void {
+export function registerDaemonStatus(server: McpServer, client: ArkeonWikiClient, namePrefix = ""): void {
   server.registerTool(
-    "daemon_status",
+    `${namePrefix}daemon_status`,
     {
       title: "Daemon status",
       description:

--- a/packages/arkeon/src/mcp/tools/index.ts
+++ b/packages/arkeon/src/mcp/tools/index.ts
@@ -15,15 +15,40 @@ import { registerReadArticle } from "./read-article.js";
 import { registerSaveConversation } from "./save-conversation.js";
 import { registerSearchWiki } from "./search-wiki.js";
 
+/**
+ * Prefix that scopes every tool's registered name to a specific wiki
+ * space. Required because Claude Desktop's local-MCP tool registry
+ * appears to dedupe by bare tool name across stdio servers — without
+ * unique names, four `iarpa-wiki` / `augustine-wiki` / `chartbook-wiki`
+ * / `opioid-kol-wiki` entries all exposing `list_articles` end up with
+ * exactly ONE callable `list_articles` total, arbitrarily routed to
+ * one of the servers. Tools that lose the dedup race appear in
+ * `tools/list` but can't actually be invoked from that server's
+ * conversation context. Empirically confirmed against Claude Desktop
+ * 0.x in May 2026.
+ *
+ * Sanitization rule: any character outside `[a-zA-Z0-9_]` becomes `_`
+ * (so "augustine-chesterton" → "augustine_chesterton"). Empty / null
+ * space yields the empty prefix, so a vanilla `arkeon-wiki mcp` with
+ * no `ARKEON_WIKI_SPACE` set keeps the original bare names — useful
+ * for single-server setups where this collision can't happen.
+ */
+export function toolNamePrefix(space: string | null | undefined): string {
+  if (!space) return "";
+  const slug = space.replace(/[^a-zA-Z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  return slug ? `${slug}__` : "";
+}
+
 export function registerAllTools(server: McpServer, client: ArkeonWikiClient): void {
-  registerDaemonStatus(server, client);
-  registerListSpaces(server, client);
-  registerCreateSpace(server, client);
-  registerSearchWiki(server, client);
-  registerListArticles(server, client);
-  registerReadArticle(server, client);
-  registerListRedlinks(server, client);
-  registerCaptureThought(server, client);
-  registerAddSource(server, client);
-  registerSaveConversation(server, client);
+  const prefix = toolNamePrefix(client.defaultSpace);
+  registerDaemonStatus(server, client, prefix);
+  registerListSpaces(server, client, prefix);
+  registerCreateSpace(server, client, prefix);
+  registerSearchWiki(server, client, prefix);
+  registerListArticles(server, client, prefix);
+  registerReadArticle(server, client, prefix);
+  registerListRedlinks(server, client, prefix);
+  registerCaptureThought(server, client, prefix);
+  registerAddSource(server, client, prefix);
+  registerSaveConversation(server, client, prefix);
 }

--- a/packages/arkeon/src/mcp/tools/list-articles.ts
+++ b/packages/arkeon/src/mcp/tools/list-articles.ts
@@ -15,9 +15,9 @@ interface EntitiesResponse {
   }>;
 }
 
-export function registerListArticles(server: McpServer, client: ArkeonWikiClient): void {
+export function registerListArticles(server: McpServer, client: ArkeonWikiClient, namePrefix = ""): void {
   server.registerTool(
-    "list_articles",
+    `${namePrefix}list_articles`,
     {
       title: "List articles",
       description:

--- a/packages/arkeon/src/mcp/tools/list-redlinks.ts
+++ b/packages/arkeon/src/mcp/tools/list-redlinks.ts
@@ -14,9 +14,9 @@ interface RedlinksResponse {
   }>;
 }
 
-export function registerListRedlinks(server: McpServer, client: ArkeonWikiClient): void {
+export function registerListRedlinks(server: McpServer, client: ArkeonWikiClient, namePrefix = ""): void {
   server.registerTool(
-    "list_redlinks",
+    `${namePrefix}list_redlinks`,
     {
       title: "List red links",
       description:

--- a/packages/arkeon/src/mcp/tools/list-spaces.ts
+++ b/packages/arkeon/src/mcp/tools/list-spaces.ts
@@ -14,9 +14,9 @@ interface SpacesResponse {
   }>;
 }
 
-export function registerListSpaces(server: McpServer, client: ArkeonWikiClient): void {
+export function registerListSpaces(server: McpServer, client: ArkeonWikiClient, namePrefix = ""): void {
   server.registerTool(
-    "list_spaces",
+    `${namePrefix}list_spaces`,
     {
       title: "List spaces",
       description:

--- a/packages/arkeon/src/mcp/tools/read-article.ts
+++ b/packages/arkeon/src/mcp/tools/read-article.ts
@@ -22,9 +22,9 @@ interface ReadResult {
   error?: string;
 }
 
-export function registerReadArticle(server: McpServer, client: ArkeonWikiClient): void {
+export function registerReadArticle(server: McpServer, client: ArkeonWikiClient, namePrefix = ""): void {
   server.registerTool(
-    "read_article",
+    `${namePrefix}read_article`,
     {
       title: "Read article(s)",
       description:

--- a/packages/arkeon/src/mcp/tools/save-conversation.ts
+++ b/packages/arkeon/src/mcp/tools/save-conversation.ts
@@ -34,9 +34,9 @@ function slugify(input: string): string {
   );
 }
 
-export function registerSaveConversation(server: McpServer, client: ArkeonWikiClient): void {
+export function registerSaveConversation(server: McpServer, client: ArkeonWikiClient, namePrefix = ""): void {
   server.registerTool(
-    "save_conversation",
+    `${namePrefix}save_conversation`,
     {
       title: "Save conversation",
       description: TOOL_DESCRIPTIONS.save_conversation,

--- a/packages/arkeon/src/mcp/tools/search-wiki.ts
+++ b/packages/arkeon/src/mcp/tools/search-wiki.ts
@@ -17,9 +17,9 @@ interface SearchResponse {
   };
 }
 
-export function registerSearchWiki(server: McpServer, client: ArkeonWikiClient): void {
+export function registerSearchWiki(server: McpServer, client: ArkeonWikiClient, namePrefix = ""): void {
   server.registerTool(
-    "search_wiki",
+    `${namePrefix}search_wiki`,
     {
       title: "Search wiki",
       description:

--- a/packages/arkeon/test/unit/mcp.test.ts
+++ b/packages/arkeon/test/unit/mcp.test.ts
@@ -69,7 +69,7 @@ describe("MCP server", () => {
     }
   });
 
-  it("registers 10 tools and 6 prompts", async () => {
+  it("registers 10 tools and 6 prompts (bare names when no space is bound)", async () => {
     const server = buildServer(new ArkeonWikiClient({ apiUrl: "http://localhost:1", caller: "test" }));
     // Access the internal registries — McpServer exposes them as public
     // properties for introspection.
@@ -94,6 +94,38 @@ describe("MCP server", () => {
     expect(prompts.sort()).toEqual(["ask", "capture", "fetch", "mode-router", "new-space", "save"].sort());
   });
 
+  it("namespaces tool names with the bound space (defeats Claude Desktop's name-based dedup)", async () => {
+    // When ARKEON_WIKI_SPACE is set (the standard claude_desktop_config
+    // shape), every registered tool name picks up a `<space>__` prefix.
+    // Without this, two arkeon-wiki MCP entries with different spaces
+    // both register `list_articles` — Claude Desktop's local tool
+    // registry routes a single canonical `list_articles` somewhere, and
+    // the other server's version becomes uncallable. Sanitization rule:
+    // any non-[a-zA-Z0-9] char in the space becomes `_` so `augustine-
+    // chesterton` → `augustine_chesterton__list_articles`.
+    const client = new ArkeonWikiClient({
+      apiUrl: "http://localhost:1",
+      space: "augustine-chesterton",
+      caller: "test",
+    });
+    const server = buildServer(client);
+    const tools = Object.keys((server as unknown as { _registeredTools: Record<string, unknown> })._registeredTools ?? {});
+    expect(tools.sort()).toEqual(
+      [
+        "augustine_chesterton__add_source",
+        "augustine_chesterton__capture_thought",
+        "augustine_chesterton__create_space",
+        "augustine_chesterton__daemon_status",
+        "augustine_chesterton__list_articles",
+        "augustine_chesterton__list_redlinks",
+        "augustine_chesterton__list_spaces",
+        "augustine_chesterton__read_article",
+        "augustine_chesterton__save_conversation",
+        "augustine_chesterton__search_wiki",
+      ].sort(),
+    );
+  });
+
   it("capture_thought POSTs the verbatim text body", async () => {
     stub = await startStub({
       "POST /test-space/inbox": {
@@ -111,7 +143,7 @@ describe("MCP server", () => {
       "This is the user's thought. It has\n\nmultiple paragraphs and a quote: \"do not summarize me\".";
     const handler = (server as unknown as {
       _registeredTools: Record<string, { handler: (args: unknown, extra: unknown) => Promise<unknown> }>;
-    })._registeredTools.capture_thought;
+    })._registeredTools["test_space__capture_thought"];
     await handler.handler({ title: "A thought", text: verbatim, kind: "md", space: null }, {});
 
     expect(stub.recorded).toHaveLength(1);
@@ -148,7 +180,7 @@ describe("MCP server", () => {
     const server = buildServer(client);
     const handler = (server as unknown as {
       _registeredTools: Record<string, { handler: (args: unknown, extra: unknown) => Promise<unknown> }>;
-    })._registeredTools.add_source;
+    })._registeredTools["test_space__add_source"];
     const result = (await handler.handler(
       { url: "https://example.com/paper.pdf", space: null },
       {},
@@ -187,7 +219,7 @@ describe("MCP server", () => {
     const server = buildServer(client);
     const handler = (server as unknown as {
       _registeredTools: Record<string, { handler: (args: unknown, extra: unknown) => Promise<unknown> }>;
-    })._registeredTools.add_source;
+    })._registeredTools["test_space__add_source"];
     const result = (await handler.handler(
       { url: "https://example.com/installer.exe", space: null },
       {},
@@ -223,7 +255,7 @@ describe("MCP server", () => {
     const server = buildServer(client);
     const handler = (server as unknown as {
       _registeredTools: Record<string, { handler: (args: unknown, extra: unknown) => Promise<unknown> }>;
-    })._registeredTools.search_wiki;
+    })._registeredTools["test_space__search_wiki"];
     const result = (await handler.handler({ q: "anything", limit: 10, type: null, space: null }, {})) as {
       content: Array<{ text: string }>;
     };
@@ -282,7 +314,7 @@ describe("MCP server", () => {
     const server = buildServer(client);
     const handler = (server as unknown as {
       _registeredTools: Record<string, { handler: (args: unknown, extra: unknown) => Promise<unknown> }>;
-    })._registeredTools.save_conversation;
+    })._registeredTools["test_space__save_conversation"];
     await handler.handler({ slug: "collides", transcript: "body", space: null }, {});
     // The retry loop must have made exactly two attempts: first 409,
     // second success with -2 suffix.
@@ -310,7 +342,7 @@ describe("MCP server", () => {
     const transcript = "# Title\n\n## Question\nQ?\n\n## Answer\nA — with **markdown** intact.";
     const handler = (server as unknown as {
       _registeredTools: Record<string, { handler: (args: unknown, extra: unknown) => Promise<unknown> }>;
-    })._registeredTools.save_conversation;
+    })._registeredTools["test_space__save_conversation"];
     try {
       await handler.handler({ slug: "foo", transcript, space: null }, {});
     } catch {


### PR DESCRIPTION
## Summary

Fixes a tool-routing bug where multiple `arkeon-wiki` MCP entries in `claude_desktop_config.json` (one per space) end up with most of their tools uncallable. Empirically reproduced against four daemons (iarpa, augustine, chartbook, opioid-kol) — only one server "owns" each tool name in Claude Desktop's registry; the other three appear in `tools/list` but error with "Tool not found" when the model tries to invoke them.

Each tool's registered name now picks up a `<sanitized-space>__` prefix from `ArkeonWikiClient.defaultSpace`, e.g. `augustine_chesterton__list_articles`. Per-server names are globally unique, defeating the dedup.

## Why this exists

Anthropic-managed remote MCPs use a UUID-scoped naming scheme (`mcp__<server-uuid>__<tool>`) so tool names don't collide. Local stdio MCPs don't — they're addressed by bare name. Two entries registering the same 10 names collapse to 10 callable tools total in the user's view, distributed unpredictably across servers. Verified against `~/Library/Logs/Claude/main.log` (only UUID-prefixed entries appear for remote integrations) and `~/Library/Logs/Claude/mcp-server-*.log` (all four local arkeon-wiki entries register all 10 tools cleanly via `tools/list`, but only some are routable per server in the model's view).

## What changed

- **`tools/index.ts`** — new `toolNamePrefix(space)` helper (sanitizes any non-`[a-zA-Z0-9]` char to `_`, returns empty for null/missing space). `registerAllTools` computes it once and passes to each `register*` call.
- **All 10 tool files in `tools/*.ts`** — each `registerXxx` function adds a `namePrefix = ""` parameter and uses it as a template-literal prefix on the `server.registerTool` name.
- **`test/unit/mcp.test.ts`** — new test asserting the prefix shape (`augustine-chesterton` → `augustine_chesterton__*`). Existing handler-lookup tests updated to use the prefixed key since they pass `space: "test-space"`. The "bare names when no space is bound" path is still covered.

Backwards compatible: a bare `arkeon-wiki mcp` (no `ARKEON_WIKI_SPACE` env) keeps the original bare names.

## Verified

- 522 unit tests pass (1 new).
- Live stdio probe with `ARKEON_WIKI_SPACE=augustine-chesterton` returns all 10 tools prefixed with `augustine_chesterton__`.

## Operator step after merge

```bash
cd ~/Working/arkeon/arkeon-wiki
git checkout main && git pull
npm run build -w packages/arkeon
# restart each daemon (they bundle the MCP code)
for n in iarpa augustine chartbook opioid-kol; do
  arkeon-wiki down --name "$n" && arkeon-wiki up --name "$n"
done
# Cmd+Q Claude Desktop and reopen — it respawns the MCP subprocess and
# picks up the new prefixed names. No claude_desktop_config.json change.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)