### PR TITLE
cli: substrate-API commands + CWD-walk daemon resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,11 +106,14 @@ Adding a new handler: drop a module under `src/server/extractors/<format>.ts` ex
 
 ## Commands
 
+### Daemon lifecycle
+
 ```bash
 arkeon-wiki up --watch-dir <path>   # start daemon watching <path>
 arkeon-wiki down                    # stop daemon
 arkeon-wiki status                  # is it running?
 arkeon-wiki ls                      # list running instances
+arkeon-wiki where                   # which instance owns this directory?
 arkeon-wiki logs [-f]               # tail daemon log
 arkeon-wiki start                   # foreground (for pm2/launchd/Docker)
 arkeon-wiki install                 # persistent service
@@ -118,6 +121,34 @@ arkeon-wiki uninstall               # remove service
 ```
 
 `arkeon-wiki install-deps` has been removed — binary extractor dependencies (PyMuPDF, future libreoffice/pandoc/tesseract) now ship in the Docker image only. The command stub remains so legacy scripts fail loudly with a pointer to the image.
+
+### Substrate API (one CLI command per HTTP endpoint)
+
+Every command below is a thin wrapper over the HTTP API — no SQLite direct reads, no caching. If stdout is a TTY they pretty-print; if piped they emit the raw JSON response (so `arkeon-wiki query | jq` works).
+
+```bash
+arkeon-wiki query [--folder X --kinds text --has-tag K[:V] --not-tag K --text Q ...]
+arkeon-wiki tag <path> <key>[=<value>]   # UPSERT — = and value optional
+arkeon-wiki untag <path> <key>
+arkeon-wiki tags <path>                  # list every tag on an artifact
+arkeon-wiki backlinks <path>             # inbound link rows (works for redlinks too)
+arkeon-wiki redlinks [--folder X --limit N --offset N]
+arkeon-wiki stats                        # corpus-level counts
+```
+
+Reading article bodies is *not* a CLI command — the filesystem is the read API. `cat`, `bat`, `$EDITOR` work fine; the daemon's job is the index, not the read path.
+
+### Daemon resolution
+
+Every substrate-API command picks a daemon in this order:
+
+1. `--api-url <url>`
+2. `ARKEON_WIKI_URL` env
+3. `--name <inst>` (looks up `~/.arkeon-wiki/instances/<inst>.json`)
+4. CWD walk — deepest registered `watch_dir` containing `process.cwd()` wins
+5. `default` instance
+
+Run `arkeon-wiki where` from inside a watched corpus to see which instance the CLI will hit. Exit code is `0` for success, `1` for HTTP 4xx/5xx, `2` for network errors.
 
 ## Docker image
 

--- a/packages/arkeon/src/cli/commands/api/_globals.ts
+++ b/packages/arkeon/src/cli/commands/api/_globals.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Helpers for grabbing program-level and per-command options into the
+ * shape `apiCall` expects. Centralized here so every command file
+ * doesn't repeat the same `optsWithGlobals` boilerplate.
+ */
+
+import type { Command } from "commander";
+
+import type { ApiCallOptions } from "../../lib/api-client.js";
+
+export interface GlobalCliOptions {
+  apiUrl?: string;
+  name?: string;
+  token?: string;
+  json?: boolean;
+}
+
+/**
+ * Pull `--api-url` (program-level), plus per-command `--name`,
+ * `--token`, and `--json`. Commander merges program- and
+ * command-scoped options into the same record via `optsWithGlobals`.
+ */
+export function readGlobals(command: Command): GlobalCliOptions {
+  return command.optsWithGlobals() as GlobalCliOptions;
+}
+
+/** Build the transport-layer options that `apiCall` cares about. */
+export function transportOptions(g: GlobalCliOptions): ApiCallOptions {
+  return {
+    apiUrl: g.apiUrl,
+    name: g.name,
+    token: g.token,
+  };
+}
+
+/**
+ * Attach the three flags every api command shares. Keeps the
+ * registration sites tiny:
+ *
+ *   addCommonOptions(program.command("stats"))
+ *     .description("...")
+ *     .action(...)
+ */
+export function addCommonOptions(cmd: Command): Command {
+  return cmd
+    .option(
+      "--api-url <url>",
+      "Override API base URL (highest precedence)",
+    )
+    .option(
+      "--name <name>",
+      "Target a specific named instance (overrides CWD-based resolution)",
+    )
+    .option(
+      "--token <token>",
+      "Bearer token sent as Authorization (also ARKEON_WIKI_TOKEN)",
+    )
+    .option("--json", "Emit raw JSON even when stdout is a TTY");
+}

--- a/packages/arkeon/src/cli/commands/api/backlinks.ts
+++ b/packages/arkeon/src/cli/commands/api/backlinks.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `arkeon-wiki backlinks <path>` — `GET /backlinks?path=...`.
+ *
+ * Works uniformly for resolved artifacts and unresolved redlink
+ * targets; the response's `exists` field tells you which.
+ */
+
+import type { Command } from "commander";
+
+import { apiCall } from "../../lib/api-client.js";
+import { isTty, printJson, printTable, truncate } from "../../lib/format.js";
+import {
+  addCommonOptions,
+  readGlobals,
+  transportOptions,
+} from "./_globals.js";
+
+interface BacklinksResponse {
+  path: string;
+  exists: boolean;
+  demand: number;
+  backlinks: Array<{
+    source_path: string;
+    link_text: string | null;
+    attrs: Record<string, string>;
+    synced_at: string;
+  }>;
+}
+
+export function registerBacklinksCommand(program: Command): void {
+  const cmd = addCommonOptions(
+    program
+      .command("backlinks <path>")
+      .description("Show inbound links pointing at an artifact (or redlink target)"),
+  );
+  cmd.action(async (path: string, _o: unknown, command: Command) => {
+    const g = readGlobals(command);
+    const result = await apiCall<BacklinksResponse>(
+      "GET",
+      "/backlinks",
+      { query: { path } },
+      transportOptions(g),
+    );
+    if (g.json || !isTty()) {
+      printJson(result);
+      return;
+    }
+    process.stdout.write(
+      `target:  ${result.path}\n` +
+        `exists:  ${result.exists}\n` +
+        `demand:  ${result.demand}\n\n`,
+    );
+    const rows = result.backlinks.map((b) => ({
+      SOURCE: b.source_path,
+      TEXT: truncate(b.link_text, 30),
+      QUOTE: truncate(b.attrs.quote, 50),
+      SYNCED: b.synced_at,
+    }));
+    printTable(rows);
+  });
+}

