### PR TITLE
substrate: strict JSON validation on POST + dogfood doc gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,40 @@ PDF extraction is **not** available on the npm path — use the Docker image if 
 
 Every file the watcher sees lands in the `artifacts` table keyed by its path relative to the watched root (e.g. `iarpa/sources/paper.pdf`).
 
-- HTML files: `<title>` + `<meta>` tags go into `properties`; `<a class="wikilink">` anchors become graph edges with optional `data-*` citation metadata captured in `links.attrs` JSON.
+- HTML files: `<title>` populates the artifact's top-level `label`; every `<meta name="X" content="Y">` lands in `properties[X]`. Two meta names are reserved and skipped (they'd shadow top-level columns): `title` and `label`. `<a class="wikilink">` anchors become graph edges with optional `data-*` citation metadata captured in `links.attrs` JSON.
 - Markdown: `[[X]]` and `[[X|Display]]` wikilinks resolve by shortest-unique-basename match against the index.
 - Text files (code, configs, logs, ...): indexed for FTS5 search; no link extraction.
-- Binaries (PDFs today): indexed as `kind='asset'` so links resolve. An HTML sidecar lands at `.sidecars/<mirrored-path>.html` (requires the Docker image — PyMuPDF ships baked in).
+- Binaries (PDFs today): indexed as `kind='asset'` so links resolve. An HTML sidecar lands at `.sidecars/<mirrored-path>.html` (requires the Docker image — PyMuPDF ships baked in). The sidecar's `label` is derived from the binary's filename basename (not the embedded `<title>`) so asset and sidecar labels stay aligned for harnesses dereferencing `asset.properties.sidecar_path`.
 
 The filesystem is the source of truth. SQLite is the index. Delete a file → its row goes. Edit a file → re-sync. No manual commands.
+
+### A minimal HTML article
+
+Drop this under your watched root as `iarpa/example.html` and it'll be a fully-indexed article with title, meta, wikilinks, and citation metadata:
+
+```html
+<!doctype html>
+<html>
+<head>
+  <title>Why semiconductor exports matter</title>
+  <meta name="status" content="draft">
+  <meta name="topic" content="us-china">
+</head>
+<body>
+  <p>
+    The 2024 controls cited
+    <a class="wikilink"
+       href="./sources/bis-2024.pdf"
+       data-quote="On October 7th, the Department imposed..."
+       data-page="3"
+       data-cite-type="evidence">the BIS rule</a>
+    as the immediate trigger.
+  </p>
+</body>
+</html>
+```
+
+`title` becomes the artifact's `label`; `status` and `topic` land in `properties`; the wikilink lands in `links` with `attrs: { quote, page, "cite-type" }` (the `data-` prefix is stripped). Use `[[X]]` syntax in `.md` files for the same effect with shortest-unique-basename resolution.
 
 ## HTTP API
 
@@ -74,6 +102,8 @@ Two tag-key conventions coexist:
 "No tag = unprocessed" is the trigger model.
 
 `POST /query` filters are AND-composed. `has_tag` / `not_tag` entries can be `"key"` (presence) or `"key:value"` (key+value match). `text` runs FTS5 MATCH against the artifact body.
+
+**Strict body validation.** POST endpoints reject malformed JSON with `400 invalid_json` and unknown top-level fields with `400 unknown_field`. A typo like `notag` instead of `not_tag` errors loudly rather than silently returning the unfiltered corpus.
 
 `GET /redlinks` returns two shapes of `target_path`: HTML `<a class="wikilink" href="...">` resolves to an fs-relative path at extraction time (e.g. `iarpa/sources/missing.html`), while Markdown `[[X]]` keeps the literal slug (e.g. `missing-topic`) until a matching artifact lands, then auto-converges. Branch on `target_path.includes("/")` if your harness needs to distinguish "create at this path" from "create anywhere by basename."
 
@@ -138,9 +168,36 @@ External harnesses do the agent loop. Each worker tick:
 1. `POST /query` with `not_tag: ["processed-by-<worker-name>"]` and whatever folder/has_tag filters fit the worker.
 2. Read each artifact from the filesystem.
 3. Write outputs to the filesystem (the watcher indexes them).
-4. `POST /tag` with `{ key: "processed-by-<worker-name>", value: <hash-or-ts> }` to mark the artifact done.
+4. `POST /tag` with `{ key: "processed-by-<worker-name>", value: <artifact.source_hash> }` to mark the artifact done.
 
 New content surfaces because `syncFile` indexes new artifacts without any `processed-by-*` tag — the worker's next tick picks them up automatically.
