### PR TITLE
substrate+reader: reject ':' in tag keys; reader uses artifact.label

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Two tag-key conventions coexist:
 
 **Strict body validation.** POST endpoints reject malformed JSON with `400 invalid_json` and unknown top-level fields with `400 unknown_field`. A typo like `notag` instead of `not_tag` errors loudly rather than silently returning the unfiltered corpus.
 
+**Reserved characters.** Tag KEYS may not contain `:` (`400 reserved_character`). The colon is the key/value separator in `has_tag` / `not_tag` query specs — a literal colon in the key would store fine but then collide on read with the (key, value) split. Pass the colon in the request shape (`{ key: "status", value: "published" }`), not in the key. Values may contain colons.
+
 `GET /redlinks` returns two shapes of `target_path`: HTML `<a class="wikilink" href="...">` resolves to an fs-relative path at extraction time (e.g. `iarpa/sources/missing.html`), while Markdown `[[X]]` keeps the literal slug (e.g. `missing-topic`) until a matching artifact lands, then auto-converges. Branch on `target_path.includes("/")` if your harness needs to distinguish "create at this path" from "create anywhere by basename."
 
 Full reference at `GET /llms.txt` or `GET /help`.

--- a/packages/arkeon/src/server/lib/entities.ts
+++ b/packages/arkeon/src/server/lib/entities.ts
@@ -366,11 +366,29 @@ export interface SetTagResult {
   action: SetTagAction;
 }
 
