### PR TITLE
Docker quickstart fixes: :latest, arm64, worker-tag convention

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,8 +6,12 @@ name: Docker
 #   - pull_request           → build-only (no push); verifies the image
 #                              compiles before merge.
 #   - push to main           → ghcr.io/.../arkeon-wiki:main + :sha-<short>
-#   - tag arkeon-wiki-v*     → :latest + :v<version> (mirrors the npm release)
+#                              + :latest (head-of-main convention until v1)
+#   - tag arkeon-wiki-v*     → :v<version> (mirrors the npm release)
 #   - workflow_dispatch      → manual rebuild against current ref
+#
+# Images are multi-arch (linux/amd64 + linux/arm64) so Apple Silicon
+# developers can `docker compose up -d` without platform overrides.
 #
 # The image bundles the Python venv (PyMuPDF) so binary extractors work
 # without per-host bootstrap. See Dockerfile for the layer plan.
@@ -43,6 +47,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU for cross-platform builds
+        # Required for the linux/arm64 leg of the manifest on amd64 runners.
+        uses: docker/setup-qemu-action@v3
+
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
@@ -65,8 +73,8 @@ jobs:
           tags: |
             type=raw,value=main,enable={{is_default_branch}}
             type=sha,prefix=sha-,format=short,enable={{is_default_branch}}
+            type=raw,value=latest,enable={{is_default_branch}}
             type=match,pattern=arkeon-wiki-v(.+),group=1,prefix=v
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/arkeon-wiki-v') }}
             type=ref,event=pr
 
       - name: Build and push
@@ -74,7 +82,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           # PRs build-only; pushes (main + tags) publish to GHCR.
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/README.md
+++ b/README.md
@@ -10,13 +10,18 @@ Two distribution surfaces. Pick one.
 
 ```bash
 curl -O https://raw.githubusercontent.com/Arkeon-Technologies/arkeon-wiki/main/docker-compose.example.yml
-mv docker-compose.example.yml docker-compose.yml
-# edit volumes:/watch to point at your corpus, set PUID/PGID to your host UID/GID
+cp docker-compose.example.yml docker-compose.yml
+# edit volumes:/watch to point at your corpus
+# Linux: set PUID/PGID to your host `id -u` / `id -g`
+# Docker Desktop (Mac/Windows): leave the defaults — bind-mount writes
+# end up owned by your host user regardless.
 docker compose up -d
 open http://localhost:8062
 ```
 