+
+**Detecting edits — use `source_hash` as the tag value.** "No tag = unprocessed" surfaces *new* files. To surface *edited* files, store the artifact's `source_hash` as the tag value, then widen the gate so anything with a stale hash is re-included:
+
+```jsonc
+// Anything missing the tag, OR tagged with a different hash than the
+// artifact currently has, should be re-processed.
+POST /query
+{
+  "kinds": ["text"],
+  "not_tag": ["processed-by-editor"]
+}
+// → process the artifacts you get back, then for each:
+POST /tag
+{ "path": "...", "key": "processed-by-editor", "value": "<artifact.source_hash>" }
+```
+
+A second pass then catches *edited* artifacts (already-tagged but the hash drifted):
+
+```jsonc
+// Find anything where the recorded hash no longer matches the current
+// source_hash. The simplest approach: list everything with the tag,
+// then in the harness compare tag.value to artifact.source_hash.
+POST /query
+{ "kinds": ["text"], "has_tag": ["processed-by-editor"] }
+```
+
+If `tag.value !== artifact.source_hash`, the source changed since you last processed it — re-run and overwrite the tag (UPSERT). The `action: "updated"` response on `POST /tag` confirms a collision was overwritten.
 
 **Tag the sidecar, not the binary.** Worker `processed-by-<name>` tags belong on the `kind='text'` sidecar (`.sidecars/<mirrored>.html`), not on the `kind='asset'` binary — asset rows are invisible to `kinds: ["text"]` queries. Use `asset.properties.sidecar_path` to find the right target.
 

