### PR TITLE
stats: top-N tag keys + cli: in-container daemon fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ arkeon-wiki up [--watch-dir <path>]   # start the daemon detached
 arkeon-wiki down                      # stop it
 arkeon-wiki status                    # is it running?
 arkeon-wiki ls                        # list running instances
-arkeon-wiki where                     # which instance owns this directory?
+arkeon-wiki where                     # which daemon will my next command hit?
 arkeon-wiki logs [-f]                 # print/tail the daemon log
 arkeon-wiki start                     # foreground (for pm2/launchd/Docker/etc.)
 arkeon-wiki install                   # persistent service
@@ -173,7 +173,7 @@ arkeon-wiki reconcile                    # force a full re-walk + orphan-prune n
 
 Reading article bodies is *not* a CLI command — the filesystem is the read API. `cat`, `bat`, `$EDITOR` work fine; the daemon's job is the index, not the read path.
 
-**Daemon resolution.** Every substrate-API command picks a daemon in this order: `--api-url <url>` → `ARKEON_WIKI_URL` env → `--name <inst>` → CWD walk (deepest registered `watch_dir` containing your shell's cwd) → `default` instance → in-container fallback (`http://127.0.0.1:${PORT}` when `ARKEON_WIKI_IN_CONTAINER=1`, which the Dockerfile sets so `docker exec arkeon-wiki arkeon-wiki query` Just Works). Run `arkeon-wiki where` from inside a watched corpus to see which instance the CLI will hit. Exit codes: `0` success, `1` HTTP 4xx/5xx (response body on stderr), `2` network error.
+**Daemon resolution.** Every substrate-API command picks a daemon in this order: `--api-url <url>` → `ARKEON_WIKI_URL` env → `--name <inst>` → CWD walk (deepest registered `watch_dir` containing your shell's cwd) → `default` instance → in-container fallback (`http://127.0.0.1:${PORT}` when `ARKEON_WIKI_IN_CONTAINER=1`, which the Dockerfile sets so `docker exec arkeon-wiki arkeon-wiki query` Just Works). Run `arkeon-wiki where` to see exactly which source resolved and which `api_url` is on the other end. Exit codes: `0` success, `1` HTTP 4xx/5xx (response body on stderr), `2` network error.
 
 **`--api-url` placement.** `--api-url` is per-command, not program-level: write `arkeon-wiki query --api-url http://...` (the flag AFTER the subcommand). The program-level `--data-dir` flag still comes before the subcommand.
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ arkeon-wiki reconcile                    # force a full re-walk + orphan-prune n
 
 Reading article bodies is *not* a CLI command — the filesystem is the read API. `cat`, `bat`, `$EDITOR` work fine; the daemon's job is the index, not the read path.
 
-**Daemon resolution.** Every substrate-API command picks a daemon in this order: `--api-url <url>` → `ARKEON_WIKI_URL` env → `--name <inst>` → CWD walk (deepest registered `watch_dir` containing your shell's cwd) → `default` instance. Run `arkeon-wiki where` from inside a watched corpus to see which instance the CLI will hit. Exit codes: `0` success, `1` HTTP 4xx/5xx (response body on stderr), `2` network error.
+**Daemon resolution.** Every substrate-API command picks a daemon in this order: `--api-url <url>` → `ARKEON_WIKI_URL` env → `--name <inst>` → CWD walk (deepest registered `watch_dir` containing your shell's cwd) → `default` instance → in-container fallback (`http://127.0.0.1:${PORT}` when `ARKEON_WIKI_IN_CONTAINER=1`, which the Dockerfile sets so `docker exec arkeon-wiki arkeon-wiki query` Just Works). Run `arkeon-wiki where` from inside a watched corpus to see which instance the CLI will hit. Exit codes: `0` success, `1` HTTP 4xx/5xx (response body on stderr), `2` network error.
 
 **`--api-url` placement.** `--api-url` is per-command, not program-level: write `arkeon-wiki query --api-url http://...` (the flag AFTER the subcommand). The program-level `--data-dir` flag still comes before the subcommand.
 

--- a/packages/arkeon/src/cli/commands/api/stats.ts
+++ b/packages/arkeon/src/cli/commands/api/stats.ts
@@ -23,18 +23,26 @@ interface StatsResponse {
   tag_keys_top: Array<{ key: string; n: number }>;
 }
 
+interface StatsOptions {
+  tagKeysTop?: string;
+}
+
 export function registerStatsCommand(program: Command): void {
   const cmd = addCommonOptions(
     program
       .command("stats")
-      .description("Show corpus-level counts (artifacts, links, redlinks, tag keys)"),
+      .description("Show corpus-level counts (artifacts, links, redlinks, tag keys)")
+      .option(
+        "--tag-keys-top <n>",
+        "Number of top tag keys to include (default 10, max 100)",
+      ),
   );
-  cmd.action(async (_o: unknown, command: Command) => {
+  cmd.action(async (options: StatsOptions, command: Command) => {
     const g = readGlobals(command);
     const result = await apiCall<StatsResponse>(
       "GET",
       "/stats",
-      {},
+      { query: { tag_keys_top: options.tagKeysTop ?? null } },
       transportOptions(g),
     );
     if (g.json || !isTty()) {

--- a/packages/arkeon/src/cli/commands/api/stats.ts
+++ b/packages/arkeon/src/cli/commands/api/stats.ts
@@ -20,6 +20,7 @@ interface StatsResponse {
   links: number;
   redlinks: number;
   tag_keys: number;
+  tag_keys_top: Array<{ key: string; n: number }>;
 }
 
 export function registerStatsCommand(program: Command): void {
@@ -40,13 +41,17 @@ export function registerStatsCommand(program: Command): void {
       printJson(result);
       return;
     }
-    printKeyValue([
+    const rows: Array<[string, string]> = [
       ["artifacts.total", String(result.artifacts.total)],
       ["artifacts.text", String(result.artifacts.text)],
       ["artifacts.asset", String(result.artifacts.asset)],
       ["links", String(result.links)],
       ["redlinks", String(result.redlinks)],
       ["tag_keys", String(result.tag_keys)],
-    ]);
+    ];
+    for (const { key, n } of result.tag_keys_top) {
+      rows.push([`tag_keys_top.${key}`, String(n)]);
+    }
+    printKeyValue(rows);
   });
 }

--- a/packages/arkeon/src/cli/commands/local/where.ts
+++ b/packages/arkeon/src/cli/commands/local/where.ts
@@ -2,29 +2,33 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * `arkeon-wiki where` — print which running instance owns the current
- * working directory, along with the CWD-relative path inside its
- * watched root.
+ * `arkeon-wiki where` — print which daemon the next substrate-API
+ * command will target, and (when the answer is "an instance you have
+ * registered") which watch root + relative path inside it.
  *
  * Mirrors `git rev-parse --show-toplevel` / `git rev-parse --show-prefix`
- * — a small introspection command so users can sanity-check what every
- * other api-CLI command (`query`, `tag`, ...) will end up talking to.
+ * — a small introspection command so users can sanity-check what
+ * `query`, `tag`, etc. will end up talking to. Resolves via the full
+ * resolveTarget chain so the answer agrees with what other commands
+ * see (including the in-container fallback and `default`-instance
+ * fallback, which were invisible to `where` before).
  *
  * Exit codes:
- *   0  CWD is under a registered watch root
- *   1  no instance owns CWD (no daemon running, or CWD is outside)
+ *   0  resolveTarget found a target (any source)
+ *   1  resolveTarget threw (no daemon, --name miss, ...)
  */
 
 import type { Command } from "commander";
 
 import {
-  findInstanceForCwd,
   relativeToWatchDir,
+  resolveTarget,
 } from "../../lib/instance-resolve.js";
-import { listInstances } from "../../lib/instances.js";
 import { output } from "../../lib/output.js";
 
 interface WhereOptions {
+  apiUrl?: string;
+  name?: string;
   json?: boolean;
 }
 
@@ -32,53 +36,57 @@ export function registerWhereCommand(program: Command): void {
   program
     .command("where")
     .description(
-      "Show which running instance owns the current directory (watch root + relative path)",
+      "Show which daemon the next substrate-API command will target (resolution source + api_url)",
     )
+    .option("--api-url <url>", "Probe with an explicit api_url override")
+    .option("--name <name>", "Probe a specific named instance")
     .option("--json", "Emit JSON instead of a human-readable summary")
     .action((options: WhereOptions) => {
       const cwd = process.cwd();
-      const instances = listInstances();
-      const owner = findInstanceForCwd(cwd, instances);
 
-      if (!owner) {
+      let target: ReturnType<typeof resolveTarget>;
+      try {
+        target = resolveTarget({ apiUrl: options.apiUrl, name: options.name });
+      } catch (err) {
+        const message = (err as Error).message;
         if (options.json) {
-          output.error(
-            new Error(
-              `No running instance watches a directory containing ${cwd}.`,
-            ),
-            { operation: "where", code: "no_owner" },
-          );
+          output.error(new Error(message), { operation: "where", code: "unresolved" });
         } else {
-          process.stderr.write(
-            `No running instance watches a directory containing ${cwd}.\n` +
-              `  - Run \`arkeon-wiki ls\` to see what's running.\n` +
-              `  - Start one with \`arkeon-wiki up --watch-dir <path>\`.\n`,
-          );
+          process.stderr.write(`${message}\n`);
         }
         process.exit(1);
       }
 
-      // findInstanceForCwd guarantees watch_dir is set, so this is non-null.
-      const rel = relativeToWatchDir(cwd, owner) ?? "";
+      const inst = target.instance;
+      const rel = inst ? relativeToWatchDir(cwd, inst) : null;
 
       if (options.json) {
         output.result({
           operation: "where",
-          instance: owner.name,
-          api_url: owner.api_url,
-          watch_dir: owner.watch_dir,
+          source: target.source,
+          api_url: target.api_url,
+          instance: inst?.name ?? null,
+          watch_dir: inst?.watch_dir ?? null,
           cwd,
           relative: rel,
         });
         return;
       }
 
-      process.stdout.write(
-        `instance:  ${owner.name}\n` +
-          `api_url:   ${owner.api_url}\n` +
-          `watch_dir: ${owner.watch_dir}\n` +
-          `cwd:       ${cwd}\n` +
-          `relative:  ${rel === "" ? "." : rel}\n`,
-      );
+      const lines: string[] = [
+        `source:    ${target.source}`,
+        `api_url:   ${target.api_url}`,
+      ];
+      if (inst) {
+        lines.push(`instance:  ${inst.name}`);
+        if (inst.watch_dir) {
+          lines.push(`watch_dir: ${inst.watch_dir}`);
+        }
+      }
+      lines.push(`cwd:       ${cwd}`);
+      if (rel !== null) {
+        lines.push(`relative:  ${rel === "" ? "." : rel}`);
+      }
+      process.stdout.write(`${lines.join("\n")}\n`);
     });
 }

--- a/packages/arkeon/src/cli/lib/instance-resolve.ts
+++ b/packages/arkeon/src/cli/lib/instance-resolve.ts
@@ -56,6 +56,7 @@ export type ResolveSource =
   | "env"
   | "name_flag"
   | "cwd_walk"
+  | "in_container_default"
   | "default";
 
 export interface ResolvedTarget {
@@ -63,11 +64,19 @@ export interface ResolvedTarget {
   source: ResolveSource;
   /**
    * The registered instance backing the target — populated for every
-   * source except `api_url_flag` and `env`, where the CLI has no idea
-   * what instance (if any) is on the other end of the URL.
+   * source except `api_url_flag`, `env`, and `in_container_default`,
+   * where the CLI has no idea what instance (if any) is on the other
+   * end of the URL.
    */
   instance?: Instance;
 }
+
+/**
+ * Default port the in-container fallback dials. The Dockerfile pins
+ * PORT=8062, but we honor whatever `PORT` says at runtime so a custom
+ * port mapping doesn't strand the in-container CLI.
+ */
+const DEFAULT_CONTAINER_PORT = "8062";
 
 /**
  * Precedence (first hit wins):
@@ -76,6 +85,7 @@ export interface ResolvedTarget {
  *   3. --name <name>
  *   4. CWD walk against registered watch_dirs (deepest match wins)
  *   5. instance named "default"
+ *   6. ARKEON_WIKI_IN_CONTAINER=1 → http://127.0.0.1:${PORT}
  *
  * Throws with an actionable error if nothing matches.
  */
@@ -105,6 +115,18 @@ export function resolveTarget(opts: ResolveOptions = {}): ResolvedTarget {
   const fallback = findInstance(DEFAULT_INSTANCE_NAME);
   if (fallback) {
     return { api_url: fallback.api_url, source: "default", instance: fallback };
+  }
+  // Last-resort in-container fallback: `docker exec arkeon-wiki
+  // arkeon-wiki query` lands in `/`, which sits under no registered
+  // watch root, but the daemon is right there on loopback. Tied to
+  // ARKEON_WIKI_IN_CONTAINER=1 from the Dockerfile so host CLIs that
+  // happen to have neither flag nor running daemon still fail loudly.
+  if (env.ARKEON_WIKI_IN_CONTAINER === "1") {
+    const port = env.PORT ?? DEFAULT_CONTAINER_PORT;
+    return {
+      api_url: `http://127.0.0.1:${port}`,
+      source: "in_container_default",
+    };
   }
   throw new Error(
     `No arkeon-wiki daemon is running, and CWD (${cwd}) is not under any registered watch root. ` +

--- a/packages/arkeon/src/server/lib/entities.ts
+++ b/packages/arkeon/src/server/lib/entities.ts
@@ -528,7 +528,11 @@ export interface CorpusStats {
   redlinks: number;
   /** Distinct tag keys in use. */
   tag_keys: number;
+  /** Top tag keys by row count, descending. Capped at TAG_KEYS_TOP_LIMIT. */
+  tag_keys_top: Array<{ key: string; n: number }>;
 }
+
+const TAG_KEYS_TOP_LIMIT = 10;
 
 export async function getStats(): Promise<CorpusStats> {
   const sql = createSql();
@@ -563,11 +567,16 @@ export async function getStats(): Promise<CorpusStats> {
     `SELECT COUNT(DISTINCT key) AS n FROM tags`,
     [],
   )) as { n: number }[];
+  const tagKeysTopRows = (await sql.query(
+    `SELECT key, COUNT(*) AS n FROM tags GROUP BY key ORDER BY n DESC, key ASC LIMIT ?`,
+    [TAG_KEYS_TOP_LIMIT],
+  )) as Array<{ key: string; n: number }>;
   return {
     artifacts: { total: textN + assetN, text: textN, asset: assetN },
     links: Number(linksN),
     redlinks: Number(redlinksN),
     tag_keys: Number(tagKeysN),
+    tag_keys_top: tagKeysTopRows.map((r) => ({ key: r.key, n: Number(r.n) })),
   };
 }
 

--- a/packages/arkeon/src/server/lib/entities.ts
+++ b/packages/arkeon/src/server/lib/entities.ts
@@ -528,13 +528,19 @@ export interface CorpusStats {
   redlinks: number;
   /** Distinct tag keys in use. */
   tag_keys: number;
-  /** Top tag keys by row count, descending. Capped at TAG_KEYS_TOP_LIMIT. */
+  /** Top tag keys by row count, descending. Capped by tag_keys_top option. */
   tag_keys_top: Array<{ key: string; n: number }>;
 }
 
-const TAG_KEYS_TOP_LIMIT = 10;
+const TAG_KEYS_TOP_DEFAULT = 10;
 
-export async function getStats(): Promise<CorpusStats> {
+export interface GetStatsOptions {
+  /** How many rows to include in `tag_keys_top`. Defaults to 10. */
+  tag_keys_top?: number;
+}
+
+export async function getStats(opts: GetStatsOptions = {}): Promise<CorpusStats> {
+  const tagKeysTop = opts.tag_keys_top ?? TAG_KEYS_TOP_DEFAULT;
   const sql = createSql();
   const artifactsByKind = (await sql.query(
     `SELECT kind, COUNT(*) AS n FROM artifacts GROUP BY kind`,
@@ -569,7 +575,7 @@ export async function getStats(): Promise<CorpusStats> {
   )) as { n: number }[];
   const tagKeysTopRows = (await sql.query(
     `SELECT key, COUNT(*) AS n FROM tags GROUP BY key ORDER BY n DESC, key ASC LIMIT ?`,
-    [TAG_KEYS_TOP_LIMIT],
+    [tagKeysTop],
   )) as Array<{ key: string; n: number }>;
   return {
     artifacts: { total: textN + assetN, text: textN, asset: assetN },

--- a/packages/arkeon/src/server/lib/llms-txt.ts
+++ b/packages/arkeon/src/server/lib/llms-txt.ts
@@ -395,7 +395,8 @@ discovery-loop sanity checks ("did the watcher actually pick up
 my new files?") without paginating through \`/query\`. \`tag_keys_top\`
 is the top 10 tag keys by row count (descending, ties broken
 alphabetically) — the same shape harnesses use to spot which
-processed-by-* gates dominate the corpus.
+processed-by-* gates dominate the corpus. Override the size with
+\`?tag_keys_top=N\` (capped at 100).
 
 ### POST /reconcile
 

--- a/packages/arkeon/src/server/lib/llms-txt.ts
+++ b/packages/arkeon/src/server/lib/llms-txt.ts
@@ -380,13 +380,22 @@ lands).
   "artifacts": { "total": 1234, "text": 1180, "asset": 54 },
   "links": 4321,
   "redlinks": 17,
-  "tag_keys": 8
+  "tag_keys": 8,
+  "tag_keys_top": [
+    { "key": "processed-by-editor", "n": 1100 },
+    { "key": "processed-by-writer", "n": 600 },
+    { "key": "extracted_by", "n": 54 },
+    { "key": "status", "n": 12 }
+  ]
 }
 \`\`\`
 
 Constant-time corpus size snapshot. Useful for dashboards or for
 discovery-loop sanity checks ("did the watcher actually pick up
-my new files?") without paginating through \`/query\`.
+my new files?") without paginating through \`/query\`. \`tag_keys_top\`
+is the top 10 tag keys by row count (descending, ties broken
+alphabetically) — the same shape harnesses use to spot which
+processed-by-* gates dominate the corpus.
 
 ### POST /reconcile
 

--- a/packages/arkeon/src/server/routes/space-scoped.ts
+++ b/packages/arkeon/src/server/routes/space-scoped.ts
@@ -123,6 +123,31 @@ function requireString(raw: unknown, name: string): string {
   return raw;
 }
 
+/**
+ * Parse the `?tag_keys_top=` query param. Capped at 100 so /stats stays
+ * a constant-time-ish dashboard rather than degenerating into a /tags
+ * dump. `undefined` falls through to the default in getStats().
+ */
+function parseTagKeysTop(raw: string | undefined): number | undefined {
+  if (raw == null) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+    throw new ApiError(
+      400,
+      "validation_error",
+      "tag_keys_top must be a non-negative integer",
+    );
+  }
+  if (n > 100) {
+    throw new ApiError(
+      400,
+      "validation_error",
+      "tag_keys_top must be ≤ 100 (use /tags for a full key dump)",
+    );
+  }
+  return n;
+}
+
 const ORDER_BY_VALUES: QueryOrderBy[] = ["updated_at", "created_at", "path"];
 
 function parseOrderBy(raw: unknown): QueryOrderBy | null {
@@ -162,7 +187,9 @@ apiRouter.post("/query", async (c) => {
 });
 
 apiRouter.get("/stats", async (c) => {
-  const stats = await getStats();
+  const stats = await getStats({
+    tag_keys_top: parseTagKeysTop(c.req.query("tag_keys_top")),
+  });
   return c.json(stats);
 });
 

--- a/packages/arkeon/test/e2e/substrate.test.ts
+++ b/packages/arkeon/test/e2e/substrate.test.ts
@@ -200,6 +200,64 @@ describe("substrate", () => {
     }
   });
 
+  it("GET /stats?tag_keys_top=N overrides the default 10-row cap", async () => {
+    // Seed three distinct keys, then ask for 2 — only the top 2 by
+    // count should come back, ordered desc.
+    const seeded = [
+      ["limit-alpha", ["iarpa/article.html"]],
+      ["limit-beta", ["iarpa/article.html", "iarpa/notes.html"]],
+      [
+        "limit-gamma",
+        ["iarpa/article.html", "iarpa/notes.html", "chartbook/about.html"],
+      ],
+    ] as const;
+    for (const [key, paths] of seeded) {
+      for (const path of paths) {
+        await app.fetch(
+          new Request("http://test/tag", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ path, key, value: "1" }),
+          }),
+        );
+      }
+    }
+    const res = await app.fetch(
+      new Request("http://test/stats?tag_keys_top=2"),
+    );
+    const body = (await res.json()) as {
+      tag_keys_top: Array<{ key: string; n: number }>;
+    };
+    expect(body.tag_keys_top.length).toBe(2);
+    const ours = body.tag_keys_top.filter((r) => r.key.startsWith("limit-"));
+    expect(ours).toEqual([
+      { key: "limit-gamma", n: 3 },
+      { key: "limit-beta", n: 2 },
+    ]);
+
+    const bad = await app.fetch(
+      new Request("http://test/stats?tag_keys_top=101"),
+    );
+    expect(bad.status).toBe(400);
+
+    const negative = await app.fetch(
+      new Request("http://test/stats?tag_keys_top=-1"),
+    );
+    expect(negative.status).toBe(400);
+
+    for (const [key, paths] of seeded) {
+      for (const path of paths) {
+        await app.fetch(
+          new Request("http://test/untag", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ path, key }),
+          }),
+        );
+      }
+    }
+  });
+
   it("POST /query honors order_by + order", async () => {
     const asc = await app.fetch(
       new Request("http://test/query", {

--- a/packages/arkeon/test/e2e/substrate.test.ts
+++ b/packages/arkeon/test/e2e/substrate.test.ts
@@ -134,12 +134,70 @@ describe("substrate", () => {
       links: number;
       redlinks: number;
       tag_keys: number;
+      tag_keys_top: Array<{ key: string; n: number }>;
     };
     expect(body.artifacts.total).toBeGreaterThan(0);
     expect(body.artifacts.total).toBe(body.artifacts.text + body.artifacts.asset);
     expect(body.links).toBeGreaterThan(0);
     expect(body.redlinks).toBeGreaterThan(0); // missing-target from setup
     expect(body.tag_keys).toBeGreaterThanOrEqual(0);
+    expect(Array.isArray(body.tag_keys_top)).toBe(true);
+    expect(body.tag_keys_top.length).toBeLessThanOrEqual(10);
+    expect(body.tag_keys_top.length).toBeLessThanOrEqual(body.tag_keys);
+  });
+
+  it("GET /stats tag_keys_top orders by row count desc, ties alphabetical", async () => {
+    // Self-contained: post three distinct keys at three distinct row
+    // counts, then assert ordering. Cleans up after itself so other
+    // tests see the same starting state.
+    const fixtures = [
+      // key, [paths to tag]
+      ["topN-alpha", ["iarpa/article.html"]],
+      [
+        "topN-beta",
+        ["iarpa/article.html", "iarpa/notes.html"],
+      ],
+      [
+        "topN-gamma",
+        [
+          "iarpa/article.html",
+          "iarpa/notes.html",
+          "chartbook/about.html",
+        ],
+      ],
+    ] as const;
+    for (const [key, paths] of fixtures) {
+      for (const path of paths) {
+        await app.fetch(
+          new Request("http://test/tag", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ path, key, value: "1" }),
+          }),
+        );
+      }
+    }
+    const res = await app.fetch(new Request("http://test/stats"));
+    const body = (await res.json()) as {
+      tag_keys_top: Array<{ key: string; n: number }>;
+    };
+    const ours = body.tag_keys_top.filter((r) => r.key.startsWith("topN-"));
+    expect(ours).toEqual([
+      { key: "topN-gamma", n: 3 },
+      { key: "topN-beta", n: 2 },
+      { key: "topN-alpha", n: 1 },
+    ]);
+    for (const [key, paths] of fixtures) {
+      for (const path of paths) {
+        await app.fetch(
+          new Request("http://test/untag", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ path, key }),
+          }),
+        );
+      }
+    }
   });
 
   it("POST /query honors order_by + order", async () => {

--- a/packages/arkeon/test/unit/instance-resolve.test.ts
+++ b/packages/arkeon/test/unit/instance-resolve.test.ts
@@ -119,4 +119,37 @@ describe("resolveTarget (no-filesystem branches)", () => {
     expect(result.source).toBe("env");
     expect(result.api_url).toBe("http://from-env");
   });
+
+  it("ARKEON_WIKI_IN_CONTAINER=1 defaults to http://127.0.0.1:${PORT} when nothing else matches", () => {
+    // The Dockerfile sets ARKEON_WIKI_IN_CONTAINER=1 + PORT=8062 so the
+    // in-container CLI can fall back to the daemon's known loopback
+    // when CWD is `/` and the registry lookup misses.
+    const result = resolveTarget({
+      env: { ARKEON_WIKI_IN_CONTAINER: "1", PORT: "9000" },
+      cwd: "/",
+    });
+    expect(result.source).toBe("in_container_default");
+    expect(result.api_url).toBe("http://127.0.0.1:9000");
+  });
+
+  it("ARKEON_WIKI_IN_CONTAINER=1 honors PORT default when unset", () => {
+    const result = resolveTarget({
+      env: { ARKEON_WIKI_IN_CONTAINER: "1" },
+      cwd: "/",
+    });
+    expect(result.source).toBe("in_container_default");
+    expect(result.api_url).toBe("http://127.0.0.1:8062");
+  });
+
+  it("ARKEON_WIKI_URL still wins over in-container default", () => {
+    const result = resolveTarget({
+      env: {
+        ARKEON_WIKI_IN_CONTAINER: "1",
+        ARKEON_WIKI_URL: "http://elsewhere:1234",
+      },
+      cwd: "/",
+    });
+    expect(result.source).toBe("env");
+    expect(result.api_url).toBe("http://elsewhere:1234");
+  });
 });


### PR DESCRIPTION
## Summary

Four dogfood follow-ups bundled. All low-risk; tiny touches across stats, CLI, and the in-container path.

- **#197** — `/stats` returns `tag_keys_top: [{key, n}]` (default top 10, descending, ties alphabetical) alongside the existing `tag_keys` integer. Now you can actually tell which `processed-by-*` gate dominates the corpus instead of staring at an opaque count. Configurable via `?tag_keys_top=N` (or `arkeon-wiki stats --tag-keys-top N`), capped at 100.
- **#199** — Adds an `in_container_default` resolution source. When `ARKEON_WIKI_IN_CONTAINER=1` is set (the Dockerfile bakes it in) and `--api-url`/`ARKEON_WIKI_URL`/`--name`/CWD walk/default-instance all miss, fall back to `http://127.0.0.1:${PORT:-8062}`. Eliminates the `docker exec arkeon-wiki arkeon-wiki query` failure where CWD=`/` sits under no registered watch root.
- **bonus** — `arkeon-wiki where` now resolves through the full chain instead of just CWD-walking, surfacing the `source:` line. Inside `docker exec` it reports `in_container_default` instead of the misleading "no instance owns this directory." `--api-url`/`--name` flags added for probing arbitrary targets.

## Resolution precedence (updated)

1. `--api-url`
2. `ARKEON_WIKI_URL` env
3. `--name`
4. CWD walk (deepest match wins)
5. `default` instance from registry
6. **NEW**: `ARKEON_WIKI_IN_CONTAINER=1` → `http://127.0.0.1:${PORT}`
7. throw

## Test plan

- npm run typecheck -w packages/arkeon
- npm test -w packages/arkeon — 253 unit tests, +3 new in instance-resolve
- npm run test:e2e -w packages/arkeon — 50 e2e tests, +2 new (tag_keys_top ordering, ?tag_keys_top=N override + 400 on overcap)
- README + llms-txt /stats example updated

Closes #197, #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)