--- a/packages/arkeon/src/cli/commands/api/index.ts
+++ b/packages/arkeon/src/cli/commands/api/index.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Command } from "commander";
+
+import { registerBacklinksCommand } from "./backlinks.js";
+import { registerQueryCommand } from "./query.js";
+import { registerRedlinksCommand } from "./redlinks.js";
+import { registerStatsCommand } from "./stats.js";
+import { registerTagCommands } from "./tag.js";
+import { registerTagsCommand } from "./tags.js";
+
+/**
+ * Register the substrate-API commands on the root program:
+ * `query`, `tag`, `untag`, `tags`, `backlinks`, `redlinks`, `stats`.
+ *
+ * Each command maps 1:1 to an HTTP endpoint exposed by the daemon —
+ * no SQLite direct reads, no caching.
+ */
+export function registerApiCommands(program: Command): void {
+  registerQueryCommand(program);
+  registerTagCommands(program);
+  registerTagsCommand(program);
+  registerBacklinksCommand(program);
+  registerRedlinksCommand(program);
+  registerStatsCommand(program);
+}

--- a/packages/arkeon/src/cli/commands/api/query.ts
+++ b/packages/arkeon/src/cli/commands/api/query.ts
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `arkeon-wiki query` — `POST /query`. The workhorse: filter the
+ * artifact index by folder prefix, kind, tag presence/absence, and
+ * FTS5 match.
+ */
+
+import type { Command } from "commander";
+
+import { apiCall } from "../../lib/api-client.js";
+import { isTty, printJson, printTable, truncate } from "../../lib/format.js";
+import {
+  addCommonOptions,
+  readGlobals,
+  transportOptions,
+} from "./_globals.js";
+
+interface QueryFlags {
+  folder?: string;
+  kinds?: string[];
+  hasTag?: string[];
+  notTag?: string[];
+  text?: string;
+  orderBy?: string;
+  order?: string;
+  limit?: string;
+  offset?: string;
+}
+
+interface QueryResponse {
+  artifacts: Array<{
+    path: string;
+    kind: string;
+    label: string | null;
+    updated_at: string;
+  }>;
+  total: number;
+}
+
+const collect = (val: string, prev: string[]): string[] => prev.concat([val]);
+
+export function registerQueryCommand(program: Command): void {
+  const cmd = addCommonOptions(
+    program
+      .command("query")
+      .description("List artifacts matching the given filters")
+      .option("--folder <path>", "Restrict to artifacts under this folder prefix")
+      .option(
+        "--kinds <kinds>",
+        "Restrict by artifact kind (text or asset, repeatable or comma-separated)",
+        collect,
+        [] as string[],
+      )
+      .option(
+        "--has-tag <key[:value]>",
+        "Require this tag (repeatable)",
+        collect,
+        [] as string[],
+      )
+      .option(
+        "--not-tag <key[:value]>",
+        "Exclude artifacts with this tag (repeatable)",
+        collect,
+        [] as string[],
+      )
+      .option("--text <query>", "FTS5 match query against artifact body text")
+      .option(
+        "--order-by <column>",
+        "Sort column: updated_at | created_at | path",
+      )
+      .option("--order <dir>", "Sort direction: asc | desc")
+      .option("--limit <n>", "Result limit (max 200, default 50)")
+      .option("--offset <n>", "Result offset"),
+  );
+
+  cmd.action(async (flags: QueryFlags, command: Command) => {
+    const g = readGlobals(command);
+    const body = {
+      folder: flags.folder,
+      kinds: flags.kinds && flags.kinds.length > 0 ? flags.kinds : undefined,
+      has_tag: flags.hasTag && flags.hasTag.length > 0 ? flags.hasTag : undefined,
+      not_tag: flags.notTag && flags.notTag.length > 0 ? flags.notTag : undefined,
+      text: flags.text,
+      order_by: flags.orderBy,
+      order: flags.order,
+      limit: flags.limit != null ? Number(flags.limit) : undefined,
+      offset: flags.offset != null ? Number(flags.offset) : undefined,
+    };
+    const result = await apiCall<QueryResponse>(
+      "POST",
+      "/query",
+      { body },
+      transportOptions(g),
+    );
+
+    if (g.json || !isTty()) {
+      printJson(result);
+      return;
+    }
+    const rows = result.artifacts.map((a) => ({
+      PATH: a.path,
+      KIND: a.kind,
+      LABEL: truncate(a.label, 40),
+      UPDATED: a.updated_at,
+    }));
+    printTable(rows);
+    if (result.total > result.artifacts.length) {
+      process.stdout.write(
+        `\n(showing ${result.artifacts.length} of ${result.total} — use --limit / --offset to page)\n`,
+      );
+    }
+  });
+}

--- a/packages/arkeon/src/cli/commands/api/redlinks.ts
+++ b/packages/arkeon/src/cli/commands/api/redlinks.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `arkeon-wiki redlinks` — `GET /redlinks`. The work-to-be-written
+ * queue: unresolved link targets ranked by demand.
+ */
+
+import type { Command } from "commander";
+
+import { apiCall } from "../../lib/api-client.js";
+import { isTty, printJson, printTable, truncate } from "../../lib/format.js";
+import {
+  addCommonOptions,
+  readGlobals,
+  transportOptions,
+} from "./_globals.js";
+
+interface RedlinksResponse {
+  redlinks: Array<{
+    target_path: string;
+    demand: number;
+    linked_from: string[];
+  }>;
+  total: number;
+}
+
+export function registerRedlinksCommand(program: Command): void {
+  const cmd = addCommonOptions(
+    program
+      .command("redlinks")
+      .description("List unresolved link targets, ranked by demand")
+      .option("--folder <path>", "Restrict to redlinks under this folder prefix")
+      .option("--limit <n>", "Result limit (max 200, default 50)")
+      .option("--offset <n>", "Result offset"),
+  );
+  cmd.action(
+    async (
+      flags: { folder?: string; limit?: string; offset?: string },
+      command: Command,
+    ) => {
+      const g = readGlobals(command);
+      const result = await apiCall<RedlinksResponse>(
+        "GET",
+        "/redlinks",
+        {
+          query: {
+            folder: flags.folder,
+            limit: flags.limit,
+            offset: flags.offset,
+          },
+        },
+        transportOptions(g),
+      );
+      if (g.json || !isTty()) {
+        printJson(result);
+        return;
+      }
+      const rows = result.redlinks.map((r) => ({
+        TARGET: r.target_path,
+        DEMAND: String(r.demand),
+        FROM: truncate(r.linked_from.join(", "), 60),
+      }));
+      printTable(rows);
+      if (result.total > result.redlinks.length) {
+        process.stdout.write(
+          `\n(showing ${result.redlinks.length} of ${result.total})\n`,
+        );
+      }
+    },
+  );
+}