+/**
+ * Validate a tag key. `:` is reserved because `has_tag` / `not_tag`
+ * query specs use the first `:` to split key from value
+ * (parseTagSpec). A key like `"status:published"` would be stored
+ * verbatim but then collide with `key="status", value="published"`
+ * on read — invisible until you list raw tags. Reject up front.
+ */
+export function validateTagKey(key: string): void {
+  if (key.includes(":")) {
+    throw new ApiError(
+      400,
+      "reserved_character",
+      `tag key must not contain ":" (reserved as the key/value separator in has_tag / not_tag query specs); got ${JSON.stringify(key)}`,
+    );
+  }
+}
+
 export async function setTag(
   path: string,
   key: string,
   value: string,
 ): Promise<SetTagResult> {
+  validateTagKey(key);
   const sql = createSql();
   const existing = (await sql.query(
     `SELECT value FROM tags WHERE path = ? AND key = ? LIMIT 1`,
@@ -394,6 +412,7 @@ export async function setTag(
 }
 
 export async function deleteTag(path: string, key: string): Promise<boolean> {
+  validateTagKey(key);
   const sql = createSql();
   const rows = await sql.query(
     `DELETE FROM tags WHERE path = ? AND key = ? RETURNING key`,

--- a/packages/arkeon/src/server/lib/llms-txt.ts
+++ b/packages/arkeon/src/server/lib/llms-txt.ts
@@ -45,6 +45,13 @@ Three tables in SQLite, plus an FTS5 virtual table:
         \`topic:us-china\`. The \`key:value\` string form is for
         these where the value carries meaning across artifacts.
 
+    Tag KEYS reject \`:\` (400 \`reserved_character\`). The colon
+    is the key/value separator in \`has_tag\` / \`not_tag\` query
+    specs — a literal colon in the key would store fine but then
+    collide on read with the (key, value) split. Put the colon
+    in the request shape (\`{key: "status", value: "published"}\`),
+    not in the key. Values may contain colons.
+
     "No tag = unprocessed" is the trigger model.
 
   - **links** \`(source_path, target_path, link_text, attrs)\` —

--- a/packages/arkeon/src/server/lib/reader.ts
+++ b/packages/arkeon/src/server/lib/reader.ts
@@ -45,6 +45,12 @@ export function rewriteWikilinks(
 export interface DirEntry {
   name: string;
   is_dir: boolean;
+  /**
+   * For files: artifact.label from the index (derived from
+   * `<title>` or filename slug). Null for directories — they're
+   * not in the artifact table.
+   */
+  label: string | null;
   /** For files: short_description from <meta name="short_description"> if any. */
   short_description: string | null;
 }
@@ -54,11 +60,26 @@ export function renderDirectoryListing(dirPath: string, entries: DirEntry[]): st
   const items = entries
     .map((e) => {
       const href = e.is_dir ? `${e.name}/` : e.name;
+      // Anchor text: artifact label (typically the <title>) when it
+      // adds information over the filename; otherwise the raw
+      // filename. Sync falls back to the filename basename when
+      // there's no <title>, so a label that matches basename(name)
+      // or name itself is treated as "no real label" and skipped —
+      // showing `paper (paper.md)` for a Markdown file would just
+      // be noise. The filename is preserved alongside any real
+      // label so the URL stays discoverable.
+      let anchor: string;
+      if (e.is_dir) {
+        anchor = escapeHtml(e.name) + "/";
+      } else if (e.label && !isFilenameDerivedLabel(e.label, e.name)) {
+        anchor = `${escapeHtml(e.label)} <span class="ark-sub">(${escapeHtml(e.name)})</span>`;
+      } else {
+        anchor = escapeHtml(e.name);
+      }
       const subtitle = e.short_description
         ? ` <span class="ark-sub">— ${escapeHtml(e.short_description)}</span>`
         : "";
-      const label = escapeHtml(e.name) + (e.is_dir ? "/" : "");
-      return `<li><a href="${escapeAttr(href)}">${label}</a>${subtitle}</li>`;
+      return `<li><a href="${escapeAttr(href)}">${anchor}</a>${subtitle}</li>`;
     })
     .join("\n");
   return `<!DOCTYPE html>
@@ -91,6 +112,19 @@ export function renderNotFound(path: string): string {
   <p><code>${escapeHtml(path)}</code></p>
 </body>
 </html>`;
+}
+
+/**
+ * Returns true when `label` looks like sync's no-<title> fallback —
+ * the filename with its extension stripped, or the filename itself.
+ * Used to avoid emitting `Foo (foo.md)`-style noise for files whose
+ * "label" is just the slug.
+ */
+function isFilenameDerivedLabel(label: string, name: string): boolean {
+  if (label === name) return true;
+  const dot = name.lastIndexOf(".");
+  if (dot > 0 && label === name.slice(0, dot)) return true;
+  return false;
 }
 
 function escapeHtml(s: string): string {

--- a/packages/arkeon/src/server/routes/reader.ts
+++ b/packages/arkeon/src/server/routes/reader.ts
@@ -21,7 +21,6 @@ import { ApiError } from "../lib/errors.js";
 import { createSql } from "../lib/sql.js";
 import { safeResolve } from "../lib/path.js";
 import { getWatchedRoot, shouldIgnorePath } from "../lib/fs-watcher.js";
-import { parseHtmlMeta } from "../lib/html-meta.js";
 import {
   renderDirectoryListing,
   renderNotFound,
@@ -100,25 +99,32 @@ async function serveDirectory(
   if (!existsSync(abs) || !statSync(abs).isDirectory()) {
     return c.html(renderNotFound(relPath), 404);
   }
+
+  // Pull labels + short_description for every immediate child of this
+  // directory in one query, so we don't re-read each HTML file from
+  // disk (would be 3k+ syscalls on a Substack-sized corpus). Sync
+  // already parses <title> and <meta> into artifact.label /
+  // properties — re-reading would just duplicate that work.
+  const childIndex = await loadChildIndex(relPath);
+
   const entries: DirEntry[] = [];
   for (const entry of readdirSync(abs, { withFileTypes: true })) {
     if (entry.name.startsWith(".")) continue;
     if (entry.isDirectory()) {
-      entries.push({ name: entry.name, is_dir: true, short_description: null });
+      entries.push({
+        name: entry.name,
+        is_dir: true,
+        label: null,
+        short_description: null,
+      });
     } else if (entry.isFile()) {
-      let short: string | null = null;
-      const ext = extname(entry.name).toLowerCase();
-      if (ext === ".html" || ext === ".htm") {
-        try {
-          const html = readFileSync(safeResolve(abs, entry.name), "utf-8");
-          const meta = parseHtmlMeta(html);
-          const desc = meta.properties.short_description;
-          if (typeof desc === "string" && desc.length > 0) short = desc;
-        } catch {
-          /* ignore */
-        }
-      }
-      entries.push({ name: entry.name, is_dir: false, short_description: short });
+      const meta = childIndex.get(entry.name);
+      entries.push({
+        name: entry.name,
+        is_dir: false,
+        label: meta?.label ?? null,
+        short_description: meta?.short_description ?? null,
+      });
     }
   }
   entries.sort((a, b) => {
@@ -126,6 +132,48 @@ async function serveDirectory(
     return a.name.localeCompare(b.name);
   });
   return c.html(renderDirectoryListing(relPath, entries));
+}
+
+interface ChildMeta {
+  label: string | null;
+  short_description: string | null;
+}
+
+async function loadChildIndex(relPath: string): Promise<Map<string, ChildMeta>> {
+  const sql = createSql();
+  // Match immediate children only: paths starting with the dir prefix
+  // and with no further `/` after it. Root (`relPath === ""`) → any
+  // path with no slash at all.
+  let rows: { path: string; label: string | null; properties: unknown }[];
+  if (relPath === "") {
+    rows = (await sql`
+      SELECT path, label, properties
+      FROM artifacts
+      WHERE path NOT LIKE '%/%'
+    `) as { path: string; label: string | null; properties: unknown }[];
+  } else {
+    const prefix = `${relPath}/`;
+    const wildcard = `${prefix}%`;
+    const deeper = `${prefix}%/%`;
+    rows = (await sql.query(
+      `SELECT path, label, properties
+         FROM artifacts
+        WHERE path LIKE ? AND path NOT LIKE ?`,
+      [wildcard, deeper],
+    )) as { path: string; label: string | null; properties: unknown }[];
+  }
+  const index = new Map<string, ChildMeta>();
+  const prefixLen = relPath === "" ? 0 : relPath.length + 1;
+  for (const row of rows) {
+    const basename = row.path.slice(prefixLen);
+    const props = (row.properties as Record<string, unknown> | null) ?? {};
+    const desc = props.short_description;
+    index.set(basename, {
+      label: row.label,
+      short_description: typeof desc === "string" && desc.length > 0 ? desc : null,
+    });
+  }
+  return index;
 }
 
 const MIME_TYPES: Record<string, string> = {

--- a/packages/arkeon/test/e2e/substrate.test.ts
+++ b/packages/arkeon/test/e2e/substrate.test.ts
@@ -433,6 +433,29 @@ describe("substrate", () => {
     expect(text).toContain("chartbook/");
   });
 
+  it("GET /<dir>/ renders artifact.label (from <title>) next to filename", async () => {
+    // chartbook/about.html has <title>Chartbook</title>; the
+    // directory listing should show that label alongside the
+    // raw filename so the link text isn't just the slug.
+    const res = await app.fetch(new Request("http://test/chartbook/"));
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    // Label first, filename in muted suffix.
+    expect(text).toMatch(/Chartbook\s*<span[^>]*>\(about\.html\)<\/span>/);
+  });
+
+  it("GET /<dir>/ falls back to filename when label equals basename", async () => {
+    // Markdown files derive label from the filename slug (no <title>),
+    // so paper.md → label "paper". The renderer should render the
+    // filename as the anchor, with no `(paper.md)` muted suffix —
+    // anything else would be visual noise.
+    const res = await app.fetch(new Request("http://test/iarpa/sources/"));
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("paper.md");
+    expect(text).not.toMatch(/paper\s*<span[^>]*>\(paper\.md\)<\/span>/);
+  });
+
   it("GET /<file> rewrites wikilinks and marks unresolved as redlinks", async () => {
     const res = await app.fetch(new Request("http://test/iarpa/article.html"));
     expect(res.status).toBe(200);
@@ -660,6 +683,42 @@ describe("substrate", () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: { code: string } };
     expect(body.error.code).toBe("unknown_field");
+  });
+
+  it("POST /tag rejects keys containing ':' with 400 reserved_character", async () => {
+    // The colon is the key/value separator in has_tag / not_tag specs.
+    // A literal colon-key would store fine but then collide on read with
+    // the (key, value) split, so reject up front.
+    const res = await app.fetch(
+      new Request("http://test/tag", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          path: "iarpa/article.html",
+          key: "status:published",
+        }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("reserved_character");
+    expect(body.error.message).toContain(":");
+  });
+
+  it("POST /untag rejects keys containing ':' with 400 reserved_character", async () => {
+    const res = await app.fetch(
+      new Request("http://test/untag", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          path: "iarpa/article.html",
+          key: "status:published",
+        }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("reserved_character");
   });
 
   it("POST /query accepts an empty body (all-defaults query)", async () => {


### PR DESCRIPTION
## Summary

Two round-7 dogfood findings landed together:

1. **Tag-key validation (#2 in the round-7 report).** `POST /tag {key: "status:published"}` used to store the colon literally — fine until you queried it. The colon is the key/value separator in `has_tag` / `not_tag` specs, so a literal colon-key would collide on read with the (key, value) split, invisible until you listed raw tags. `setTag` / `deleteTag` now reject keys containing `:` with `400 reserved_character`; the validation lives in `entities.ts` so internal callers (extractor runner, etc.) also fail fast. Documented in README + llms.txt.

2. **Reader directory listing uses `artifact.label` (#5).** Previously the listing showed only filenames + `<meta short_description>`; titles from `<title>` were ignored entirely. `serveDirectory` now pulls `label + properties` in one SQL query per directory — no per-file disk re-reads, which matters on a Substack-sized 3k-file corpus — and the anchor renders `Label (filename)` when a real `<title>` is present, plain `filename` when the label is sync's filename-basename fallback. No `Foo (foo.md)` noise.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 240/240 unit pass (no behavior change in non-substrate code)
- [x] `npm run test:e2e` — 36/36 pass, including:
  - new `POST /tag` reserved_character test
  - new `POST /untag` reserved_character test
  - new directory listing renders `<title>` next to filename
  - new directory listing falls back to filename when label === basename

🤖 Generated with [Claude Code](https://claude.com/claude-code)