### PR TITLE
docs: round-7 dogfood tightening (CLI section + reserved tag + FTS stemmer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The image bakes PyMuPDF (PDF extraction) so it works out of the box — no host-
 
 Verify PDF extraction with any PDF you already have — or print this README to one (macOS Preview ⌘P → "Save as PDF"; Linux: any browser's Print → PDF). Drop it under `./corpus/`, then `curl http://localhost:8062/stats` should show the asset count tick up and a sidecar appear under `./corpus/.sidecars/`.
 
+**Teardown.** `docker compose down -v` removes the container + the named state volume (SQLite index, daemon logs). The `.sidecars/` tree inside your bind-mounted corpus stays on disk — that's the filesystem-is-truth contract. To wipe sidecars too, `rm -rf ./corpus/.sidecars/` after `down -v`; the watcher will rebuild them next time you `up -d` against the same corpus.
+
 ### npm (HTML + Markdown only)
 
 ```bash
@@ -123,11 +125,14 @@ The same article opens identically under `file://` and `http://`.
 
 ## CLI
 
+### Daemon lifecycle
+
 ```bash
 arkeon-wiki up [--watch-dir <path>]   # start the daemon detached
 arkeon-wiki down                      # stop it
 arkeon-wiki status                    # is it running?
 arkeon-wiki ls                        # list running instances
+arkeon-wiki where                     # which instance owns this directory?
 arkeon-wiki logs [-f]                 # print/tail the daemon log
 arkeon-wiki start                     # foreground (for pm2/launchd/Docker/etc.)
 arkeon-wiki install                   # persistent service
@@ -135,6 +140,28 @@ arkeon-wiki uninstall                 # remove the service
 ```
 
 `--name <name>` runs multiple instances side by side (different state dirs, different ports).
+
+### Substrate API (one CLI command per HTTP endpoint)
+
+Thin wrappers over the HTTP API — no SQLite reads, no caching. Pretty-print on a TTY, raw JSON when piped (so `arkeon-wiki query | jq` works).
+
+```bash
+arkeon-wiki query [--folder X --kinds text --has-tag K[:V] --not-tag K --text Q ...]
+arkeon-wiki tag <path> <key>[=<value>]   # UPSERT — = and value optional
+arkeon-wiki untag <path> <key>
+arkeon-wiki tags <path>                  # list every tag on an artifact
+arkeon-wiki backlinks <path>             # inbound link rows (works for redlinks too)
+arkeon-wiki redlinks [--folder X --limit N --offset N]
+arkeon-wiki stats                        # corpus-level counts
+```
+
+Reading article bodies is *not* a CLI command — the filesystem is the read API. `cat`, `bat`, `$EDITOR` work fine; the daemon's job is the index, not the read path.
+
+**Daemon resolution.** Every substrate-API command picks a daemon in this order: `--api-url <url>` → `ARKEON_WIKI_URL` env → `--name <inst>` → CWD walk (deepest registered `watch_dir` containing your shell's cwd) → `default` instance. Run `arkeon-wiki where` from inside a watched corpus to see which instance the CLI will hit. Exit codes: `0` success, `1` HTTP 4xx/5xx (response body on stderr), `2` network error.
+
+**`--api-url` placement.** `--api-url` is per-command, not program-level: write `arkeon-wiki query --api-url http://...` (the flag AFTER the subcommand). The program-level `--data-dir` flag still comes before the subcommand.
+
+**Auth flag is forward-looking.** `--token <token>` and `ARKEON_WIKI_TOKEN` are wired into every substrate-API command so future hardening doesn't break invocations — the daemon currently ignores them and `Authorization: Bearer …` headers are silently dropped. Treat `--token` as scaffolding, not enforcement.
 
 ## Persistent service
 

--- a/packages/arkeon/src/server/lib/llms-txt.ts
+++ b/packages/arkeon/src/server/lib/llms-txt.ts
@@ -125,6 +125,15 @@ The asset's \`properties.sidecar_path\` carries the convention path,
 so harnesses can dereference \`asset.properties.sidecar_path\` to
 get the right target without hard-coding the convention.
 
+**Reserved tag: \`extracted_by\`.** Every sidecar gets an
+\`extracted_by\` tag set automatically by the extractor runner
+(value: the handler name, e.g. \`pymupdf\`). Used internally to
+distinguish handler-generated sidecars from hand-written ones
+during re-extraction. Harnesses can read it for provenance, but
+should NOT use it as a worker gate or overwrite it — use a
+\`processed-by-<worker>\` key for your own bookkeeping. The
+\`extracted_by\` key is reserved for the extractor pipeline.
+
 ## API surface
 
 Six substrate commands (\`/query\`, \`/tag\`, \`/untag\`, \`/tags\`,
@@ -167,6 +176,12 @@ entries may be:
 Space-separated tokens are AND'd by default (\`shannon entropy\`
 matches docs containing both terms); wrap in quotes for an exact
 phrase (\`"shannon entropy"\` matches the literal phrase only).
+
+**Tokenizer**: \`porter unicode61\` — Porter-stemmed, Unicode-aware.
+Stemming means \`chokepoint\` matches \`chokepoints\`, \`indexing\`
+matches \`indexed\`, etc. Precision-sensitive callers wanting an
+exact-form match should wrap the term in double quotes
+(\`"chokepoint"\` won't match \`chokepoints\`).
 
 **Folder note**: sidecar HTMLs for binaries live under
 \`.sidecars/<mirrored-path>.html\` — OUTSIDE the source folder. A


### PR DESCRIPTION
## Summary

Pure-docs PR closing the five gaps the round-7 cold-stranger smoke flagged against post-#194 main. No behavior change — the smoke verdict was already **Y**; this lifts every remaining doc paper cut.

## What's fixed

| # | Gap | Fix |
|---|---|---|
| 1 | README CLI section only listed lifecycle commands — `query / tag / untag / tags / backlinks / redlinks / stats` (from #190) only discoverable via `--help` | New "Substrate API" subsection with all 7 commands, plus `where` added to "Daemon lifecycle" |
| 2 | Daemon resolution precedence + `--api-url` placement gotcha + exit codes not in README | Documented inline in the new Substrate API subsection |
| 3 | `--token` / `ARKEON_WIKI_TOKEN` in CLI `--help` contradicted "no auth" claim | One-paragraph note: forward-looking scaffolding, daemon currently ignores it |
| 4 | `docker compose down -v` doesn't sweep `.sidecars/` from bind-mounted corpus | One-sentence teardown note explaining the filesystem-is-truth contract + the `rm -rf` escape hatch |
| 5 | `extracted_by=<handler>` tag auto-applied to sidecars but undocumented | llms.txt Sidecars section now documents it as a reserved tag for extractor provenance |
| 6 | FTS5 tokenizer + Porter stemming undocumented (`chokepoint` matches `chokepoints`) | llms.txt POST /query section now documents the tokenizer + the double-quote escape for exact-form matches |

## Out of scope (filed as follow-ups when convenient)

- `properties.X` filter on `/query` — real feature gap, not a doc fix
- `/stats.tag_keys` top-N preview — feature ask
- Page-render PNG kind discriminator — feature ask
- CLI `=` vs `:` separator — internally consistent, accepted as designed
- `docker exec arkeon-wiki query` helpful error when CWD-resolution fails — code change, not docs

## Test plan

- [x] `npm run typecheck -w packages/arkeon` — clean
- [x] `npm test -w packages/arkeon` — 240/240 (llms-txt drift-guard included; the new content references existing tokens it already knows about)
- [x] Diff fits in two files: README.md + `packages/arkeon/src/server/lib/llms-txt.ts`. No source code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)