--- a/packages/arkeon/src/cli/commands/api/stats.ts
+++ b/packages/arkeon/src/cli/commands/api/stats.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `arkeon-wiki stats` — `GET /stats`. Corpus-level counts.
+ */
+
+import type { Command } from "commander";
+
+import { apiCall } from "../../lib/api-client.js";
+import { isTty, printJson, printKeyValue } from "../../lib/format.js";
+import {
+  addCommonOptions,
+  readGlobals,
+  transportOptions,
+} from "./_globals.js";
+
+interface StatsResponse {
+  artifacts: { total: number; text: number; asset: number };
+  links: number;
+  redlinks: number;
+  tag_keys: number;
+}
+
+export function registerStatsCommand(program: Command): void {
+  const cmd = addCommonOptions(
+    program
+      .command("stats")
+      .description("Show corpus-level counts (artifacts, links, redlinks, tag keys)"),
+  );
+  cmd.action(async (_o: unknown, command: Command) => {
+    const g = readGlobals(command);
+    const result = await apiCall<StatsResponse>(
+      "GET",
+      "/stats",
+      {},
+      transportOptions(g),
+    );
+    if (g.json || !isTty()) {
+      printJson(result);
+      return;
+    }
+    printKeyValue([
+      ["artifacts.total", String(result.artifacts.total)],
+      ["artifacts.text", String(result.artifacts.text)],
+      ["artifacts.asset", String(result.artifacts.asset)],
+      ["links", String(result.links)],
+      ["redlinks", String(result.redlinks)],
+      ["tag_keys", String(result.tag_keys)],
+    ]);
+  });
+}

--- a/packages/arkeon/src/cli/commands/api/tag.ts
+++ b/packages/arkeon/src/cli/commands/api/tag.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `arkeon-wiki tag <path> <key>[=<value>]` — `POST /tag` (UPSERT).
+ * `arkeon-wiki untag <path> <key>`           — `POST /untag`.
+ *
+ * The `=value` form mirrors `KEY=VALUE` shell conventions; the
+ * key-only form lets workers drop "presence" tags with empty value.
+ */
+
+import type { Command } from "commander";
+
+import { apiCall } from "../../lib/api-client.js";
+import { isTty, printJson, printKeyValue } from "../../lib/format.js";
+import {
+  addCommonOptions,
+  readGlobals,
+  transportOptions,
+} from "./_globals.js";
+
+interface TagResponse {
+  ok: true;
+  path: string;
+  key: string;
+  value: string;
+  previous_value: string | null;
+  action: "created" | "updated" | "unchanged";
+}
+
+interface UntagResponse {
+  ok: true;
+  path: string;
+  key: string;
+  existed: boolean;
+}
+
+/** Split `key=value` (only on the *first* `=` so values may contain `=`). */
+function splitKeyValue(spec: string): { key: string; value: string } {
+  const idx = spec.indexOf("=");
+  if (idx === -1) return { key: spec, value: "" };
+  return { key: spec.slice(0, idx), value: spec.slice(idx + 1) };
+}
+
+export function registerTagCommands(program: Command): void {
+  const tagCmd = addCommonOptions(
+    program
+      .command("tag <path> <keyValue>")
+      .description("Upsert a tag on an artifact (key[=value])"),
+  );
+  tagCmd.action(async (path: string, keyValue: string, _o: unknown, command: Command) => {
+    const { key, value } = splitKeyValue(keyValue);
+    if (!key) {
+      process.stderr.write(`arkeon-wiki: tag key cannot be empty\n`);
+      process.exit(1);
+    }
+    const g = readGlobals(command);
+    const result = await apiCall<TagResponse>(
+      "POST",
+      "/tag",
+      { body: { path, key, value } },
+      transportOptions(g),
+    );
+    if (g.json || !isTty()) {
+      printJson(result);
+      return;
+    }
+    printKeyValue([
+      ["path", result.path],
+      ["key", result.key],
+      ["value", result.value || "(empty)"],
+      ["action", result.action],
+      ["previous_value", result.previous_value ?? "(none)"],
+    ]);
+  });
+
+  const untagCmd = addCommonOptions(
+    program
+      .command("untag <path> <key>")
+      .description("Remove a tag from an artifact (no-op if absent)"),
+  );
+  untagCmd.action(async (path: string, key: string, _o: unknown, command: Command) => {
+    if (!key) {
+      process.stderr.write(`arkeon-wiki: tag key cannot be empty\n`);
+      process.exit(1);
+    }
+    const g = readGlobals(command);
+    const result = await apiCall<UntagResponse>(
+      "POST",
+      "/untag",
+      { body: { path, key } },
+      transportOptions(g),
+    );
+    if (g.json || !isTty()) {
+      printJson(result);
+      return;
+    }
+    printKeyValue([
+      ["path", result.path],
+      ["key", result.key],
+      ["action", result.existed ? "removed" : "no-op (tag was not set)"],
+    ]);
+  });
+}

--- a/packages/arkeon/src/cli/commands/api/tags.ts
+++ b/packages/arkeon/src/cli/commands/api/tags.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `arkeon-wiki tags <path>` — `GET /tags?path=...`.
+ */
+
+import type { Command } from "commander";
+
+import { apiCall } from "../../lib/api-client.js";
+import { isTty, printJson, printKeyValue } from "../../lib/format.js";
+import {
+  addCommonOptions,
+  readGlobals,
+  transportOptions,
+} from "./_globals.js";
+
+interface TagsResponse {
+  path: string;
+  tags: Record<string, string>;
+}
+
+export function registerTagsCommand(program: Command): void {
+  const cmd = addCommonOptions(
+    program
+      .command("tags <path>")
+      .description("Show all tags on an artifact"),
+  );
+  cmd.action(async (path: string, _o: unknown, command: Command) => {
+    const g = readGlobals(command);
+    const result = await apiCall<TagsResponse>(
+      "GET",
+      "/tags",
+      { query: { path } },
+      transportOptions(g),
+    );
+    if (g.json || !isTty()) {
+      printJson(result);
+      return;
+    }
+    const entries = Object.entries(result.tags).sort(([a], [b]) =>
+      a.localeCompare(b),
+    );
+    printKeyValue(entries.map(([k, v]) => [k, v || "(empty)"]));
+  });
+}

--- a/packages/arkeon/src/cli/commands/local/index.ts
+++ b/packages/arkeon/src/cli/commands/local/index.ts
@@ -13,6 +13,7 @@ import { registerStatusCommand } from "./status.js";
 import { registerStopCommand } from "./stop.js";
 import { registerUninstallCommand } from "./uninstall.js";
 import { registerUpCommand } from "./up.js";