-The image bakes PyMuPDF (PDF extraction) so it works out of the box — no host-side bootstrap. Image: `ghcr.io/arkeon-technologies/arkeon-wiki:latest`.
+The image bakes PyMuPDF (PDF extraction) so it works out of the box — no host-side bootstrap. Multi-arch (`linux/amd64` + `linux/arm64`). Image: `ghcr.io/arkeon-technologies/arkeon-wiki:latest`.
+
+Verify PDF extraction (any plain PDF works — generate one with `pandoc README.md -o test.pdf` if you don't have one handy, or use macOS Quick Look "Print → Save as PDF"). Drop it under `./corpus/`, then `curl http://localhost:8062/stats` should show the asset count tick up and a sidecar appear under `./corpus/.sidecars/`.
 
 ### npm (HTML + Markdown only)
 
@@ -40,9 +45,9 @@ Every file the watcher sees lands in the `artifacts` table keyed by its path rel
 
 The filesystem is the source of truth. SQLite is the index. Delete a file → its row goes. Edit a file → re-sync. No manual commands.
 
-## HTTP API — six commands
+## HTTP API
 
-Default base URL: `http://localhost:8000`. No auth (loopback bind). All POSTs are JSON.
+Default base URL: `http://localhost:8062` for Docker, `http://localhost:8000` for npm. No auth (loopback bind). All POSTs are JSON.
 
 ```
 POST /query        { folder?, kinds?, has_tag?[], not_tag?[], text?, limit?, offset? }
@@ -51,9 +56,18 @@ POST /untag        { path, key }
 GET  /tags?path=...
 GET  /backlinks?path=...
 GET  /redlinks?folder=...&limit=&offset=
+GET  /stats
+GET  /health       — liveness
+GET  /ready        — readiness (probes SQLite)
+GET  /llms.txt     — full API reference (also at /help)
 ```
 
-Tag conventions: `key:value` strings throughout (e.g. `status:feedback`, `processed-by:editor`). Workers query for artifacts MISSING their `processed-by:<worker-name>` tag. "No tag = unprocessed."
+Two tag-key conventions coexist:
+
+- **Worker gates** — one key per worker, e.g. `processed-by-editor`, `processed-by-writer`. Each worker queries for artifacts MISSING its own key. **Do not** collapse these into a single `processed-by` key with the worker name as value — worker A's tag would clobber worker B's.
+- **Content labels** — `key:value` strings like `status:feedback`, `topic:us-china`, where the value carries meaning across artifacts.
+
+"No tag = unprocessed" is the trigger model.
 
 `POST /query` filters are AND-composed. `has_tag` / `not_tag` entries can be `"key"` (presence) or `"key:value"` (key+value match). `text` runs FTS5 MATCH against the artifact body.
 
@@ -115,12 +129,14 @@ All state lives in `~/.arkeon-wiki/`.
 
 External harnesses do the agent loop. Each worker tick:
 
-1. `POST /query` with `not_tag: ["processed-by:<worker-name>"]` and whatever folder/has_tag filters fit the worker.
+1. `POST /query` with `not_tag: ["processed-by-<worker-name>"]` and whatever folder/has_tag filters fit the worker.
 2. Read each artifact from the filesystem.
 3. Write outputs to the filesystem (the watcher indexes them).
-4. `POST /tag` with `processed-by:<worker-name>` to mark the artifact done.
+4. `POST /tag` with `{ key: "processed-by-<worker-name>", value: <hash-or-ts> }` to mark the artifact done.
 
-New content surfaces because `syncFile` indexes new artifacts without any `processed-by` tag — the worker's next tick picks them up automatically.
+New content surfaces because `syncFile` indexes new artifacts without any `processed-by-*` tag — the worker's next tick picks them up automatically.
+
+**Tag the sidecar, not the binary.** Worker `processed-by-<name>` tags belong on the `kind='text'` sidecar (`.sidecars/<mirrored>.html`), not on the `kind='asset'` binary — asset rows are invisible to `kinds: ["text"]` queries. Use `asset.properties.sidecar_path` to find the right target.
 
 ## Development
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -19,9 +19,11 @@ services:
     ports:
       - "8062:8062"
     environment:
-      # Match the host UID/GID that owns your corpus directory. `id -u`
-      # / `id -g` on Linux; on Docker Desktop for Mac, files end up
-      # owned by your host user regardless.
+      # Linux: set to the host UID/GID that owns your corpus
+      # directory (`id -u` / `id -g`) so the watcher can write
+      # sidecars without permission surprises.
+      # Docker Desktop for Mac / Windows: bind-mount writes already
+      # land owned by your host user — leave the defaults.
       PUID: "1000"
       PGID: "1000"
     volumes:


### PR DESCRIPTION
## Summary

Three issues from a cold-start dry-run of the README's Docker quickstart, plus doc polish:

**P0 — blockers for new users**
- `:latest` never existed on GHCR. The `docker.yml` workflow only minted it on `arkeon-wiki-v*` tags (never cut). README and `docker-compose.example.yml` both referenced `:latest` → `manifest unknown` on the first command. Now also minted on every `main` push (head-of-main convention until v1 release tags exist).
- `linux/amd64`-only manifest → Apple Silicon users hit `no matching manifest for linux/arm64/v8` at `docker compose up -d`. Added `linux/arm64` to the buildx platform list plus `setup-qemu-action` for cross-build on amd64 runners.

**P1 — correctness contradiction**
- README's worker-gate example used `processed-by:<name>` (colon, name in value); llms.txt corrected this to `processed-by-<name>` (dash, name in key) in #179 but README still had the deprecated form. Because `(path, key)` is the `tags` PK, the colon form lets worker A's `processed-by:editor` tag stomp worker B's `processed-by:writer`. Swept the README to the dash form and added the "tag the sidecar, not the binary" note that was missing from the trigger pattern section.

**P2 — doc polish**
- Port confusion: clarified Docker default 8062 vs npm default 8000.
- API list missing `/stats`, `/health`, `/ready`, `/llms.txt`, `/help` — added.
- One-line "how to verify PDF extraction" hint after the quickstart so users can prove the binary-extractor pitch on their own machine.
- Unified PUID/PGID guidance between README and `docker-compose.example.yml` (was contradictory: README "set them," compose "doesn't matter on Mac").
- Fixed `mv` → `cp` in README to match the compose file's own header.

P3 latent bugs (PyMuPDF `<br>` mid-word in sidecars, `entities.label` vs `properties.label` collision, redlink `target_path` shape inconsistency) will stack on top of this branch.

## Test plan

- [ ] Wait for `Docker` workflow on this PR to succeed (build-only — proves arm64 + qemu setup compiles).
- [ ] After merge: confirm `ghcr.io/arkeon-technologies/arkeon-wiki:latest` resolves and `docker compose up -d` from the example file works clean on both Linux/amd64 and macOS/arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)