### PR TITLE
Orphan-sidecar eviction + double-prefix guard + README polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Two tag-key conventions coexist:
 
 `POST /query` filters are AND-composed. `has_tag` / `not_tag` entries can be `"key"` (presence) or `"key:value"` (key+value match). `text` runs FTS5 MATCH against the artifact body.
 
+`GET /redlinks` returns two shapes of `target_path`: HTML `<a class="wikilink" href="...">` resolves to an fs-relative path at extraction time (e.g. `iarpa/sources/missing.html`), while Markdown `[[X]]` keeps the literal slug (e.g. `missing-topic`) until a matching artifact lands, then auto-converges. Branch on `target_path.includes("/")` if your harness needs to distinguish "create at this path" from "create anywhere by basename."
+
 Full reference at `GET /llms.txt` or `GET /help`.
 
 ## Reader

--- a/README.md
+++ b/README.md
@@ -16,12 +16,16 @@ cp docker-compose.example.yml docker-compose.yml
 # Docker Desktop (Mac/Windows): leave the defaults — bind-mount writes
 # end up owned by your host user regardless.
 docker compose up -d
+# Wait for readiness (SQLite probe). 200 = ready, 503 = still warming.
+curl -s http://localhost:8062/ready
 open http://localhost:8062
 ```
 
 The image bakes PyMuPDF (PDF extraction) so it works out of the box — no host-side bootstrap. Multi-arch (`linux/amd64` + `linux/arm64`). Image: `ghcr.io/arkeon-technologies/arkeon-wiki:latest`.
 
-Verify PDF extraction (any plain PDF works — generate one with `pandoc README.md -o test.pdf` if you don't have one handy, or use macOS Quick Look "Print → Save as PDF"). Drop it under `./corpus/`, then `curl http://localhost:8062/stats` should show the asset count tick up and a sidecar appear under `./corpus/.sidecars/`.
+**Corpus directory ownership.** On Linux, the daemon writes sidecars and `.arkeon-wiki-state/` next to your files; if the corpus dir was auto-created by Docker (root-owned), `PUID`/`PGID` writes will fail. Either `chown -R $(id -u):$(id -g) ./corpus` before `up -d`, or `mkdir -p ./corpus` ahead of time so it inherits your shell's user.
+
+Verify PDF extraction with any PDF you already have — or print this README to one (macOS Preview ⌘P → "Save as PDF"; Linux: any browser's Print → PDF). Drop it under `./corpus/`, then `curl http://localhost:8062/stats` should show the asset count tick up and a sidecar appear under `./corpus/.sidecars/`.
 
 ### npm (HTML + Markdown only)
 

--- a/packages/arkeon/src/server/extractors/runner.ts
+++ b/packages/arkeon/src/server/extractors/runner.ts
@@ -250,6 +250,20 @@ async function runExtractionInner(
     }
 
     const errorMessage = err instanceof Error ? err.message : String(err);
+
+    // If the source binary vanished between the entry-point existsSync
+    // and now (transient files like wkhtmltopdf's toPdfViaTempFile*.pdf
+    // that get deleted mid-debounce), don't fabricate a stub sidecar.
+    // The watcher's unlink branch will reap the binary's row shortly;
+    // writing a stub here would leave an orphan sidecar pointing at a
+    // binary that never existed long enough to be useful.
+    if (!existsSync(absPath)) {
+      console.error(
+        `[ingest/${handler.name}] ${relativePath}: source disappeared mid-extraction (${errorMessage})`,
+      );
+      return { status: "skipped", reason: "binary disappeared during extraction" };
+    }
+
     const stubHtml = buildStubSidecar({
       binaryRelPath: relativePath,
       handlerName: handler.name,

--- a/packages/arkeon/src/server/lib/fs-watcher.ts
+++ b/packages/arkeon/src/server/lib/fs-watcher.ts
@@ -13,8 +13,8 @@
  * poll the API on whatever schedule they own.
  */
 
-import { watch, type FSWatcher, existsSync, readdirSync, openSync, readSync, closeSync, statSync } from "node:fs";
-import { join, extname, basename } from "node:path";
+import { watch, type FSWatcher, existsSync, readdirSync, openSync, readSync, closeSync, statSync, unlinkSync, rmSync } from "node:fs";
+import { join, extname, basename, dirname } from "node:path";
 
 import {
   cleanStaleStaging,
@@ -418,8 +418,64 @@ async function handleFileEvent(watchedRoot: string, relativePath: string): Promi
       if (removed) {
         console.log(`[watcher] removed: ${relativePath}`);
       }
+      // Sidecars are derived state — when the source binary is gone,
+      // its sidecar HTML and per-binary assets dir should follow. The
+      // index would otherwise carry an orphan kind='text' sidecar row
+      // pointing at a binary that no longer exists. Only cascade for
+      // ingestable binaries that produce sidecars, and skip if we ARE
+      // a sidecar (avoid recursion on .sidecars/X.html unlink).
+      if (isIngestable(relativePath) && !relativePath.startsWith(".sidecars/")) {
+        await cascadeRemoveSidecar(watchedRoot, relativePath);
+      }
     } catch (err) {
       console.error(`[watcher] Error removing ${relativePath}:`, (err as Error).message);
+    }
+  }
+}
+
+async function cascadeRemoveSidecar(
+  watchedRoot: string,
+  binaryRelPath: string,
+): Promise<void> {
+  const sidecarRelPath = `.sidecars/${binaryRelPath}.html`;
+  const sidecarAbsPath = join(watchedRoot, sidecarRelPath);
+  // .sidecars/<dirname>/<basename>.assets/ holds per-binary render output.
+  const sidecarParentRel = dirname(sidecarRelPath);
+  const assetsRelDir =
+    sidecarParentRel === "."
+      ? `${basename(binaryRelPath)}.assets`
+      : `${sidecarParentRel}/${basename(binaryRelPath)}.assets`;
+  const assetsAbsDir = join(watchedRoot, assetsRelDir);
+
+  if (existsSync(sidecarAbsPath)) {
+    try {
+      unlinkSync(sidecarAbsPath);
+    } catch {
+      // Best-effort — if the file's already gone or unwritable, the
+      // row removal below still cleans the index.
+    }
+    await removeByPath(sidecarRelPath);
+    console.log(`[watcher] cascade-removed sidecar: ${sidecarRelPath}`);
+  }
+
+  if (existsSync(assetsAbsDir)) {
+    let assetNames: string[] = [];
+    try {
+      assetNames = readdirSync(assetsAbsDir);
+    } catch {
+      assetNames = [];
+    }
+    for (const name of assetNames) {
+      try {
+        await removeByPath(`${assetsRelDir}/${name}`);
+      } catch {
+        // best-effort
+      }
+    }
+    try {
+      rmSync(assetsAbsDir, { recursive: true, force: true });
+    } catch {
+      // best-effort
     }
   }
 }

--- a/packages/arkeon/src/server/lib/html-meta.ts
+++ b/packages/arkeon/src/server/lib/html-meta.ts
@@ -22,6 +22,11 @@ export interface ParsedHtmlMeta {
   properties: Record<string, string>;
 }
 
+// Meta names the substrate already claims as top-level artifact columns.
+// Hoisting them into `properties` would shadow the top-level field and
+// confuse any consumer that walks `artifact.properties` blindly.
+const RESERVED_META_NAMES = new Set(["label", "title"]);
+
 export function parseHtmlMeta(html: string): ParsedHtmlMeta {
   const root = parse(html);
   const titleNode = root.querySelector("title");
@@ -31,7 +36,7 @@ export function parseHtmlMeta(html: string): ParsedHtmlMeta {
   for (const meta of root.querySelectorAll("meta")) {
     const name = meta.getAttribute("name");
     const content = meta.getAttribute("content");
-    if (name && content !== undefined) {
+    if (name && content !== undefined && !RESERVED_META_NAMES.has(name)) {
       properties[name] = content;
     }
   }

--- a/packages/arkeon/src/server/lib/llms-txt.ts
+++ b/packages/arkeon/src/server/lib/llms-txt.ts
@@ -261,6 +261,26 @@ discovery loop building a work queue uses \`/redlinks\`.
 
 The work-to-be-written queue.
 
+**Two \`target_path\` shapes coexist** because the two link syntaxes
+resolve differently:
+
+  - **HTML \`<a class="wikilink" href="./missing.html">\`** — hrefs are
+    resolved relative to the source file's directory at extraction
+    time, so a redlink \`target_path\` looks like an fs-relative path
+    under the watched root (e.g. \`iarpa/sources/missing.html\`).
+  - **Markdown \`[[missing-topic]]\`** — resolved by shortest-unique-
+    basename match against the artifact index. If no match exists,
+    the row keeps the literal slug as \`target_path\` (e.g.
+    \`missing-topic\`, no slashes). Once a matching artifact lands the
+    row auto-converges to the resolved fs path on the next reconcile
+    pass — that "literal until resolved" contract is what lets the MD
+    redlink converge later without manual rewiring.
+
+Harnesses building work queues can branch on the shape:
+\`target_path.includes("/")\` ⇒ fs-relative path (suggests where to
+create the file); otherwise ⇒ MD slug (resolves by basename anywhere
+under the watched root once written).
+
 ### GET /stats
 
 \`\`\`json

--- a/packages/arkeon/src/server/lib/sync.ts
+++ b/packages/arkeon/src/server/lib/sync.ts
@@ -173,7 +173,6 @@ async function syncText(
     label =
       sidecarLbl ??
       meta.title ??
-      (meta.properties.label as string | undefined) ??
       basename(relativePath, extname(relativePath));
     propsJson = JSON.stringify(meta.properties);
     for (const l of extractHtmlLinks(content, relativePath)) {

--- a/packages/arkeon/src/server/lib/sync.ts
+++ b/packages/arkeon/src/server/lib/sync.ts
@@ -272,12 +272,20 @@ async function syncAsset(
   const properties: Record<string, unknown> = {
     file_type: extname(relativePath).slice(1).toLowerCase() || "unknown",
     size_bytes: stats.size,
-    // Address of the searchable HTML sidecar a future extractor pass
-    // will produce. The convention is fixed (.sidecars/<mirrored>.html);
-    // the file may not exist yet (no handler registered, or extraction
-    // pending) — harnesses dereference and check.
-    sidecar_path: `.sidecars/${relativePath}.html`,
   };
+  // Address of the searchable HTML sidecar a future extractor pass
+  // will produce. The convention is fixed (.sidecars/<mirrored>.html);
+  // the file may not exist yet (no handler registered, or extraction
+  // pending) — harnesses dereference and check.
+  //
+  // Assets that themselves live under .sidecars/ (e.g. PDF page-render
+  // PNGs at .sidecars/X.assets/page-N.png) are terminal derived state —
+  // no further extractor pass will produce a sidecar from a sidecar's
+  // own derived files. Omit the field rather than fabricate a doubly-
+  // prefixed path (.sidecars/.sidecars/...) that points at nothing.
+  if (!relativePath.startsWith(".sidecars/")) {
+    properties.sidecar_path = `.sidecars/${relativePath}.html`;
+  }
   const propsJson = JSON.stringify(properties);
 
   if (existing) {

--- a/packages/arkeon/test/e2e/substrate.test.ts
+++ b/packages/arkeon/test/e2e/substrate.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -506,6 +506,64 @@ describe("substrate", () => {
     expect(quotes).toEqual(["first", "second"]);
     const pages = fromMulti.map((b) => b.attrs.page).sort();
     expect(pages).toEqual(["3", "7"]);
+  });
+
+  it("cascade-removes sidecar + assets when the source binary is unlinked", async () => {
+    // Regression guard: when a binary disappears, the watcher must
+    // evict its derived state — the sidecar HTML, the per-binary
+    // assets directory, and every row pointing at any of it.
+    // Otherwise /stats reports phantom sidecars and /query returns
+    // kind='text' rows for binaries that no longer exist.
+    //
+    // Simulating a full PDF extraction would need the Python venv
+    // (Docker-only). Stand in by creating the binary, its sidecar
+    // file, and one asset by hand — the cascade-on-unlink path
+    // doesn't care how the sidecar got there.
+    const binaryRel = "iarpa/sources/orphan-probe.pdf";
+    const sidecarRel = `.sidecars/${binaryRel}.html`;
+    const assetRel = `.sidecars/iarpa/sources/orphan-probe.pdf.assets/page-1.png`;
+    const binaryAbs = join(workdir, binaryRel);
+    const sidecarAbs = join(workdir, sidecarRel);
+    const assetAbs = join(workdir, assetRel);
+
+    writeFileSync(binaryAbs, "%PDF-1.4 minimal placeholder\n");
+    mkdirSync(join(workdir, ".sidecars/iarpa/sources"), { recursive: true });
+    writeFileSync(
+      sidecarAbs,
+      `<!doctype html><html><head><title>Orphan probe</title></head><body><p>extracted text</p></body></html>`,
+    );
+    mkdirSync(join(workdir, ".sidecars/iarpa/sources/orphan-probe.pdf.assets"), {
+      recursive: true,
+    });
+    writeFileSync(assetAbs, "fake png bytes");
+
+    const sql = createSql();
+    let deadline = Date.now() + 3000;
+    while (Date.now() < deadline) {
+      const rows = await sql`
+        SELECT path FROM artifacts
+        WHERE path IN (${binaryRel}, ${sidecarRel}, ${assetRel})
+      `;
+      if (rows.length === 3) break;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    unlinkSync(binaryAbs);
+
+    deadline = Date.now() + 3000;
+    let evicted = false;
+    while (Date.now() < deadline) {
+      const rows = await sql`
+        SELECT path FROM artifacts
+        WHERE path IN (${binaryRel}, ${sidecarRel}, ${assetRel})
+      `;
+      if (rows.length === 0 && !existsSync(sidecarAbs) && !existsSync(assetAbs)) {
+        evicted = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(evicted).toBe(true);
   });
 
   it("converges markdown [[X]] redlinks once the target artifact lands", async () => {

--- a/packages/arkeon/test/unit/html-meta.test.ts
+++ b/packages/arkeon/test/unit/html-meta.test.ts
@@ -9,14 +9,14 @@ describe("parseHtmlMeta", () => {
   it("extracts <title> and <meta name>/content pairs", () => {
     const html = `<!doctype html>
 <title>Photosynthesis</title>
-<meta name="label" content="Photosynthesis">
 <meta name="short_description" content="How plants convert light.">
+<meta name="topic" content="biology">
 <body><h1>Photosynthesis</h1></body>`;
     const result = parseHtmlMeta(html);
     expect(result.title).toBe("Photosynthesis");
     expect(result.properties).toEqual({
-      label: "Photosynthesis",
       short_description: "How plants convert light.",
+      topic: "biology",
     });
   });
 
@@ -28,8 +28,24 @@ describe("parseHtmlMeta", () => {
     const html = `<title>X</title>
 <meta charset="utf-8">
 <meta http-equiv="refresh" content="30">
-<meta name="label" content="X">`;
-    expect(parseHtmlMeta(html).properties).toEqual({ label: "X" });
+<meta name="topic" content="X">`;
+    expect(parseHtmlMeta(html).properties).toEqual({ topic: "X" });
+  });
+
+  it("filters reserved meta names that would shadow top-level artifact columns", () => {
+    // <meta name="label"> and <meta name="title"> name the same keys
+    // the substrate already exposes as top-level artifact fields; if
+    // hoisted into `properties`, an artifact would carry two `label`s
+    // with different semantics.
+    const html = `<title>Real Title</title>
+<meta name="label" content="meta-label-value">
+<meta name="title" content="meta-title-value">
+<meta name="topic" content="us-china">`;
+    const result = parseHtmlMeta(html);
+    expect(result.title).toBe("Real Title");
+    expect(result.properties).toEqual({ topic: "us-china" });
+    expect(result.properties).not.toHaveProperty("label");
+    expect(result.properties).not.toHaveProperty("title");
   });
 
   it("handles apostrophes inside double-quoted content (real parser, not regex)", () => {


### PR DESCRIPTION
Re-opens the changes from #185, which was auto-closed when its stacked base PR #184 merged with `--delete-branch` (the base branch `label-collision-and-redlink-docs` got deleted before `#185` could be retargeted to main — `gh pr edit --base` hit a classic-projects GraphQL bug and the retarget didn't actually happen).

The branch content (`round-2-quickstart-followups` at `e40924d`) is unchanged from #185.

---

Round-2 follow-ups from the post-#182 quickstart audit. Stacks on top of #184 (which already cleared the label-collision and /redlinks-shapes P3s).

## Real bugs

### Orphan failed-extraction sidecars

When a transient binary (e.g. wkhtmltopdf's `toPdfViaTempFile*.pdf`) disappeared between the watcher's debounce window and the extractor invocation, the runner's `catch` path wrote a stub sidecar anyway. End state: `/stats` reported phantom sidecars pointing at binaries that no longer existed; `/query {kinds:["text"]}` returned them too.

Two coupled fixes:

- **`extractors/runner.ts`** — re-check `existsSync(absPath)` inside the catch before `writeSidecarAtomic`. If the source vanished mid-run, skip the stub entirely and return `{status:"skipped", reason:"binary disappeared during extraction"}`. Closes the wkhtmltopdf race at the source.
- **`lib/fs-watcher.ts`** — on binary unlink, cascade-delete the matching `.sidecars/<rel>.html` file + `.assets/` dir and reap their rows. Sidecars are derived state — the FS-first doctrine says they follow their source. Guarded to only fire for ingestable binaries (`isIngestable(rel) && !rel.startsWith(".sidecars/")`) so bare sidecar unlinks (user-initiated re-extraction) don't recurse.

### Double `.sidecars/.sidecars/` prefix

`syncAsset` unconditionally prepended `.sidecars/` to compute `properties.sidecar_path`. For render PNGs that themselves live under `.sidecars/X.assets/`, this produced paths like `.sidecars/.sidecars/iarpa/sources/test.pdf.assets/page-1.png.html` — pointing at nothing.

Render assets are terminal derived state — no further extraction pass will produce a sidecar from a sidecar's own derived file. So: omit the field entirely for assets under `.sidecars/` rather than fabricate a doubly-prefixed dead path. One-line guard in `lib/sync.ts`.

## README polish

- Pandoc hint replaced with **Preview ⌘P → Save as PDF** (macOS) and **browser Print → PDF** (Linux). Vanilla `brew install pandoc` doesn't bundle TeX, so the original `pandoc README.md -o test.pdf` failed cold on `! LaTeX Error: File 'bookmark.sty' not found`.
- Added `curl http://localhost:8062/ready` after `docker compose up -d` so users can close the "is it warm yet?" loop without `open`-ing prematurely.
- Surfaced the Linux **corpus-directory ownership** note (auto-created root-owned dirs vs `PUID`/`PGID` writes) from the compose-file comments into the README body, since it bites users who never read the compose YAML.

## Round-1 finding still unfixed → filed as issue (no code change here)

**Redlink demand not deduped across MD/HTML target forms** — `[[chloroplast]]` (MD) creates redlink `chloroplast`, `<a class="wikilink" href="chloroplast.html">` (HTML) creates `chloroplast.html`. Creating one file resolves both, but a harness planning by demand sees two gaps. Filing separately rather than expanding this PR's scope.

## P3 README gaps → filed as issues

- Example response shapes in the HTTP API section (`.artifacts[]` vs `.results[]` discoverability).
- Expand the corpus-ownership Linux note with a copy-pasteable `chown` snippet next to the compose example.

## Test plan

- [x] `npm run typecheck -w packages/arkeon` clean
- [x] `npm test -w packages/arkeon` — 212/212 passing
- [x] `npm run test:e2e -w packages/arkeon` — 28/28 passing (added orphan-eviction regression: drops fake binary + sidecar HTML + asset on disk, unlinks binary, asserts full triple disappears from FS and DB within debounce window)
- [ ] Re-target to `main` once #184 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)