+import { registerWhereCommand } from "./where.js";
 
 export function registerLocalCommands(program: Command): void {
   registerUpCommand(program);
@@ -22,6 +23,7 @@ export function registerLocalCommands(program: Command): void {
   registerStatusCommand(program);
   registerLsCommand(program);
   registerLogsCommand(program);
+  registerWhereCommand(program);
   registerInstallCommand(program);
   registerInstallDepsCommand(program);
   registerUninstallCommand(program);

--- a/packages/arkeon/src/cli/commands/local/start.ts
+++ b/packages/arkeon/src/cli/commands/local/start.ts
@@ -13,7 +13,9 @@
  */
 
 import type { Command } from "commander";
+import { realpathSync } from "node:fs";
 import { platform } from "node:os";
+import { resolve } from "node:path";
 
 const IS_WIN = platform() === "win32";
 
@@ -66,8 +68,14 @@ async function runStart(options: StartOptions): Promise<void> {
     options.port ?? named?.port ?? process.env.PORT ?? DEFAULT_API_PORT,
   );
   const instanceName = options.name ?? DEFAULT_INSTANCE_NAME;
-  const watchedRoot =
-    options.watchDir ?? process.env.ARKEON_WIKI_WATCH_DIR ?? process.cwd();
+  // Resolve + realpath so the registry stores the canonical absolute
+  // path. macOS aliases `/var` → `/private/var` and `/tmp` → `/private/tmp`,
+  // so a watched root specified as `/var/folders/...` won't string-match
+  // a `process.cwd()` of `/private/var/folders/...`. Canonicalize both
+  // sides (here, plus in instance-resolve) and the comparison just works.
+  const watchedRoot = canonicalize(
+    options.watchDir ?? process.env.ARKEON_WIKI_WATCH_DIR ?? process.cwd(),
+  );
 
   const existingPid = readPidfile();
   if (existingPid && isProcessAlive(existingPid)) {
@@ -157,6 +165,7 @@ async function runStart(options: StartOptions): Promise<void> {
     api_url: `http://localhost:${apiPort}`,
     api_port: apiPort,
     home: arkeonDir(),
+    watch_dir: watchedRoot,
     pid: process.pid,
     started_at: new Date().toISOString(),
   });
@@ -167,4 +176,19 @@ async function runStart(options: StartOptions): Promise<void> {
   console.log(`              Health: http://localhost:${apiPort}/health`);
   console.log("");
   console.log("              Press Ctrl+C to stop.");
+}
+
+/**
+ * Resolve `p` to an absolute path, then chase symlinks to its canonical
+ * form. Falls back to plain resolve() if the path doesn't exist yet —
+ * realpath throws ENOENT and we'd rather index a not-yet-created
+ * directory than abort startup.
+ */
+function canonicalize(p: string): string {
+  const abs = resolve(p);
+  try {
+    return realpathSync(abs);
+  } catch {
+    return abs;
+  }
 }

--- a/packages/arkeon/src/cli/commands/local/where.ts
+++ b/packages/arkeon/src/cli/commands/local/where.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `arkeon-wiki where` — print which running instance owns the current
+ * working directory, along with the CWD-relative path inside its
+ * watched root.
+ *
+ * Mirrors `git rev-parse --show-toplevel` / `git rev-parse --show-prefix`
+ * — a small introspection command so users can sanity-check what every
+ * other api-CLI command (`query`, `tag`, ...) will end up talking to.
+ *
+ * Exit codes:
+ *   0  CWD is under a registered watch root
+ *   1  no instance owns CWD (no daemon running, or CWD is outside)
+ */
+
+import type { Command } from "commander";
+
+import {
+  findInstanceForCwd,
+  relativeToWatchDir,
+} from "../../lib/instance-resolve.js";
+import { listInstances } from "../../lib/instances.js";
+import { output } from "../../lib/output.js";
+
+interface WhereOptions {
+  json?: boolean;
+}
+
+export function registerWhereCommand(program: Command): void {
+  program
+    .command("where")
+    .description(
+      "Show which running instance owns the current directory (watch root + relative path)",
+    )
+    .option("--json", "Emit JSON instead of a human-readable summary")
+    .action((options: WhereOptions) => {
+      const cwd = process.cwd();
+      const instances = listInstances();
+      const owner = findInstanceForCwd(cwd, instances);
+
+      if (!owner) {
+        if (options.json) {
+          output.error(
+            new Error(
+              `No running instance watches a directory containing ${cwd}.`,
+            ),
+            { operation: "where", code: "no_owner" },
+          );
+        } else {
+          process.stderr.write(
+            `No running instance watches a directory containing ${cwd}.\n` +
+              `  - Run \`arkeon-wiki ls\` to see what's running.\n` +
+              `  - Start one with \`arkeon-wiki up --watch-dir <path>\`.\n`,
+          );
+        }
+        process.exit(1);
+      }
+
+      // findInstanceForCwd guarantees watch_dir is set, so this is non-null.
+      const rel = relativeToWatchDir(cwd, owner) ?? "";
+
+      if (options.json) {
+        output.result({
+          operation: "where",
+          instance: owner.name,
+          api_url: owner.api_url,
+          watch_dir: owner.watch_dir,
+          cwd,
+          relative: rel,
+        });
+        return;
+      }
+
+      process.stdout.write(
+        `instance:  ${owner.name}\n` +
+          `api_url:   ${owner.api_url}\n` +
+          `watch_dir: ${owner.watch_dir}\n` +
+          `cwd:       ${cwd}\n` +
+          `relative:  ${rel === "" ? "." : rel}\n`,
+      );
+    });
+}

--- a/packages/arkeon/src/cli/lib/api-client.ts
+++ b/packages/arkeon/src/cli/lib/api-client.ts
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared HTTP client for the api-CLI commands (`query`, `tag`, ...).
+ *
+ * Every command does the same thing: resolve which daemon to hit,
+ * issue a JSON request, exit with a useful code on failure. This
+ * module owns that whole flow so the command files stay tiny.
+ *
+ * Exit codes (set on the returned process when `exitOnError` is true,
+ * which is the default for command-line use):
+ *   0  success
+ *   1  the API responded with a 4xx/5xx — error payload printed to stderr
+ *   2  network error reaching the daemon (daemon down, wrong port, etc.)
+ */
+
+import { resolveTarget, type ResolveOptions } from "./instance-resolve.js";
+
+export interface ApiCallOptions extends ResolveOptions {
+  /** Override `Authorization: Bearer <token>`. Falls back to ARKEON_WIKI_TOKEN. */
+  token?: string;
+  /** When false, throws instead of calling process.exit. Used by tests. */
+  exitOnError?: boolean;
+}
+
+/**
+ * Build a URL from base + path + optional query params. Tolerates
+ * trailing slashes on base and missing leading slashes on path so
+ * callers don't need to worry. `null`/`undefined` query values are
+ * dropped — `apiCall` callers pass the flag object straight through.
+ *
+ * Exported for unit testing.
+ */
+export function buildUrl(
+  base: string,
+  path: string,
+  query?: Record<string, string | number | undefined | null>,
+): string {
+  const trimmedBase = base.endsWith("/") ? base.slice(0, -1) : base;
+  const trimmedPath = path.startsWith("/") ? path : `/${path}`;
+  const url = new URL(`${trimmedBase}${trimmedPath}`);
+  if (query) {
+    for (const [k, v] of Object.entries(query)) {
+      if (v == null) continue;
+      url.searchParams.set(k, String(v));
+    }
+  }
+  return url.toString();
+}
+
+/**
+ * Resolve the bearer token. `--token` (`opts.token`) wins; falls back
+ * to `ARKEON_WIKI_TOKEN` from `opts.env` (defaults to `process.env`).
+ * Returns an empty header map when no token is set.
+ *
+ * Exported for unit testing.
+ */
+export function authHeader(opts: ApiCallOptions): Record<string, string> {
+  const token = opts.token ?? (opts.env ?? process.env).ARKEON_WIKI_TOKEN;
+  return token ? { authorization: `Bearer ${token}` } : {};
+}
+
+/**
+ * Strip `undefined` and `null` from a JSON request body so callers can
+ * forward raw flag objects — an absent `--limit` becomes a missing
+ * field rather than a literal `null`. Returns `undefined` when no body
+ * was given so GET requests don't send a `Content-Type` header.
+ *
+ * Exported for unit testing.
+ */
+export function cleanRequestBody(body: Record<string, unknown> | undefined): string | undefined {
+  if (body === undefined) return undefined;
+  const filtered: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(body)) {
+    if (v === undefined || v === null) continue;
+    filtered[k] = v;
+  }
+  return JSON.stringify(filtered);
+}
+
+/**
+ * Issue a JSON request against the resolved daemon.
+ *
+ * Strips `undefined` and `null` from JSON bodies so callers can pass
+ * the raw flag object without filtering — `--limit` left off becomes
+ * an absent field rather than `null`.
+ */
+export async function apiCall<T = unknown>(
+  method: "GET" | "POST",
+  path: string,
+  args: {
+    body?: Record<string, unknown>;
+    query?: Record<string, string | number | undefined | null>;
+  } = {},
+  opts: ApiCallOptions = {},
+): Promise<T> {
+  const exitOnError = opts.exitOnError !== false;
+  let target;
+  try {
+    target = resolveTarget(opts);
+  } catch (err) {
+    return failResolve(err as Error, exitOnError);
+  }
+
+  const url = buildUrl(target.api_url, path, args.query);
+  const body = cleanRequestBody(args.body);
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method,
+      headers: {
+        ...(body ? { "content-type": "application/json" } : {}),
+        ...authHeader(opts),
+      },
+      body,
+    });
+  } catch (err) {
+    return failNetwork(url, err as Error, exitOnError);
+  }
+
+  if (!res.ok) {
+    return failHttp(url, res, exitOnError);
+  }
+
+  // The substrate always returns JSON. If something else comes back,
+  // surface that loudly rather than guess.
+  const contentType = res.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) {
+    return failNetwork(
+      url,
+      new Error(
+        `Expected JSON response, got content-type=${contentType || "<empty>"}`,
+      ),
+      exitOnError,
+    );
+  }
+  return (await res.json()) as T;
+}
+
+function failResolve(err: Error, exitOnError: boolean): never {
+  if (!exitOnError) throw err;
+  process.stderr.write(`arkeon-wiki: ${err.message}\n`);
+  process.exit(2);
+}
+
+function failNetwork(url: string, err: Error, exitOnError: boolean): never {
+  const msg = `arkeon-wiki: cannot reach ${url}: ${err.message}`;
+  if (!exitOnError) throw new Error(msg);
+  process.stderr.write(`${msg}\n`);
+  process.exit(2);
+}
+
+async function failHttp(url: string, res: Response, exitOnError: boolean): Promise<never> {
+  let bodyText: string;
+  try {
+    bodyText = await res.text();
+  } catch {
+    bodyText = "";
+  }
+  const msg = `arkeon-wiki: ${url} → HTTP ${res.status} ${res.statusText}${bodyText ? `\n${bodyText}` : ""}`;
+  if (!exitOnError) throw new Error(msg);
+  process.stderr.write(`${msg}\n`);
+  process.exit(1);
+}

