### PR TITLE
substrate: dedup /redlinks across MD slug + HTML href; README response shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,12 @@ Two tag-key conventions coexist:
 
 **Reserved characters.** Tag KEYS may not contain `:` (`400 reserved_character`). The colon is the key/value separator in `has_tag` / `not_tag` query specs — a literal colon in the key would store fine but then collide on read with the (key, value) split. Pass the colon in the request shape (`{ key: "status", value: "published" }`), not in the key. Values may contain colons.
 
-`GET /redlinks` dedups HTML href and MD slug forms by lowercased basename-minus-extension: `<a href="./chloroplast.html">` and `[[chloroplast]]` collapse into one row whose `demand` sums both anchors and whose `linked_from` unions their source files. The returned `target_path` prefers the fs-relative form (e.g. `iarpa/chloroplast.html`) so harnesses get an actionable place to drop the file; it falls back to the bare slug only when no fs-path anchor exists. Branch on `target_path.includes("/")` to distinguish "create at this path" from "create anywhere by basename."
+`GET /redlinks` aggregates the queue the same way the resolver itself resolves links — so a row represents one concrete unit of work:
+
+- Each unique fs-path target is its own row. `iarpa/wiki.html` and `chartbook/wiki.html` are two distinct gaps; creating one resolves only the anchors that named exactly that path.
+- An MD slug redlink (`[[wiki]]`, no folder/extension) merges into a fs-path row only when its basename has exactly one fs-path match in the queue — the same condition under which `[[wiki]]` would auto-resolve once the file lands. With zero matches the slug stays as its own row (target=`wiki`). With two+ matches the slug stays standalone too (ambiguous — same way the resolver punts).
+
+Branch on `target_path.includes("/")` to distinguish "create at this path" from "create anywhere by basename." Cross-folder same-basename collisions stay visible as separate work items rather than masquerading as one.
 
 Full reference at `GET /llms.txt` or `GET /help`.
 

--- a/README.md
+++ b/README.md
@@ -84,16 +84,22 @@ Drop this under your watched root as `iarpa/example.html` and it'll be a fully-i
 Default base URL: `http://localhost:8062` for Docker, `http://localhost:8000` for npm. No auth (loopback bind). All POSTs are JSON.
 
 ```
-POST /query        { folder?, kinds?, has_tag?[], not_tag?[], text?, limit?, offset? }
-POST /tag          { path, key, value? }
-POST /untag        { path, key }
+POST /query     { folder?, kinds?, has_tag?[], not_tag?[], text?, limit?, offset? }
+                → { artifacts: [{ path, kind, label, source_hash, properties, tags, created_at, updated_at }], total }
+POST /tag       { path, key, value? }
+                → { ok, path, key, value, previous_value, action }   # action ∈ created|updated|unchanged
+POST /untag     { path, key }
+                → { ok, path, key, existed }
 GET  /tags?path=...
+                → { path, tags: { key: value, ... } }
 GET  /backlinks?path=...
+                → { path, exists, demand, backlinks: [{ source_path, link_text, attrs, synced_at }] }
 GET  /redlinks?folder=...&limit=&offset=
-GET  /stats
-GET  /health       — liveness
-GET  /ready        — readiness (probes SQLite)
-GET  /llms.txt     — full API reference (also at /help)
+                → { redlinks: [{ target_path, demand, linked_from: [...] }], total }
+GET  /stats     → { artifacts: { total, text, asset }, links, redlinks, tag_keys }
+GET  /health    — liveness
+GET  /ready     — readiness (probes SQLite)
+GET  /llms.txt  — full API reference (also at /help)
 ```
 
 Two tag-key conventions coexist:
@@ -109,7 +115,7 @@ Two tag-key conventions coexist:
 
 **Reserved characters.** Tag KEYS may not contain `:` (`400 reserved_character`). The colon is the key/value separator in `has_tag` / `not_tag` query specs — a literal colon in the key would store fine but then collide on read with the (key, value) split. Pass the colon in the request shape (`{ key: "status", value: "published" }`), not in the key. Values may contain colons.
 
-`GET /redlinks` returns two shapes of `target_path`: HTML `<a class="wikilink" href="...">` resolves to an fs-relative path at extraction time (e.g. `iarpa/sources/missing.html`), while Markdown `[[X]]` keeps the literal slug (e.g. `missing-topic`) until a matching artifact lands, then auto-converges. Branch on `target_path.includes("/")` if your harness needs to distinguish "create at this path" from "create anywhere by basename."
+`GET /redlinks` dedups HTML href and MD slug forms by lowercased basename-minus-extension: `<a href="./chloroplast.html">` and `[[chloroplast]]` collapse into one row whose `demand` sums both anchors and whose `linked_from` unions their source files. The returned `target_path` prefers the fs-relative form (e.g. `iarpa/chloroplast.html`) so harnesses get an actionable place to drop the file; it falls back to the bare slug only when no fs-path anchor exists. Branch on `target_path.includes("/")` to distinguish "create at this path" from "create anywhere by basename."
 
 Full reference at `GET /llms.txt` or `GET /help`.
 