--- a/packages/arkeon/src/server/lib/llms-txt.ts
+++ b/packages/arkeon/src/server/lib/llms-txt.ts
@@ -57,6 +57,24 @@ Three tables in SQLite, plus an FTS5 virtual table:
   - **fts_artifacts** — FTS5 over text-kind artifact contents.
     Populated by syncFile; queried via POST /query \`{text}\`.
 
+## HTML \`<head>\` extraction
+
+The first \`<title>\` element populates the artifact's top-level
+\`label\` column. Every \`<meta name="X" content="Y">\` lands in
+\`properties[X]\`, EXCEPT for two reserved names:
+
+  - \`title\` — would shadow the column derived from \`<title>\`.
+  - \`label\` — would shadow the artifact's \`label\` column.
+
+Both are silently stripped so a harness walking \`artifact.properties\`
+never sees a value that doesn't match the top-level field. Use any
+other meta name (\`status\`, \`topic\`, \`source\`, …) freely.
+
+Sidecars (\`.sidecars/<binary>.html\`) get their label from the
+binary's filename basename, NOT the embedded \`<title>\` — that keeps
+\`asset.label\` and \`sidecar.label\` aligned so harnesses dereferencing
+\`asset.properties.sidecar_path\` see consistent labels.
+
 ## Link conventions
 
 HTML: \`<a class="wikilink" href="./topic-x">topic X</a>\`. Only
@@ -100,9 +118,18 @@ The asset's \`properties.sidecar_path\` carries the convention path,
 so harnesses can dereference \`asset.properties.sidecar_path\` to
 get the right target without hard-coding the convention.
 
-## API surface — six commands
+## API surface
 
+Six substrate commands (\`/query\`, \`/tag\`, \`/untag\`, \`/tags\`,
+\`/backlinks\`, \`/redlinks\`) + \`/stats\`, plus the op endpoints
+(\`/health\`, \`/ready\`) and this doc surface (\`/llms.txt\`, \`/help\`).
 All POST bodies are JSON; all GET params are URL-encoded.
+
+POST endpoints validate strictly: a malformed JSON body returns
+\`400 invalid_json\` (never silently treated as empty); any
+top-level key that isn't in the documented field set returns
+\`400 unknown_field\`. A typo like \`notag\` instead of \`not_tag\`
+errors loudly rather than returning the unfiltered corpus.
 
 ### POST /query
 
@@ -312,12 +339,30 @@ Each tick:
   1. POST /query with \`not_tag: ["processed-by-<worker-name>"]\` and
      whatever \`kinds\` / \`has_tag\` filters fit the worker.
   2. Process each artifact.
-  3. POST /tag with \`{ key: "processed-by-<worker-name>", value: <hash-or-ts> }\`
+  3. POST /tag with
+     \`{ key: "processed-by-<worker-name>", value: <artifact.source_hash> }\`
      so it doesn't pick up the same artifact next tick.
 
 New content surfaces because \`syncFile\` indexes new artifacts
 without any \`processed-by-*\` tag — the worker's next tick picks them
 up automatically.
+
+**Detecting edits.** "No tag = unprocessed" only catches new files.
+To catch *edited* files, store \`artifact.source_hash\` as the tag
+value and add a second pass:
+
+  - Pass 1: \`not_tag: ["processed-by-<worker>"]\` — picks up new
+    artifacts (no tag at all).
+  - Pass 2: \`has_tag: ["processed-by-<worker>"]\` — yields every
+    tagged artifact. For each, compare the tag's value (in the
+    \`/tags\` response or by tracking it locally) against the
+    artifact's current \`source_hash\`. If they differ, the source
+    was edited since the last run — re-process and UPSERT the tag
+    with the new hash. \`POST /tag\` returns \`action: "updated"\` on
+    a hash overwrite, confirming the collision.
+
+Without this pattern an edited source keeps its stale tag forever
+and the worker silently skips updated content.
 
 **Sidecars and folder scoping**: don't reach for \`folder\` when the
 intent is "process all unprocessed text in space X." PDF/Word

--- a/packages/arkeon/src/server/routes/space-scoped.ts
+++ b/packages/arkeon/src/server/routes/space-scoped.ts
@@ -2,16 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * The substrate HTTP API surface — six commands.
+ * The substrate HTTP API surface.
  *
- *   POST /query        { folder?, kinds?, has_tag?[], not_tag?[], text?, limit?, offset? }
+ *   POST /query        { folder?, kinds?, has_tag?[], not_tag?[], text?,
+ *                        order_by?, order?, limit?, offset? }
  *   POST /tag          { path, key, value? }
  *   POST /untag        { path, key }
  *   GET  /tags?path=...
  *   GET  /backlinks?path=...
  *   GET  /redlinks?folder=...
+ *   GET  /stats
+ *
+ * Plus liveness (`/health`, `/ready`) and the doc surface (`/llms.txt`,
+ * `/help`) mounted at the app level.
  */
 
+import type { Context } from "hono";
 import { Hono } from "hono";
 
 import type { AppBindings } from "../types.js";
@@ -30,6 +36,60 @@ import {
 } from "../lib/entities.js";
 
 export const apiRouter = new Hono<AppBindings>();
+
+/**
+ * Parse a POST JSON body strictly:
+ *   - empty body → empty object (so callers with all-optional fields work).
+ *   - malformed JSON → 400 `invalid_json` (NOT a silent fallthrough — a
+ *     harness with a typo in its body would otherwise see the unfiltered
+ *     corpus and reprocess everything).
+ *   - non-object JSON (array, null, primitive) → 400 `validation_error`.
+ *   - any top-level key not in `allowedKeys` → 400 `unknown_field`. Catches
+ *     typos like `notag` vs `not_tag` that would otherwise be ignored.
+ */
+async function parseJsonBody(
+  c: Context<AppBindings>,
+  allowedKeys: readonly string[],
+): Promise<Record<string, unknown>> {
+  const raw = await c.req.text();
+  if (raw.length === 0) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new ApiError(400, "invalid_json", "request body must be valid JSON");
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new ApiError(400, "validation_error", "request body must be a JSON object");
+  }
+  const body = parsed as Record<string, unknown>;
+  const allowed = new Set(allowedKeys);
+  for (const key of Object.keys(body)) {
+    if (!allowed.has(key)) {
+      throw new ApiError(
+        400,
+        "unknown_field",
+        `unknown field "${key}"; allowed: ${allowedKeys.join(", ")}`,
+      );
+    }
+  }
+  return body;
+}
+
+const QUERY_FIELDS = [
+  "folder",
+  "kinds",
+  "has_tag",
+  "not_tag",
+  "text",
+  "order_by",
+  "order",
+  "limit",
+  "offset",
+] as const;
+
+const TAG_FIELDS = ["path", "key", "value"] as const;
+const UNTAG_FIELDS = ["path", "key"] as const;
 
 function parseStringArray(raw: unknown, name: string): string[] | null {
   if (raw == null) return null;
@@ -83,7 +143,7 @@ function parseOrder(raw: unknown): QueryOrder | null {
 }
 
 apiRouter.post("/query", async (c) => {
-  const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
+  const body = await parseJsonBody(c, QUERY_FIELDS);
   const result = await listArtifacts({
     folder: typeof body.folder === "string" ? body.folder : null,
     kinds: parseKinds(body.kinds),
@@ -104,7 +164,7 @@ apiRouter.get("/stats", async (c) => {
 });
 
 apiRouter.post("/tag", async (c) => {
-  const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
+  const body = await parseJsonBody(c, TAG_FIELDS);
   const path = requireString(body.path, "path");
   const key = requireString(body.key, "key");
   const value = typeof body.value === "string" ? body.value : "";
@@ -117,7 +177,7 @@ apiRouter.post("/tag", async (c) => {
 });
 
 apiRouter.post("/untag", async (c) => {
-  const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
+  const body = await parseJsonBody(c, UNTAG_FIELDS);
   const path = requireString(body.path, "path");
   const key = requireString(body.key, "key");
   // `existed` distinguishes "no-op, tag wasn't set" from "tag was removed."

--- a/packages/arkeon/test/e2e/substrate.test.ts
+++ b/packages/arkeon/test/e2e/substrate.test.ts
@@ -611,4 +611,64 @@ describe("substrate", () => {
     }
     expect(converged).toBe(true);
   });
+
+  it("POST /query rejects malformed JSON with 400 (not a silent unfiltered fallthrough)", async () => {
+    // Footgun guard: c.req.json().catch(() => ({})) used to swallow
+    // syntax errors and quietly return the full corpus. A harness with
+    // a busted body builder would then happily reprocess everything.
+    const res = await app.fetch(
+      new Request("http://test/query", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "not { valid json",
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("invalid_json");
+  });
+
+  it("POST /query rejects unknown top-level fields with 400", async () => {
+    // Typo guard: `notag` ≠ `not_tag`. Silently ignoring the unknown
+    // key would return the unfiltered corpus and the worker would
+    // reprocess everything.
+    const res = await app.fetch(
+      new Request("http://test/query", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ notag: ["processed-by-editor"] }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("unknown_field");
+    expect(body.error.message).toContain("notag");
+  });
+
+  it("POST /tag rejects unknown top-level fields with 400", async () => {
+    const res = await app.fetch(
+      new Request("http://test/tag", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          path: "iarpa/article.html",
+          key: "k",
+          extra: "nope",
+        }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("unknown_field");
+  });
+
+  it("POST /query accepts an empty body (all-defaults query)", async () => {
+    // Strict validation must not break the documented all-defaults call.
+    const res = await app.fetch(
+      new Request("http://test/query", { method: "POST" }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { artifacts: unknown[] };
+    expect(Array.isArray(body.artifacts)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Cleanup pass on findings from the latest fresh-eyes dogfood round.

- **[P2 bug]** `POST /query`, `/tag`, `/untag` silently accepted malformed JSON (caught + treated as empty) and ignored unknown top-level fields. A harness with `notag` instead of `not_tag` got back the unfiltered corpus and reprocessed everything. New `parseJsonBody` helper rejects malformed bodies with `400 invalid_json` and unknown fields with `400 unknown_field`. Empty bodies still work for the all-defaults `/query` call.
- **[P2 docs]** README + llms.txt document the edited-source tag invalidation pattern: store `artifact.source_hash` as the `processed-by-X` tag value, then a second-pass query catches edited artifacts whose tag.value drifted from the current source_hash. Without this an edited file keeps its stale tag forever.
- **[P3 docs]** README + llms.txt document the `<meta name="label">` / `<meta name="title">` reservation (consumed into top-level columns, stripped from `properties`). The README previously said "every `<meta>` goes into properties" without the carve-out.
- **[P3 docs]** README ships a minimal-but-complete 15-line HTML article example (title + meta + wikilink with data-* attrs).
- **[P3 docs]** llms.txt "six commands" headline corrected to reflect the actual ~10-endpoint surface (substrate six + `/stats` + `/health` + `/ready` + `/llms.txt` + `/help`).

## Test plan

- [x] `npm run typecheck -w packages/arkeon` — clean
- [x] `npm test -w packages/arkeon` — 240/240 (one pre-existing timing flake in `extractors-subprocess` retried green)
- [x] `npm run test:e2e -w packages/arkeon` — 32/32, including 4 new regression tests:
  - malformed JSON body → 400 `invalid_json`
  - unknown top-level field on `/query` → 400 `unknown_field` (error message names the offending key)
  - unknown top-level field on `/tag` → 400 `unknown_field`
  - empty body on `/query` still returns the full corpus (all-defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)