--- a/packages/arkeon/src/cli/lib/format.ts
+++ b/packages/arkeon/src/cli/lib/format.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Output helpers for the api-CLI commands.
+ *
+ * The contract: if stdout is a TTY, pretty-print. If it's piped or
+ * redirected (`| jq`, `> out.json`), emit the full JSON response so
+ * scripts get the same payload the daemon returned. Matches the
+ * convention used by `git log`, `ls`, `gh`, etc.
+ */
+
+export function isTty(): boolean {
+  return Boolean(process.stdout.isTTY);
+}
+
+/**
+ * Emit `value` as pretty-printed JSON followed by a newline. Use this
+ * for piped output and `--json` flags.
+ */
+export function printJson(value: unknown): void {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+/**
+ * Render an array of records as a left-aligned, two-space-padded
+ * table. Column order is taken from the first row's key order
+ * (insertion order), which the command files set deliberately.
+ *
+ * Empty rows render as "(none)" so a TTY user never sees a silently
+ * blank table.
+ */
+export function printTable(rows: Record<string, string>[]): void {
+  if (rows.length === 0) {
+    process.stdout.write("(none)\n");
+    return;
+  }
+  const headers = Object.keys(rows[0]!);
+  const widths = headers.map((h) =>
+    Math.max(h.length, ...rows.map((r) => (r[h] ?? "").length)),
+  );
+  const fmt = (cells: string[]) =>
+    cells.map((c, i) => c.padEnd(widths[i]!)).join("  ");
+  process.stdout.write(`${fmt(headers)}\n`);
+  for (const row of rows) {
+    process.stdout.write(`${fmt(headers.map((h) => row[h] ?? ""))}\n`);
+  }
+}
+
+/**
+ * Two-column key/value layout for scalar-flavored responses
+ * (`stats`, `tag`, ...). Keys are right-padded to the longest key
+ * length so colons align.
+ */
+export function printKeyValue(pairs: Array<[string, string]>): void {
+  if (pairs.length === 0) {
+    process.stdout.write("(none)\n");
+    return;
+  }
+  const width = Math.max(...pairs.map(([k]) => k.length));
+  for (const [k, v] of pairs) {
+    process.stdout.write(`${k.padEnd(width)}  ${v}\n`);
+  }
+}
+
+/**
+ * Truncate `s` to `n` characters, appending an ellipsis when cut. Used
+ * for table columns that would otherwise wrap to absurd widths on
+ * narrow terminals (long quoted citations, etc.).
+ */
+export function truncate(s: string | null | undefined, n: number): string {
+  if (s == null) return "";
+  if (s.length <= n) return s;
+  return `${s.slice(0, n - 1)}…`;
+}

--- a/packages/arkeon/src/cli/lib/instance-resolve.ts
+++ b/packages/arkeon/src/cli/lib/instance-resolve.ts
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Resolve which arkeon-wiki daemon a CLI command should talk to.
+ *
+ * The CLI is run from many places: inside a watched corpus, outside
+ * one, with explicit `--api-url` overrides, etc. This module is the
+ * single source of truth for "given the user's flags, env, and CWD,
+ * what daemon do we hit?"
+ *
+ * Lookup is read-only — it consults the on-disk registry written by
+ * `start.ts` and never spawns or contacts the daemon.
+ */
+
+import { realpathSync } from "node:fs";
+import { relative, resolve, sep } from "node:path";
+
+import {
+  DEFAULT_INSTANCE_NAME,
+  findInstance,
+  type Instance,
+  listInstances,
+} from "./instances.js";
+
+/**
+ * Resolve `p` to an absolute path, then chase symlinks. Required for
+ * macOS, where `/var` is a symlink to `/private/var` and `/tmp` to
+ * `/private/tmp` — a watch_dir like `/var/folders/.../corpus` won't
+ * string-match `process.cwd()` of `/private/var/folders/.../corpus`
+ * without this step. Falls back to plain resolve() when the path
+ * doesn't exist (test fixtures, deleted dirs).
+ */
+function canonicalize(p: string): string {
+  const abs = resolve(p);
+  try {
+    return realpathSync(abs);
+  } catch {
+    return abs;
+  }
+}
+
+export interface ResolveOptions {
+  /** From `--api-url` flag. */
+  apiUrl?: string;
+  /** From `--name` flag. */
+  name?: string;
+  /** Defaults to process.cwd(). Carved out for unit testability. */
+  cwd?: string;
+  /** Defaults to process.env. Carved out for unit testability. */
+  env?: Record<string, string | undefined>;
+}
+
+export type ResolveSource =
+  | "api_url_flag"
+  | "env"
+  | "name_flag"
+  | "cwd_walk"
+  | "default";
+
+export interface ResolvedTarget {
+  api_url: string;
+  source: ResolveSource;
+  /**
+   * The registered instance backing the target — populated for every
+   * source except `api_url_flag` and `env`, where the CLI has no idea
+   * what instance (if any) is on the other end of the URL.
+   */
+  instance?: Instance;
+}
+
+/**
+ * Precedence (first hit wins):
+ *   1. --api-url <url>
+ *   2. ARKEON_WIKI_URL env
+ *   3. --name <name>
+ *   4. CWD walk against registered watch_dirs (deepest match wins)
+ *   5. instance named "default"
+ *
+ * Throws with an actionable error if nothing matches.
+ */
+export function resolveTarget(opts: ResolveOptions = {}): ResolvedTarget {
+  const env = opts.env ?? process.env;
+  const cwd = opts.cwd ?? process.cwd();
+
+  if (opts.apiUrl) {
+    return { api_url: opts.apiUrl, source: "api_url_flag" };
+  }
+  if (env.ARKEON_WIKI_URL) {
+    return { api_url: env.ARKEON_WIKI_URL, source: "env" };
+  }
+  if (opts.name) {
+    const inst = findInstance(opts.name);
+    if (!inst) {
+      throw new Error(
+        `No running instance named "${opts.name}". Run \`arkeon-wiki ls\` to see what's running.`,
+      );
+    }
+    return { api_url: inst.api_url, source: "name_flag", instance: inst };
+  }
+  const owner = findInstanceForCwd(cwd, listInstances());
+  if (owner) {
+    return { api_url: owner.api_url, source: "cwd_walk", instance: owner };
+  }
+  const fallback = findInstance(DEFAULT_INSTANCE_NAME);
+  if (fallback) {
+    return { api_url: fallback.api_url, source: "default", instance: fallback };
+  }
+  throw new Error(
+    `No arkeon-wiki daemon is running, and CWD (${cwd}) is not under any registered watch root. ` +
+      `Start one with \`arkeon-wiki up --watch-dir <path>\`, or pass --api-url / --name explicitly.`,
+  );
+}
+
+/**
+ * Pick the instance whose watch_dir contains `cwd`. When multiple
+ * instances overlap (a watched root nested inside another), the
+ * deepest match wins — that's the answer a user would intuitively
+ * expect when standing inside the inner corpus.
+ *
+ * Instances missing `watch_dir` (registered before that field
+ * existed) are skipped silently.
+ */
+export function findInstanceForCwd(cwd: string, instances: Instance[]): Instance | null {
+  const cwdAbs = canonicalize(cwd);
+  let best: Instance | null = null;
+  let bestLen = -1;
+  for (const inst of instances) {
+    if (!inst.watch_dir) continue;
+    const watchAbs = canonicalize(inst.watch_dir);
+    if (isUnder(cwdAbs, watchAbs) && watchAbs.length > bestLen) {
+      best = inst;
+      bestLen = watchAbs.length;
+    }
+  }
+  return best;
+}
+
+/**
+ * Compute the watch-root-relative path of `cwd` under an instance's
+ * watch_dir. Returns "" when CWD *is* the watch root, and `null` when
+ * the instance has no watch_dir or CWD escapes it (defensive — callers
+ * should only call this with an instance returned by `findInstanceForCwd`).
+ */
+export function relativeToWatchDir(cwd: string, instance: Instance): string | null {
+  if (!instance.watch_dir) return null;
+  const rel = relative(canonicalize(instance.watch_dir), canonicalize(cwd));
+  if (rel.startsWith("..")) return null;
+  return rel;
+}
+
+/** True if `child` equals `parent` or sits beneath it. */
+function isUnder(child: string, parent: string): boolean {
+  if (child === parent) return true;
+  const withSep = parent.endsWith(sep) ? parent : parent + sep;
+  return child.startsWith(withSep);
+}

--- a/packages/arkeon/src/cli/lib/instances.ts
+++ b/packages/arkeon/src/cli/lib/instances.ts
@@ -24,6 +24,13 @@ export interface Instance {
   api_url: string;
   api_port: number;
   home: string;
+  /**
+   * Absolute path the daemon is watching. Stored so the CLI can resolve
+   * which instance owns the current working directory without spinning
+   * up the daemon to ask. May be absent on instances registered before
+   * this field existed — readers should treat it as optional.
+   */
+  watch_dir?: string;
   pid: number;
   started_at: string;
 }

--- a/packages/arkeon/src/index.ts
+++ b/packages/arkeon/src/index.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 
 import { Command } from "commander";
 
+import { registerApiCommands } from "./cli/commands/api/index.js";
 import { registerLocalCommands } from "./cli/commands/local/index.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -18,25 +19,24 @@ program
   .name("arkeon-wiki")
   .description("Filesystem-first knowledge graph")
   .version(pkg.version)
-  .option("--api-url <url>", "Override API base URL")
   .option(
     "--data-dir <path>",
     "Root directory for Arkeon state (overrides ARKEON_WIKI_HOME)",
   );
 
 program.hook("preAction", (command) => {
-  const options = command.optsWithGlobals() as {
-    apiUrl?: string;
-    dataDir?: string;
-  };
-  if (options.apiUrl) {
-    process.env.ARKE_API_URL = options.apiUrl;
-  }
+  const options = command.optsWithGlobals() as { dataDir?: string };
   if (options.dataDir) {
     process.env.ARKEON_WIKI_HOME = options.dataDir;
   }
+  // `--api-url` is declared on each substrate-API command (via
+  // `addCommonOptions`) rather than at the program level so users can
+  // write `arkeon-wiki query --api-url X` — commander's program-level
+  // options must appear before the subcommand, which is a surprising
+  // failure mode worth avoiding.
 });
 
 registerLocalCommands(program);
+registerApiCommands(program);
 
 program.parse();

--- a/packages/arkeon/test/unit/api-client.test.ts
+++ b/packages/arkeon/test/unit/api-client.test.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pure-function tests for the api-client helpers. The network /
+ * exit-code paths through `apiCall` are exercised end-to-end via the
+ * substrate e2e suite and manual smoke; here we just nail down the
+ * small composable pieces.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  authHeader,
+  buildUrl,
+  cleanRequestBody,
+} from "../../src/cli/lib/api-client.js";
+
+describe("buildUrl", () => {
+  it("joins base and path with no surprises", () => {
+    expect(buildUrl("http://localhost:8062", "/query")).toBe(
+      "http://localhost:8062/query",
+    );
+  });
+
+  it("tolerates a trailing slash on the base", () => {
+    expect(buildUrl("http://localhost:8062/", "/query")).toBe(
+      "http://localhost:8062/query",
+    );
+  });
+
+  it("tolerates a missing leading slash on the path", () => {
+    expect(buildUrl("http://localhost:8062", "query")).toBe(
+      "http://localhost:8062/query",
+    );
+  });
+
+  it("attaches query params and URL-encodes them", () => {
+    const url = buildUrl("http://localhost:8062", "/tags", {
+      path: "iarpa/article with spaces.html",
+    });
+    // URL serializes spaces as `+` in query strings (form-encoding).
+    expect(url).toBe(
+      "http://localhost:8062/tags?path=iarpa%2Farticle+with+spaces.html",
+    );
+  });
+
+  it("drops null and undefined query params (treats them as 'unset')", () => {
+    const url = buildUrl("http://localhost:8062", "/redlinks", {
+      folder: "iarpa",
+      limit: undefined,
+      offset: null,
+    });
+    expect(url).toBe("http://localhost:8062/redlinks?folder=iarpa");
+  });
+
+  it("coerces numeric query params to strings", () => {
+    expect(buildUrl("http://x", "/y", { limit: 50 })).toBe(
+      "http://x/y?limit=50",
+    );
+  });
+});
+
+describe("authHeader", () => {
+  it("emits no header when no token is configured", () => {
+    expect(authHeader({ env: {} })).toEqual({});
+  });
+
+  it("prefers an explicit --token over the env var", () => {
+    expect(
+      authHeader({ token: "flag-token", env: { ARKEON_WIKI_TOKEN: "env-token" } }),
+    ).toEqual({ authorization: "Bearer flag-token" });
+  });
+
+  it("falls back to ARKEON_WIKI_TOKEN from the injected env", () => {
+    expect(authHeader({ env: { ARKEON_WIKI_TOKEN: "env-token" } })).toEqual({
+      authorization: "Bearer env-token",
+    });
+  });
+});
+
+describe("cleanRequestBody", () => {
+  it("returns undefined when no body is supplied (GET requests)", () => {
+    expect(cleanRequestBody(undefined)).toBeUndefined();
+  });
+
+  it("strips undefined fields (skipped optional flags)", () => {
+    const out = cleanRequestBody({ folder: "iarpa", limit: undefined });
+    expect(JSON.parse(out!)).toEqual({ folder: "iarpa" });
+  });
+
+  it("strips null fields", () => {
+    const out = cleanRequestBody({ folder: "iarpa", limit: null });
+    expect(JSON.parse(out!)).toEqual({ folder: "iarpa" });
+  });
+
+  it("preserves false, 0, and empty strings — only null/undefined drop", () => {
+    const out = cleanRequestBody({
+      flag: false,
+      count: 0,
+      empty: "",
+      missing: undefined,
+    });
+    expect(JSON.parse(out!)).toEqual({ flag: false, count: 0, empty: "" });
+  });
+
+  it("preserves arrays (has_tag, not_tag, kinds)", () => {
+    const out = cleanRequestBody({ has_tag: ["status:reviewed", "topic:x"] });
+    expect(JSON.parse(out!)).toEqual({
+      has_tag: ["status:reviewed", "topic:x"],
+    });
+  });
+
+  it("returns '{}' for a body containing only undefined/null", () => {
+    expect(cleanRequestBody({ a: undefined, b: null })).toBe("{}");
+  });
+});