--- a/packages/arkeon/scripts/manual-substrate-smoke.ts
+++ b/packages/arkeon/scripts/manual-substrate-smoke.ts
@@ -432,22 +432,32 @@ async function runChecks(): Promise<void> {
       (rl: any) => rl.target_path === "iarpa/drought-index.html",
     );
     check(
-      "redlink target_path = iarpa/drought-index.html (HTML wikilink to missing file)",
+      "redlink target_path = iarpa/drought-index.html (HTML wikilink to missing file; preferred over the bare slug)",
       droughtIndex != null,
     );
     check(
-      "linked_from is a real source path, NOT character-shredded (regression on GROUP_CONCAT bug)",
-      droughtIndex?.linked_from?.[0] === "iarpa/article.html" &&
+      "linked_from is real source paths, NOT character-shredded (regression on GROUP_CONCAT bug)",
+      Array.isArray(droughtIndex?.linked_from) &&
         droughtIndex.linked_from.every((s: string) => s.length > 1),
       JSON.stringify(droughtIndex?.linked_from),
     );
-
-    const droughtMd = r.body.redlinks.find(
-      (rl: any) => rl.target_path === "drought-index",
+    // HTML href (./drought-index.html from iarpa/article.html → iarpa/drought-index.html)
+    // and MD [[drought-index]] (from iarpa/sources/notes.md) dedup into one row.
+    check(
+      "dedup: demand=2 sums both HTML href + MD slug anchors at the same basename",
+      droughtIndex?.demand === 2,
+      `demand=${droughtIndex?.demand}`,
     );
     check(
-      "MD [[drought-index]] surfaces as a redlink (basename verbatim)",
-      droughtMd != null,
+      "dedup: linked_from unions both source files",
+      Array.isArray(droughtIndex?.linked_from) &&
+        droughtIndex.linked_from.includes("iarpa/article.html") &&
+        droughtIndex.linked_from.includes("iarpa/sources/notes.md"),
+      JSON.stringify(droughtIndex?.linked_from),
+    );
+    check(
+      "dedup: bare slug `drought-index` does NOT appear as a separate redlink row",
+      r.body.redlinks.find((rl: any) => rl.target_path === "drought-index") == null,
     );
   }
 

--- a/packages/arkeon/src/server/lib/entities.ts
+++ b/packages/arkeon/src/server/lib/entities.ts
@@ -220,21 +220,97 @@ export interface ListRedlinksOptions {
 }
 
 /**
- * Normalize a redlink target for dedup grouping: lowercased basename
- * with the trailing extension stripped. Collapses the two target_path
- * shapes that point at the same unresolved artifact — HTML
- * `<a href="chloroplast.html">` (fs-relative path, possibly folder-
- * prefixed) and MD `[[chloroplast]]` (literal slug) — into one
- * redlink row. Mirrors the wiki's shortest-unique-basename
- * resolution: both forms WOULD resolve to the same artifact if it
- * existed under any folder.
+ * fs-path form = the target carries a folder ("/") or extension (".").
+ * Slug form = neither — only emitted by Markdown `[[X]]` redlinks that
+ * stay literal until a basename match lands. (Strictly: HTML hrefs
+ * always normalize to a path with at least a "." or "/", so fs-form
+ * uniquely identifies "the harness needs to drop a file at this path"
+ * vs. "the harness can drop a file at any basename match.")
  */
