### PR TITLE
Reserve label/title meta + document /redlinks shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Two tag-key conventions coexist:
 
 `POST /query` filters are AND-composed. `has_tag` / `not_tag` entries can be `"key"` (presence) or `"key:value"` (key+value match). `text` runs FTS5 MATCH against the artifact body.
 
+`GET /redlinks` returns two shapes of `target_path`: HTML `<a class="wikilink" href="...">` resolves to an fs-relative path at extraction time (e.g. `iarpa/sources/missing.html`), while Markdown `[[X]]` keeps the literal slug (e.g. `missing-topic`) until a matching artifact lands, then auto-converges. Branch on `target_path.includes("/")` if your harness needs to distinguish "create at this path" from "create anywhere by basename."
+
 Full reference at `GET /llms.txt` or `GET /help`.
 
 ## Reader

--- a/packages/arkeon/src/server/lib/html-meta.ts
+++ b/packages/arkeon/src/server/lib/html-meta.ts
@@ -22,6 +22,11 @@ export interface ParsedHtmlMeta {
   properties: Record<string, string>;
 }
 
+// Meta names the substrate already claims as top-level artifact columns.
+// Hoisting them into `properties` would shadow the top-level field and
+// confuse any consumer that walks `artifact.properties` blindly.
+const RESERVED_META_NAMES = new Set(["label", "title"]);
+
 export function parseHtmlMeta(html: string): ParsedHtmlMeta {
   const root = parse(html);
   const titleNode = root.querySelector("title");
@@ -31,7 +36,7 @@ export function parseHtmlMeta(html: string): ParsedHtmlMeta {
   for (const meta of root.querySelectorAll("meta")) {
     const name = meta.getAttribute("name");
     const content = meta.getAttribute("content");
-    if (name && content !== undefined) {
+    if (name && content !== undefined && !RESERVED_META_NAMES.has(name)) {
       properties[name] = content;
     }
   }

--- a/packages/arkeon/src/server/lib/llms-txt.ts
+++ b/packages/arkeon/src/server/lib/llms-txt.ts
@@ -261,6 +261,26 @@ discovery loop building a work queue uses \`/redlinks\`.
 
 The work-to-be-written queue.
 
+**Two \`target_path\` shapes coexist** because the two link syntaxes
+resolve differently:
+
+  - **HTML \`<a class="wikilink" href="./missing.html">\`** — hrefs are
+    resolved relative to the source file's directory at extraction
+    time, so a redlink \`target_path\` looks like an fs-relative path
+    under the watched root (e.g. \`iarpa/sources/missing.html\`).
+  - **Markdown \`[[missing-topic]]\`** — resolved by shortest-unique-
+    basename match against the artifact index. If no match exists,
+    the row keeps the literal slug as \`target_path\` (e.g.
+    \`missing-topic\`, no slashes). Once a matching artifact lands the
+    row auto-converges to the resolved fs path on the next reconcile
+    pass — that "literal until resolved" contract is what lets the MD
+    redlink converge later without manual rewiring.
+
+Harnesses building work queues can branch on the shape:
+\`target_path.includes("/")\` ⇒ fs-relative path (suggests where to
+create the file); otherwise ⇒ MD slug (resolves by basename anywhere
+under the watched root once written).
+
 ### GET /stats
 
 \`\`\`json

--- a/packages/arkeon/src/server/lib/sync.ts
+++ b/packages/arkeon/src/server/lib/sync.ts
@@ -173,7 +173,6 @@ async function syncText(
     label =
       sidecarLbl ??
       meta.title ??
-      (meta.properties.label as string | undefined) ??
       basename(relativePath, extname(relativePath));
     propsJson = JSON.stringify(meta.properties);
     for (const l of extractHtmlLinks(content, relativePath)) {

--- a/packages/arkeon/test/unit/html-meta.test.ts
+++ b/packages/arkeon/test/unit/html-meta.test.ts
@@ -9,14 +9,14 @@ describe("parseHtmlMeta", () => {
   it("extracts <title> and <meta name>/content pairs", () => {
     const html = `<!doctype html>
 <title>Photosynthesis</title>
-<meta name="label" content="Photosynthesis">
 <meta name="short_description" content="How plants convert light.">
+<meta name="topic" content="biology">
 <body><h1>Photosynthesis</h1></body>`;
     const result = parseHtmlMeta(html);
     expect(result.title).toBe("Photosynthesis");
     expect(result.properties).toEqual({
-      label: "Photosynthesis",
       short_description: "How plants convert light.",
+      topic: "biology",
     });
   });
 
@@ -28,8 +28,24 @@ describe("parseHtmlMeta", () => {
     const html = `<title>X</title>
 <meta charset="utf-8">
 <meta http-equiv="refresh" content="30">
-<meta name="label" content="X">`;
-    expect(parseHtmlMeta(html).properties).toEqual({ label: "X" });
+<meta name="topic" content="X">`;
+    expect(parseHtmlMeta(html).properties).toEqual({ topic: "X" });
+  });
+
+  it("filters reserved meta names that would shadow top-level artifact columns", () => {
+    // <meta name="label"> and <meta name="title"> name the same keys
+    // the substrate already exposes as top-level artifact fields; if
+    // hoisted into `properties`, an artifact would carry two `label`s
+    // with different semantics.
+    const html = `<title>Real Title</title>
+<meta name="label" content="meta-label-value">
+<meta name="title" content="meta-title-value">
+<meta name="topic" content="us-china">`;
+    const result = parseHtmlMeta(html);
+    expect(result.title).toBe("Real Title");
+    expect(result.properties).toEqual({ topic: "us-china" });
+    expect(result.properties).not.toHaveProperty("label");
+    expect(result.properties).not.toHaveProperty("title");
   });
 
   it("handles apostrophes inside double-quoted content (real parser, not regex)", () => {


### PR DESCRIPTION
Two of the P3 review items from the docker-quickstart audit (#182). The third P3 (#9, PyMuPDF `<br>` mid-word) will stack on top of this branch in a follow-up PR because it needs a PDF test fixture and a Python reflow rewrite.

## #11 — label collision

Before: an HTML doc with `<meta name="label" content="X">` landed `X` in `properties.label`, while the substrate already exposes a top-level `label` column (`<title>` for HTML, basename otherwise). Same key, different semantics, on the same artifact row. A UI grabbing `artifact.label` vs `artifact.properties.label` got contradictory values.

Fix: reserve `label` and `title` in `parseHtmlMeta` so meta hoisting can't stomp keys the substrate already claims. The dead `meta.properties.label` fallback in `syncFile` (line 176) goes with it.

- No schema change, no API shape change.
- Smaller blast radius than renaming the top-level column (which would have broken every downstream npm consumer).
- `wrapHtmlDoc` still emits `<meta name="label">` for the failure stub — it's now silently filtered on read, but the sidecar's actual `label` always came from `sidecarLabel()` first, so nothing regresses. Adjacent cleanup left for later.

## #12 — `/redlinks` `target_path` two shapes

The endpoint surfaces `target_path` in two shapes depending on which link syntax produced the row:
- HTML `<a class="wikilink" href="./missing.html">` → fs-relative path (`iarpa/sources/missing.html`).
- Markdown `[[missing-topic]]` → literal slug (`missing-topic`) until a basename match lands; auto-converges via `reresolveMarkdownRedlinks` on next reconcile.

This is load-bearing behavior — the MD slug-stays-until-resolved contract is exactly what lets unresolved markdown links converge later without manual rewiring. Auto-normalizing at write time would defeat the reconciler. So: document it, don't normalize. Added the two-shapes explainer + harness branch hint (`target_path.includes("/")` discriminator) to both `llms.txt` and the README.

## #10 — closed out

Verified empirically: no `type` field is emitted on `/query` artifacts. Reviewer misread (likely confused `kind` for `type`, or saw `properties.type` from an HTML doc with `<meta name="type">`). No fix.

## Follow-ups to file (separate issues, not blockers)

- E2e regression test for both `/redlinks` shapes side-by-side (current coverage only exercises the MD-slug case at `substrate.test.ts:342-354`).
- Whether to enrich `/redlinks` with a `would_resolve_to` field if doc-only proves insufficient for harnesses.

## Test plan

- [x] `npm run typecheck -w packages/arkeon` clean
- [x] `npm test -w packages/arkeon` — 207/207 passing (`html-meta.test.ts` now asserts reserved-name filtering)
- [x] `npm run test:e2e -w packages/arkeon` — 27/27 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)