--- a/packages/arkeon/test/unit/instance-resolve.test.ts
+++ b/packages/arkeon/test/unit/instance-resolve.test.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pure-logic tests for the CWD-walk resolver. The filesystem-touching
+ * paths (registry lookups for --name / fallback) are covered indirectly
+ * by the e2e suite — here we exercise the resolution rules where the
+ * candidate `instances` array is passed in directly.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  findInstanceForCwd,
+  relativeToWatchDir,
+  resolveTarget,
+} from "../../src/cli/lib/instance-resolve.js";
+import type { Instance } from "../../src/cli/lib/instances.js";
+
+function instance(name: string, watch_dir: string | undefined): Instance {
+  return {
+    name,
+    api_url: `http://localhost:80${name.length.toString().padStart(2, "0")}`,
+    api_port: 8000 + name.length,
+    home: `/home/.arkeon-wiki/${name}`,
+    watch_dir,
+    pid: 1234,
+    started_at: "2026-06-03T00:00:00.000Z",
+  };
+}
+
+describe("findInstanceForCwd", () => {
+  it("returns null when no instances are registered", () => {
+    expect(findInstanceForCwd("/Users/me/work/corpus", [])).toBeNull();
+  });
+
+  it("returns null when CWD is not under any instance's watch_dir", () => {
+    const insts = [instance("a", "/Users/me/work/corpus-a")];
+    expect(findInstanceForCwd("/Users/me/other", insts)).toBeNull();
+  });
+
+  it("matches when CWD equals the watch_dir exactly", () => {
+    const insts = [instance("a", "/Users/me/corpus")];
+    expect(findInstanceForCwd("/Users/me/corpus", insts)?.name).toBe("a");
+  });
+
+  it("matches when CWD is a descendant of the watch_dir", () => {
+    const insts = [instance("a", "/Users/me/corpus")];
+    expect(findInstanceForCwd("/Users/me/corpus/iarpa/sources", insts)?.name).toBe(
+      "a",
+    );
+  });
+
+  it("does not match prefix-but-not-parent (sibling with shared prefix)", () => {
+    // /a/corpus-foo should NOT be considered "inside" /a/corpus.
+    const insts = [instance("a", "/Users/me/corpus")];
+    expect(findInstanceForCwd("/Users/me/corpus-other", insts)).toBeNull();
+  });
+
+  it("picks the deepest match when watch roots are nested", () => {
+    const insts = [
+      instance("outer", "/Users/me/work"),
+      instance("inner", "/Users/me/work/corpus"),
+    ];
+    expect(
+      findInstanceForCwd("/Users/me/work/corpus/iarpa", insts)?.name,
+    ).toBe("inner");
+  });
+
+  it("ignores instances missing watch_dir (older registry entries)", () => {
+    const insts = [
+      instance("legacy", undefined),
+      instance("modern", "/Users/me/corpus"),
+    ];
+    expect(findInstanceForCwd("/Users/me/corpus", insts)?.name).toBe("modern");
+  });
+});
+
+describe("relativeToWatchDir", () => {
+  it("returns empty string when CWD equals the watch_dir", () => {
+    const inst = instance("a", "/Users/me/corpus");
+    expect(relativeToWatchDir("/Users/me/corpus", inst)).toBe("");
+  });
+
+  it("returns the relative subpath when CWD is inside the watch_dir", () => {
+    const inst = instance("a", "/Users/me/corpus");
+    expect(relativeToWatchDir("/Users/me/corpus/iarpa/sources", inst)).toBe(
+      "iarpa/sources",
+    );
+  });
+
+  it("returns null when the instance has no watch_dir", () => {
+    const inst = instance("legacy", undefined);
+    expect(relativeToWatchDir("/anywhere", inst)).toBeNull();
+  });
+
+  it("returns null when CWD escapes the watch_dir", () => {
+    const inst = instance("a", "/Users/me/corpus");
+    expect(relativeToWatchDir("/Users/me/other", inst)).toBeNull();
+  });
+});
+
+describe("resolveTarget (no-filesystem branches)", () => {
+  it("--api-url wins over everything else", () => {
+    const result = resolveTarget({
+      apiUrl: "http://example:9999",
+      name: "default",
+      env: { ARKEON_WIKI_URL: "http://from-env" },
+    });
+    expect(result.source).toBe("api_url_flag");
+    expect(result.api_url).toBe("http://example:9999");
+  });
+
+  it("ARKEON_WIKI_URL env beats --name and CWD walk", () => {
+    const result = resolveTarget({
+      env: { ARKEON_WIKI_URL: "http://from-env" },
+      cwd: "/tmp/nowhere",
+    });
+    expect(result.source).toBe("env");
+    expect(result.api_url).toBe("http://from-env");
+  });
+});