-function normalizeRedlinkTarget(target: string): string {
+function isFsPathForm(target: string): boolean {
+  return target.includes("/") || target.includes(".");
+}
+
+/** Lowercased basename with the trailing extension stripped. */
+function basenameStem(target: string): string {
   const slashIdx = target.lastIndexOf("/");
   const base = slashIdx >= 0 ? target.slice(slashIdx + 1) : target;
   const dotIdx = base.lastIndexOf(".");
   const stem = dotIdx > 0 ? base.slice(0, dotIdx) : base;
   return stem.toLowerCase();
+}
+
+type RedlinkBucket = { target_path: string; sources: string[] };
+
+/**
+ * Group raw redlink anchor rows into dedup buckets. Mirrors the
+ * substrate's link-resolution semantics so the queue summary doesn't
+ * lie about how anchors WILL resolve when a file lands:
+ *
+ *   - Each unique fs-path target stays its own row. `iarpa/wiki.html`
+ *     and `chartbook/wiki.html` are two distinct gaps — creating one
+ *     file resolves anchors that named exactly that path; cross-folder
+ *     anchors at the same basename do not collapse.
+ *
+ *   - An MD slug redlink (`[[wiki]]`, no slash/dot) merges into a fs-
+ *     path bucket IFF exactly one fs-path bucket shares its basename
+ *     stem. That's the same condition `resolveWikilink()` uses to
+ *     resolve `[[wiki]]` at extraction time — one match wins; zero or
+ *     two+ leave the slug literal. So the slug shows as its own row
+ *     when (a) no fs-path anchor exists for it yet or (b) the basename
+ *     is ambiguous across folders.
+ *
+ * Net effect: `demand` and `linked_from` describe a concrete unit of
+ * work — "create the file at this path and these N anchors resolve."
+ * Cross-folder same-basename anchors stay visible as separate work
+ * items rather than masquerading as one.
+ */
+function aggregateRedlinks(
+  rows: Array<{ target_path: string; source_path: string }>,
+): RedlinkBucket[] {
+  const fsBuckets = new Map<string, RedlinkBucket>();
+  const slugBuckets = new Map<string, RedlinkBucket>();
+  for (const r of rows) {
+    if (isFsPathForm(r.target_path)) {
+      let b = fsBuckets.get(r.target_path);
+      if (!b) {
+        b = { target_path: r.target_path, sources: [] };
+        fsBuckets.set(r.target_path, b);
+      }
+      b.sources.push(r.source_path);
+    } else {
+      const key = r.target_path.toLowerCase();
+      let b = slugBuckets.get(key);
+      if (!b) {
+        b = { target_path: r.target_path, sources: [] };
+        slugBuckets.set(key, b);
+      }
+      b.sources.push(r.source_path);
+    }
+  }
+
+  const fsByStem = new Map<string, RedlinkBucket[]>();
+  for (const b of fsBuckets.values()) {
+    const stem = basenameStem(b.target_path);
+    let arr = fsByStem.get(stem);
+    if (!arr) {
+      arr = [];
+      fsByStem.set(stem, arr);
+    }
+    arr.push(b);
+  }
+
+  const standaloneSlugs: RedlinkBucket[] = [];
+  for (const slug of slugBuckets.values()) {
+    const matches = fsByStem.get(slug.target_path.toLowerCase()) ?? [];
+    if (matches.length === 1) {
+      matches[0].sources.push(...slug.sources);
+    } else {
+      standaloneSlugs.push(slug);
+    }
+  }
+
+  return [...fsBuckets.values(), ...standaloneSlugs];
 }
 
 export async function listRedlinks(opts: ListRedlinksOptions): Promise<RedlinkResult> {
@@ -251,11 +327,11 @@ export async function listRedlinks(opts: ListRedlinksOptions): Promise<RedlinkRe
   }
   const whereSql = `WHERE ${where.join(" AND ")}`;
 
-  // Pull every unresolved anchor and dedup MD-slug vs HTML-fs-path
-  // forms in JS. Computing "lowercased basename minus extension"
-  // purely in SQLite (no REVERSE, no rfind) is hairier than the
-  // savings warrant; the redlink queue is bounded by the unresolved-
-  // link count, which stays small in practice.
+  // Pull every unresolved anchor and group in JS. The slug-into-fs-
+  // path merge depends on a corpus-wide basename uniqueness check
+  // that's awkward in SQLite (no REVERSE, no rfind); the redlink
+  // queue is bounded by the unresolved-link count, which stays small
+  // in practice.
   const rows = (await sql.query(
     `SELECT l.target_path, l.source_path
      FROM links l
@@ -264,36 +340,20 @@ export async function listRedlinks(opts: ListRedlinksOptions): Promise<RedlinkRe
     params,
   )) as Array<{ target_path: string; source_path: string }>;
 
-  type Group = { targets: Set<string>; sources: string[] };
-  const groups = new Map<string, Group>();
-  for (const r of rows) {
-    const norm = normalizeRedlinkTarget(r.target_path);
-    let g = groups.get(norm);
-    if (!g) {
-      g = { targets: new Set(), sources: [] };
-      groups.set(norm, g);
-    }
-    g.targets.add(r.target_path);
-    g.sources.push(r.source_path);
-  }
+  const buckets = aggregateRedlinks(rows);
 
-  // Representative target_path: prefer the fs-path form (slash or
-  // dot) so harnesses get an actionable place to drop the file;
-  // tie-break alphabetic for stability.
-  const aggregated: RedlinkRow[] = Array.from(groups.values()).map((g) => {
-    const targets = [...g.targets].sort();
-    const fsForm = targets.find((t) => t.includes("/") || t.includes("."));
+  const aggregated: RedlinkRow[] = buckets.map((b) => {
     const seen = new Set<string>();
     const linked_from: string[] = [];
-    for (const s of g.sources) {
+    for (const s of b.sources) {
       if (seen.has(s)) continue;
       seen.add(s);
       linked_from.push(s);
       if (linked_from.length === 3) break;
     }
     return {
-      target_path: fsForm ?? targets[0],
-      demand: g.sources.length,
+      target_path: b.target_path,
+      demand: b.sources.length,
       linked_from,
     };
   });
@@ -486,18 +546,19 @@ export async function getStats(): Promise<CorpusStats> {
     `SELECT COUNT(*) AS n FROM links`,
     [],
   )) as { n: number }[];
-  // Count redlinks via the same dedup as listRedlinks — `chloroplast.html`
-  // and `chloroplast` collapse into one. Counting DISTINCT target_path in
-  // SQL would double-count them; keep both numbers in agreement.
-  const redlinkTargets = (await sql.query(
-    `SELECT DISTINCT l.target_path FROM links l
+  // Count redlinks via the same aggregation as listRedlinks so the
+  // corpus number agrees with the row count harnesses see. We need the
+  // raw (target_path, source_path) rows for aggregateRedlinks because
+  // the slug-into-fs-path merge depends on whether the slug's basename
+  // has exactly one fs-path match — a corpus-wide condition that can't
+  // be derived from DISTINCT target_path alone.
+  const redlinkRows = (await sql.query(
+    `SELECT l.target_path, l.source_path FROM links l
      LEFT JOIN artifacts a ON a.path = l.target_path
      WHERE a.path IS NULL`,
     [],
-  )) as { target_path: string }[];
-  const normalizedRedlinks = new Set<string>();
-  for (const r of redlinkTargets) normalizedRedlinks.add(normalizeRedlinkTarget(r.target_path));
-  const redlinksN = normalizedRedlinks.size;
+  )) as Array<{ target_path: string; source_path: string }>;
+  const redlinksN = aggregateRedlinks(redlinkRows).length;
   const [{ n: tagKeysN }] = (await sql.query(
     `SELECT COUNT(DISTINCT key) AS n FROM tags`,
     [],

--- a/packages/arkeon/src/server/lib/entities.ts
+++ b/packages/arkeon/src/server/lib/entities.ts
@@ -219,6 +219,24 @@ export interface ListRedlinksOptions {
   offset?: number | null;
 }
 
+/**
+ * Normalize a redlink target for dedup grouping: lowercased basename
+ * with the trailing extension stripped. Collapses the two target_path
+ * shapes that point at the same unresolved artifact — HTML
+ * `<a href="chloroplast.html">` (fs-relative path, possibly folder-
+ * prefixed) and MD `[[chloroplast]]` (literal slug) — into one
+ * redlink row. Mirrors the wiki's shortest-unique-basename
+ * resolution: both forms WOULD resolve to the same artifact if it
+ * existed under any folder.
+ */
+function normalizeRedlinkTarget(target: string): string {
+  const slashIdx = target.lastIndexOf("/");
+  const base = slashIdx >= 0 ? target.slice(slashIdx + 1) : target;
+  const dotIdx = base.lastIndexOf(".");
+  const stem = dotIdx > 0 ? base.slice(0, dotIdx) : base;
+  return stem.toLowerCase();
+}
+
 export async function listRedlinks(opts: ListRedlinksOptions): Promise<RedlinkResult> {
   const sql = createSql();
   const limit = Math.min(Math.max(opts.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
@@ -233,41 +251,62 @@ export async function listRedlinks(opts: ListRedlinksOptions): Promise<RedlinkRe
   }
   const whereSql = `WHERE ${where.join(" AND ")}`;
 
-  const totalRow = (await sql.query(
-    `SELECT COUNT(DISTINCT l.target_path) AS n
+  // Pull every unresolved anchor and dedup MD-slug vs HTML-fs-path
+  // forms in JS. Computing "lowercased basename minus extension"
+  // purely in SQLite (no REVERSE, no rfind) is hairier than the
+  // savings warrant; the redlink queue is bounded by the unresolved-
+  // link count, which stays small in practice.
+  const rows = (await sql.query(
+    `SELECT l.target_path, l.source_path
      FROM links l
      LEFT JOIN artifacts a ON a.path = l.target_path
      ${whereSql}`,
     params,
-  )) as { n: number }[];
-  const total = Number(totalRow[0]?.n ?? 0);
+  )) as Array<{ target_path: string; source_path: string }>;
 
-  // U+001F (ASCII Unit Separator) — a control character that can't
-  // appear in a filesystem path, so we can split the GROUP_CONCAT
-  // result back into individual source paths losslessly. Interpolate
-  // through char(31) on the SQL side so the source-level character
-  // is visible (not a hidden control byte embedded in a string literal).
-  const rows = (await sql.query(
-    `SELECT l.target_path,
-            COUNT(*) AS demand,
-            GROUP_CONCAT(l.source_path, char(31)) AS linked_from_concat
-     FROM links l
-     LEFT JOIN artifacts a ON a.path = l.target_path
-     ${whereSql}
-     GROUP BY l.target_path
-     ORDER BY demand DESC, l.target_path ASC
-     LIMIT ? OFFSET ?`,
-    [...params, limit, offset],
-  )) as Array<{ target_path: string; demand: number; linked_from_concat: string }>;
+  type Group = { targets: Set<string>; sources: string[] };
+  const groups = new Map<string, Group>();
+  for (const r of rows) {
+    const norm = normalizeRedlinkTarget(r.target_path);
+    let g = groups.get(norm);
+    if (!g) {
+      g = { targets: new Set(), sources: [] };
+      groups.set(norm, g);
+    }
+    g.targets.add(r.target_path);
+    g.sources.push(r.source_path);
+  }
 
-  const redlinks: RedlinkRow[] = rows.map((r) => ({
-    target_path: r.target_path,
-    demand: Number(r.demand),
-    linked_from: (r.linked_from_concat ?? "")
-      .split("\x1f")
-      .filter(Boolean)
-      .slice(0, 3),
-  }));
+  // Representative target_path: prefer the fs-path form (slash or
+  // dot) so harnesses get an actionable place to drop the file;
+  // tie-break alphabetic for stability.
+  const aggregated: RedlinkRow[] = Array.from(groups.values()).map((g) => {
+    const targets = [...g.targets].sort();
+    const fsForm = targets.find((t) => t.includes("/") || t.includes("."));
+    const seen = new Set<string>();
+    const linked_from: string[] = [];
+    for (const s of g.sources) {
+      if (seen.has(s)) continue;
+      seen.add(s);
+      linked_from.push(s);
+      if (linked_from.length === 3) break;
+    }
+    return {
+      target_path: fsForm ?? targets[0],
+      demand: g.sources.length,
+      linked_from,
+    };
+  });
+
+  aggregated.sort((a, b) => {
+    if (a.demand !== b.demand) return b.demand - a.demand;
+    if (a.target_path < b.target_path) return -1;
+    if (a.target_path > b.target_path) return 1;
+    return 0;
+  });
+
+  const total = aggregated.length;
+  const redlinks = aggregated.slice(offset, offset + limit);
 
   return { redlinks, total };
 }
@@ -447,14 +486,18 @@ export async function getStats(): Promise<CorpusStats> {
     `SELECT COUNT(*) AS n FROM links`,
     [],
   )) as { n: number }[];
-  const [{ n: redlinksN }] = (await sql.query(
-    `SELECT COUNT(*) AS n FROM (
-       SELECT DISTINCT l.target_path FROM links l
-       LEFT JOIN artifacts a ON a.path = l.target_path
-       WHERE a.path IS NULL
-     )`,
+  // Count redlinks via the same dedup as listRedlinks — `chloroplast.html`
+  // and `chloroplast` collapse into one. Counting DISTINCT target_path in
+  // SQL would double-count them; keep both numbers in agreement.
+  const redlinkTargets = (await sql.query(
+    `SELECT DISTINCT l.target_path FROM links l
+     LEFT JOIN artifacts a ON a.path = l.target_path
+     WHERE a.path IS NULL`,
     [],
-  )) as { n: number }[];
+  )) as { target_path: string }[];
+  const normalizedRedlinks = new Set<string>();
+  for (const r of redlinkTargets) normalizedRedlinks.add(normalizeRedlinkTarget(r.target_path));
+  const redlinksN = normalizedRedlinks.size;
   const [{ n: tagKeysN }] = (await sql.query(
     `SELECT COUNT(DISTINCT key) AS n FROM tags`,
     [],

--- a/packages/arkeon/src/server/lib/llms-txt.ts
+++ b/packages/arkeon/src/server/lib/llms-txt.ts
@@ -85,18 +85,51 @@ binary's filename basename, NOT the embedded \`<title>\` — that keeps
 ## Link conventions
 
 HTML: \`<a class="wikilink" href="./topic-x">topic X</a>\`. Only
-anchors with \`wikilink\` in their class list become graph edges.
-Other \`<a>\` elements render as ordinary HTML. Hrefs resolve
-relative to the source file's directory:
-\`./sources/x.pdf\` from \`iarpa/y.html\` → \`iarpa/sources/x.pdf\`.
+anchors with \`wikilink\` in their class list become graph edges;
+other \`<a>\` elements render as ordinary HTML. Hrefs resolve
+relative to the source file's directory (browser-style):
 
-Markdown: \`[[X]]\` resolves by shortest-unique-basename match
-against the artifact index. \`[[folder/X]]\` works for
-disambiguation. \`[[X|Display]]\` carries an alias. If \`[[X]]\` is
-written before its target exists, the link row stays as the
-literal slug — but converges to the resolved path automatically as
-soon as the target lands (either during initial reconcile or via
-a live watcher event).
+  - \`./topic-x.html\` from \`iarpa/notes.html\` → \`iarpa/topic-x.html\`
+  - \`topic-x.html\` from \`iarpa/notes.html\` → \`iarpa/topic-x.html\`
+    (the leading \`./\` is decorative; both forms identical)
+  - \`../chartbook/x.html\` from \`iarpa/notes.html\` → \`chartbook/x.html\`
+  - \`/x.html\` → dropped (server-absolute paths are out of scope —
+    the watched root has no notion of "server root")
+  - \`https://...\` (or any \`scheme:\`) → dropped
+  - paths that escape the watched root → dropped
+
+Markdown: \`[[X]]\` resolves by basename match — looks for any
+artifact whose basename (with or without extension) equals \`X\`
+case-insensitively.
+
+  - **Exactly one match** → resolves to that artifact's path.
+  - **Zero matches** → stays unresolved; target stored as the
+    literal slug. Auto-converges if/when exactly one matching
+    artifact lands (during initial reconcile or via live watcher
+    event).
+  - **Multiple matches** → stays unresolved (ambiguous).
+    Disambiguate with \`[[folder/X]]\` or \`[[folder/X.html]]\`.
+
+\`[[folder/X]]\` is treated as a path-form: normalized relative to
+the source file's directory if it starts with \`./\` or \`../\`,
+otherwise relative to the watched root. \`[[X|Display]]\` carries
+an alias for \`link_text\`.
+
+**Same basename in different folders is the norm, not a
+collision.** \`iarpa/wiki.html\` and \`chartbook/wiki.html\` are two
+distinct artifacts, each with its own backlink graph. An MD
+\`[[wiki]]\` from anywhere in the corpus only resolves if exactly
+one \`wiki.*\` exists. Write \`[[iarpa/wiki]]\` or
+\`[[chartbook/wiki]]\` for an unambiguous cross-folder link. The
+HTML equivalent from a sibling-folder source is
+\`<a class="wikilink" href="../chartbook/wiki.html">\`.
+
+**Prefer \`[[folder/X]]\` over HTML's \`../folder/X.html\` for
+cross-folder links.** The MD form is stable when the SOURCE file
+moves between folders (the resolver walks from the source's
+directory; the path-form normalizes consistently). HTML's
+\`../folder/X.html\` form breaks when you move the source because
+\`../\` is now interpreted from a different starting point.
 
 Citation metadata: \`<a class="wikilink" data-quote="..." data-page="3"
 data-cite-type="evidence" href="./paper.pdf.html">paper</a>\`. Every
@@ -308,30 +341,36 @@ discovery loop building a work queue uses \`/redlinks\`.
 }
 \`\`\`
 
-The work-to-be-written queue.
+The work-to-be-written queue. One row = one concrete unit of work.
 
-**Two link syntaxes, one redlink row.** HTML
-\`<a class="wikilink" href="./missing.html">\` and Markdown
-\`[[missing]]\` both surface as unresolved targets, but they enter the
-index in different shapes:
+**Aggregation mirrors the resolver.** \`/redlinks\` groups anchors the
+same way the substrate resolves links, so a row represents the
+anchors that WILL resolve when a single file lands:
 
-  - **HTML** hrefs resolve to an fs-relative path under the watched
-    root (e.g. \`iarpa/sources/missing.html\`).
-  - **Markdown** \`[[X]]\` keeps the literal slug (e.g.
-    \`missing\`, no slashes) until a matching artifact lands and
-    converges via shortest-unique-basename resolution.
+  - **Each unique fs-path target is its own row.** HTML
+    \`<a class="wikilink" href="...">\` always lands as an fs-relative
+    path (e.g. \`iarpa/missing.html\`). \`iarpa/wiki.html\` and
+    \`chartbook/wiki.html\` are two distinct redlinks — creating one
+    file does NOT resolve anchors that named the other.
+  - **MD slug redlinks** (\`[[X]]\` with no slash or extension) merge
+    into a fs-path row only when the slug's basename has EXACTLY ONE
+    fs-path match in the queue — the same condition under which
+    \`[[X]]\` would auto-resolve once the file lands. Zero matches:
+    slug stays as its own row (target=\`X\`); two+ matches: slug stays
+    standalone too (ambiguous; the resolver would punt the same way).
 
-The endpoint deduplicates across the two shapes by lowercased
-basename-minus-extension, so \`./missing.html\`, \`folder/missing.html\`,
-and \`[[missing]]\` aggregate into one row whose \`demand\` sums all
-anchors and whose \`linked_from\` unions the source files. The
-returned \`target_path\` prefers the fs-relative form (so harnesses
-have an actionable path to create the file at); the slug form only
-surfaces if no fs-path anchor exists.
+So a \`[[chloroplast]]\` slug + a single \`iarpa/chloroplast.html\`
+fs-path anchor surface as one row whose \`demand\` sums both anchors
+and whose \`linked_from\` unions both source files. But two cross-
+folder fs-paths sharing a basename (e.g. \`iarpa/wiki.html\` and
+\`chartbook/wiki.html\`) stay as two rows — plus a third row for any
+\`[[wiki]]\` slug, because the slug is ambiguous and can't be
+attributed to either fs-path safely.
 
 Branch on \`target_path.includes("/")\` ⇒ fs-relative path (suggests
 where to create the file); otherwise ⇒ MD slug (resolves by basename
-anywhere under the watched root once written).
+anywhere under the watched root once exactly one matching file
+lands).
 
 ### GET /stats
 

--- a/packages/arkeon/src/server/lib/llms-txt.ts
+++ b/packages/arkeon/src/server/lib/llms-txt.ts
@@ -310,25 +310,28 @@ discovery loop building a work queue uses \`/redlinks\`.
 
 The work-to-be-written queue.
 
-**Two \`target_path\` shapes coexist** because the two link syntaxes
-resolve differently:
+**Two link syntaxes, one redlink row.** HTML
+\`<a class="wikilink" href="./missing.html">\` and Markdown
+\`[[missing]]\` both surface as unresolved targets, but they enter the
+index in different shapes:
 
-  - **HTML \`<a class="wikilink" href="./missing.html">\`** — hrefs are
-    resolved relative to the source file's directory at extraction
-    time, so a redlink \`target_path\` looks like an fs-relative path
-    under the watched root (e.g. \`iarpa/sources/missing.html\`).
-  - **Markdown \`[[missing-topic]]\`** — resolved by shortest-unique-
-    basename match against the artifact index. If no match exists,
-    the row keeps the literal slug as \`target_path\` (e.g.
-    \`missing-topic\`, no slashes). Once a matching artifact lands the
-    row auto-converges to the resolved fs path on the next reconcile
-    pass — that "literal until resolved" contract is what lets the MD
-    redlink converge later without manual rewiring.
+  - **HTML** hrefs resolve to an fs-relative path under the watched
+    root (e.g. \`iarpa/sources/missing.html\`).
+  - **Markdown** \`[[X]]\` keeps the literal slug (e.g.
+    \`missing\`, no slashes) until a matching artifact lands and
+    converges via shortest-unique-basename resolution.
 
-Harnesses building work queues can branch on the shape:
-\`target_path.includes("/")\` ⇒ fs-relative path (suggests where to
-create the file); otherwise ⇒ MD slug (resolves by basename anywhere
-under the watched root once written).
+The endpoint deduplicates across the two shapes by lowercased
+basename-minus-extension, so \`./missing.html\`, \`folder/missing.html\`,
+and \`[[missing]]\` aggregate into one row whose \`demand\` sums all
+anchors and whose \`linked_from\` unions the source files. The
+returned \`target_path\` prefers the fs-relative form (so harnesses
+have an actionable path to create the file at); the slug form only
+surfaces if no fs-path anchor exists.
+
+Branch on \`target_path.includes("/")\` ⇒ fs-relative path (suggests
+where to create the file); otherwise ⇒ MD slug (resolves by basename
+anywhere under the watched root once written).
 
 ### GET /stats
 

--- a/packages/arkeon/test/e2e/substrate.test.ts
+++ b/packages/arkeon/test/e2e/substrate.test.ts
@@ -41,6 +41,18 @@ beforeAll(async () => {
     join(workdir, "chartbook/about.html"),
     `<!doctype html><html><head><title>Chartbook</title></head><body><p>chart</p></body></html>`,
   );
+  // Two unresolved anchors at the same basename ("chloroplast") via the
+  // two link syntaxes: HTML href lands as fs-relative path
+  // (iarpa/chloroplast.html), MD [[X]] stays as a literal slug
+  // (chloroplast). /redlinks should dedup them into one row.
+  writeFileSync(
+    join(workdir, "iarpa/notes.html"),
+    `<!doctype html><html><head><title>Notes</title></head><body><p>See <a class="wikilink" href="./chloroplast.html">chloroplast</a>.</p></body></html>`,
+  );
+  writeFileSync(
+    join(workdir, "iarpa/sources/notes.md"),
+    `# Notes\n\nSee [[chloroplast]] for context.\n`,
+  );
 
   await startWatching(workdir);
   app = createApp();
@@ -351,6 +363,30 @@ describe("substrate", () => {
     const missing = body.redlinks.find((r) => r.target_path === "missing-target")!;
     expect(missing.linked_from).toEqual(["iarpa/sources/paper.md"]);
     expect(missing.demand).toBe(1);
+  });
+
+  it("GET /redlinks dedups HTML href vs MD slug forms of the same target", async () => {
+    // iarpa/notes.html links to ./chloroplast.html (fs-path form)
+    // iarpa/sources/notes.md links to [[chloroplast]] (slug form)
+    // Both resolve to the same unresolved artifact; one redlink row.
+    const res = await app.fetch(new Request("http://test/redlinks"));
+    const body = (await res.json()) as {
+      redlinks: Array<{ target_path: string; demand: number; linked_from: string[] }>;
+      total: number;
+    };
+    const chloroplastRows = body.redlinks.filter(
+      (r) => r.target_path === "chloroplast" || r.target_path.endsWith("/chloroplast.html") || r.target_path === "chloroplast.html",
+    );
+    expect(chloroplastRows).toHaveLength(1);
+    const row = chloroplastRows[0];
+    // Representative target_path prefers the fs-path form so harnesses
+    // get an actionable file location.
+    expect(row.target_path).toBe("iarpa/chloroplast.html");
+    expect(row.demand).toBe(2);
+    expect(row.linked_from.sort()).toEqual([
+      "iarpa/notes.html",
+      "iarpa/sources/notes.md",
+    ]);
   });
 
   it("POST /query filters by documented `kinds` array (not legacy `kind`)", async () => {

--- a/packages/arkeon/test/e2e/substrate.test.ts
+++ b/packages/arkeon/test/e2e/substrate.test.ts
@@ -41,10 +41,11 @@ beforeAll(async () => {
     join(workdir, "chartbook/about.html"),
     `<!doctype html><html><head><title>Chartbook</title></head><body><p>chart</p></body></html>`,
   );
-  // Two unresolved anchors at the same basename ("chloroplast") via the
-  // two link syntaxes: HTML href lands as fs-relative path
-  // (iarpa/chloroplast.html), MD [[X]] stays as a literal slug
-  // (chloroplast). /redlinks should dedup them into one row.
+  // chloroplast: unique fs-path basename match. HTML href from
+  // iarpa/notes.html resolves to iarpa/chloroplast.html; MD
+  // [[chloroplast]] from iarpa/sources/notes.md stays as a literal
+  // slug. /redlinks should merge the slug into the fs-path row because
+  // the slug's basename has exactly one fs-path match.
   writeFileSync(
     join(workdir, "iarpa/notes.html"),
     `<!doctype html><html><head><title>Notes</title></head><body><p>See <a class="wikilink" href="./chloroplast.html">chloroplast</a>.</p></body></html>`,
@@ -52,6 +53,24 @@ beforeAll(async () => {
   writeFileSync(
     join(workdir, "iarpa/sources/notes.md"),
     `# Notes\n\nSee [[chloroplast]] for context.\n`,
+  );
+  // biology: cross-folder same-basename collision. Two distinct
+  // fs-path redlinks (iarpa/biology.html, chartbook/biology.html) and
+  // a MD slug [[biology]] whose basename has TWO fs-path matches.
+  // /redlinks should keep all three as separate rows — the slug
+  // can't merge because it's ambiguous, and creating either fs-path
+  // file does NOT resolve the other.
+  writeFileSync(
+    join(workdir, "iarpa/biology-source.html"),
+    `<!doctype html><html><head><title>Biology (iarpa)</title></head><body><p>See <a class="wikilink" href="./biology.html">biology overview</a>.</p></body></html>`,
+  );
+  writeFileSync(
+    join(workdir, "chartbook/biology-source.html"),
+    `<!doctype html><html><head><title>Biology (chartbook)</title></head><body><p>See <a class="wikilink" href="./biology.html">biology overview</a>.</p></body></html>`,
+  );
+  writeFileSync(
+    join(workdir, "iarpa/sources/bio.md"),
+    `# Bio\n\nRelated: [[biology]].\n`,
   );
 
   await startWatching(workdir);
@@ -365,28 +384,65 @@ describe("substrate", () => {
     expect(missing.demand).toBe(1);
   });
 
-  it("GET /redlinks dedups HTML href vs MD slug forms of the same target", async () => {
-    // iarpa/notes.html links to ./chloroplast.html (fs-path form)
-    // iarpa/sources/notes.md links to [[chloroplast]] (slug form)
-    // Both resolve to the same unresolved artifact; one redlink row.
+  it("GET /redlinks merges MD slug into a UNIQUE fs-path basename match", async () => {
+    // iarpa/notes.html links to ./chloroplast.html (fs-path form
+    // iarpa/chloroplast.html). iarpa/sources/notes.md has [[chloroplast]]
+    // (slug). Creating iarpa/chloroplast.html resolves BOTH anchors —
+    // the slug auto-converges via shortest-unique-basename. So the
+    // redlink queue surfaces one row; demand=2 reflects the real
+    // unit of work.
     const res = await app.fetch(new Request("http://test/redlinks"));
     const body = (await res.json()) as {
       redlinks: Array<{ target_path: string; demand: number; linked_from: string[] }>;
       total: number;
     };
     const chloroplastRows = body.redlinks.filter(
-      (r) => r.target_path === "chloroplast" || r.target_path.endsWith("/chloroplast.html") || r.target_path === "chloroplast.html",
+      (r) =>
+        r.target_path === "chloroplast" ||
+        r.target_path.endsWith("/chloroplast.html") ||
+        r.target_path === "chloroplast.html",
     );
     expect(chloroplastRows).toHaveLength(1);
     const row = chloroplastRows[0];
-    // Representative target_path prefers the fs-path form so harnesses
-    // get an actionable file location.
     expect(row.target_path).toBe("iarpa/chloroplast.html");
     expect(row.demand).toBe(2);
     expect(row.linked_from.sort()).toEqual([
       "iarpa/notes.html",
       "iarpa/sources/notes.md",
     ]);
+  });
+
+  it("GET /redlinks keeps cross-folder same-basename fs-paths as separate gaps", async () => {
+    // iarpa/biology-source.html and chartbook/biology-source.html each
+    // link to ./biology.html — two distinct unresolved fs-paths
+    // (iarpa/biology.html, chartbook/biology.html). They are NOT the
+    // same gap: creating iarpa/biology.html doesn't resolve the
+    // chartbook anchor and vice versa. The substrate's MD resolver
+    // would punt on [[biology]] with two matches, so the slug also
+    // stays as its own row rather than merging into either fs-path.
+    const res = await app.fetch(new Request("http://test/redlinks"));
+    const body = (await res.json()) as {
+      redlinks: Array<{ target_path: string; demand: number; linked_from: string[] }>;
+    };
+    const biologyRows = body.redlinks.filter(
+      (r) =>
+        r.target_path === "biology" ||
+        r.target_path === "iarpa/biology.html" ||
+        r.target_path === "chartbook/biology.html",
+    );
+    expect(biologyRows).toHaveLength(3);
+
+    const iarpaRow = biologyRows.find((r) => r.target_path === "iarpa/biology.html")!;
+    expect(iarpaRow.demand).toBe(1);
+    expect(iarpaRow.linked_from).toEqual(["iarpa/biology-source.html"]);
+
+    const chartbookRow = biologyRows.find((r) => r.target_path === "chartbook/biology.html")!;
+    expect(chartbookRow.demand).toBe(1);
+    expect(chartbookRow.linked_from).toEqual(["chartbook/biology-source.html"]);
+
+    const slugRow = biologyRows.find((r) => r.target_path === "biology")!;
+    expect(slugRow.demand).toBe(1);
+    expect(slugRow.linked_from).toEqual(["iarpa/sources/bio.md"]);
   });
 
   it("POST /query filters by documented `kinds` array (not legacy `kind`)", async () => {


### PR DESCRIPTION
## Summary

Three changes, one PR:

- **#186 — redlink dedup (reshape after review).** `listRedlinks` (`packages/arkeon/src/server/lib/entities.ts`) now aggregates the queue the same way the substrate resolves links, so a row = one concrete unit of work:
  - Each unique fs-path target stays its own row. `iarpa/wiki.html` and `chartbook/wiki.html` are two distinct gaps — creating one file does NOT resolve anchors that named the other.
  - An MD slug redlink (`[[X]]`, no slash/dot) merges into a fs-path row iff the slug's basename has exactly one fs-path match — the same condition `resolveWikilink()` uses at extraction time. Zero or two+ matches: slug stays standalone.
  - `getStats` uses the same aggregator so corpus count agrees with `/redlinks` total.
- **#187 — README response shapes.** Inlined one-line response shapes under each route. Full schema still at `/llms.txt`.
- **Link-conventions docs expansion.** `llms.txt` Link conventions section rewritten to cover what an agent writing a wiki actually needs: HTML href resolution (incl. `..`, `/`, schemes, escape-root drops), MD basename match outcomes (1 / 0 / many), cross-folder same-basename as the norm, and `[[folder/X]]` as the move-stable cross-folder idiom. `/redlinks` block in `llms.txt` rewritten to match the narrower dedup contract.

Closes #186, closes #187.

## Test plan

- [x] `npm run typecheck -w packages/arkeon` — clean
- [x] `npm test -w packages/arkeon` — 240 unit tests pass
- [x] `npm run test:e2e -w packages/arkeon` — 38 e2e tests pass, including:
  - `GET /redlinks merges MD slug into a UNIQUE fs-path basename match` (chloroplast: 1 fs-path + 1 slug → 1 row, demand=2)
  - `GET /redlinks keeps cross-folder same-basename fs-paths as separate gaps` (biology: 2 fs-paths + 1 ambiguous slug → 3 rows)
- [ ] CI runs typecheck + unit + e2e on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)