### PR DESCRIPTION
## Summary

Adds one CLI command per substrate HTTP endpoint plus `where` for introspection. Every command is a thin HTTP wrapper — no SQLite reads, no caching, no daemon bypass.

**New commands:**
```
arkeon-wiki query / tag / untag / tags / backlinks / redlinks / stats
arkeon-wiki where  — prints which running instance owns CWD
```

**Daemon resolution precedence** for every api-CLI call:
1. `--api-url <url>`
2. `ARKEON_WIKI_URL` env
3. `--name <inst>`
4. CWD walk — deepest registered `watch_dir` containing `process.cwd()` wins
5. `default` instance

Both write side (`start.ts`) and read side (`instance-resolve.ts`) canonicalize via `realpath` so `/var` ↔ `/private/var` on macOS compares correctly. `Instance.watch_dir` is added to the registry record — optional, so instances started before this PR are silently skipped during the walk.

**Output** is isatty-aware: pretty table / key-value on a terminal, raw JSON when piped. Exit codes follow shell convention — `0` success, `1` HTTP 4xx/5xx, `2` network error.

**`--api-url` is per-command** (via `addCommonOptions`) so `arkeon-wiki query --api-url X` parses — commander program-level options must appear *before* the subcommand, which is a surprising failure mode. Dead `ARKE_API_URL` preAction bridge is removed (nothing read it).

## What is NOT in this PR

- **No `read` command** — the filesystem is the read API; `cat` / `bat` / `$EDITOR` cover this better than any CLI we'd write.
- **No CLI shell-out e2e harness** — left as a follow-up; existing e2e suite covers HTTP endpoints in-process, manual smoke covers the CLI shell-out for now.
- **No bulk operations** (`tag-all`, etc.) — that's `arkeon-wiki query | jq -r '.artifacts[].path' | xargs ...`.

## Test plan

- [x] `npm run typecheck -w packages/arkeon` — clean
- [x] `npm test -w packages/arkeon` — 240/240 unit (13 new for `instance-resolve`, 15 new for `api-client`)
- [x] `npm run test:e2e -w packages/arkeon` — 28/28
- [x] Manual smoke against real daemon: `up` → `where` → `stats` → `query` → `tag k=v` → `tag (unchanged)` → `tags` → `untag` → `backlinks` → `redlinks` → `down`
- [x] Verified CWD-walk picks the named instance with no `--name` flag (from inside the watched corpus)
- [x] Verified exit codes: `0` success, `1` on HTTP 404 (tag on nonexistent path), `2` on unreachable daemon
- [x] Verified `arkeon-wiki query --api-url X` parses post-command after the placement fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)