### PR TITLE
extractors: parallel asset sync + PDF page cap + SIGTERM grace

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,20 @@ All state lives in `~/.arkeon-wiki/`.
 | `--port <port>` | API port (default 8000, or derived from `--name`) |
 | `--name <name>` | Run a named instance side-by-side with others |
 | `ARKEON_WIKI_HOST` | Bind address (default `127.0.0.1` — loopback) |
+| `ARKEON_WIKI_RECONCILE_INTERVAL_SECONDS` | Periodic reconcile interval (default 30, `0` disables) |
+
+### Extractor tunables
+
+Defaults are calibrated against typical Docker workloads — bump them when a specific corpus pushes a limit.
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `ARKEON_WIKI_INGEST_CONCURRENCY` | 4 | Max concurrent extractor subprocesses (PyMuPDF, future handlers) |
+| `ARKEON_WIKI_ASSET_SYNC_CONCURRENCY` | 16 | Parallel `syncFile` calls per binary's post-extract asset batch |
+| `ARKEON_WIKI_ASSET_PROGRESS_INTERVAL` | 100 | Log "syncing assets: N / total" every N assets when total > N |
+| `ARKEON_WIKI_PDF_MAX_PAGES` | 2000 | Reject PDFs above this size with a clear stub sidecar (`0` disables) |
+| `ARKEON_WIKI_PDF_EXTRACT_TIMEOUT_MS` | 600000 | Per-PDF subprocess timeout (10 min) |
+| `ARKEON_WIKI_SIGTERM_GRACE_MS` | 2000 | SIGTERM → SIGKILL grace window for extractor subprocesses |
 
 ## Trigger pattern (for harnesses)
 

--- a/packages/arkeon/src/server/extractors/python/pdf_extract.py
+++ b/packages/arkeon/src/server/extractors/python/pdf_extract.py
@@ -203,6 +203,26 @@ def main(argv: list[str]) -> int:
             )
             return 4
 
+        # Bail before iterating on pathologically large PDFs. At ~500ms
+        # per page render via PyMuPDF.get_pixmap, anything past a few
+        # thousand pages will blow past the subprocess timeout and burn
+        # significant disk + CPU before being killed mid-stream. Cap
+        # via ARKEON_WIKI_PDF_MAX_PAGES (default 2000) — the failed
+        # stub the runner writes captures the cause so operators see
+        # the reason instead of a vague timeout. Set to 0 to disable.
+        max_pages_raw = os.environ.get("ARKEON_WIKI_PDF_MAX_PAGES", "2000")
+        try:
+            max_pages = int(max_pages_raw)
+        except ValueError:
+            max_pages = 2000
+        if max_pages > 0 and doc.page_count > max_pages:
+            print(
+                f"PDF exceeds {max_pages}-page cap ({doc.page_count} pages in "
+                f"{input_path}). Raise ARKEON_WIKI_PDF_MAX_PAGES or split the file.",
+                file=sys.stderr,
+            )
+            return 5
+
         write(out,f'<meta name="page_count" content="{doc.page_count}">')
 
         for page_index, page in enumerate(doc):

--- a/packages/arkeon/src/server/extractors/runner.ts
+++ b/packages/arkeon/src/server/extractors/runner.ts
@@ -205,17 +205,20 @@ async function runExtractionInner(
     // renamed directory, so the watcher would never index our assets.
     // Sync them explicitly here — same code path the watcher uses for
     // any normal file landing.
-    for (const assetName of readdirSync(assetsAbsDir)) {
-      const assetSpaceRelPath = `${assetsSpaceRelDir}/${assetName}`;
-      try {
-        await syncFile(watchedRoot, assetSpaceRelPath);
-      } catch (err) {
-        log(
-          "warn",
-          `failed to sync asset ${assetSpaceRelPath}: ${(err as Error).message}`,
-        );
-      }
-    }
+    //
+    // Sync in parallel batches: a 568-page book produces 568+ asset
+    // files, and a sequential await loop here means each page render
+    // waits for the prior `syncFile` (one hash + one SQL transaction)
+    // before starting. Better to amortize via small concurrent chunks
+    // and emit progress so the daemon log isn't silent during the
+    // post-extraction stretch.
+    const assetNames = readdirSync(assetsAbsDir);
+    await syncAssetsParallel({
+      assetNames,
+      watchedRoot,
+      assetsSpaceRelDir,
+      log,
+    });
 
     writeSidecarAtomic(sidecarAbsPath, result.html);
     await syncFile(watchedRoot, sidecarRelPath);
@@ -341,6 +344,69 @@ async function shouldSkipExisting(
 function baseName(relativePath: string): string {
   const idx = relativePath.lastIndexOf("/");
   return idx >= 0 ? relativePath.slice(idx + 1) : relativePath;
+}
+
+type ExtractionLog = (level: "info" | "warn" | "error", msg: string) => void;
+
+/**
+ * Maximum number of parallel asset-sync calls per binary. PDF
+ * extraction of a 600-page scan can land 600+ assets; running them
+ * serially through `syncFile` (one content-hash + one SQL transaction
+ * each) stalls the daemon. 16 keeps SQLite from gridlocking on
+ * concurrent writes while making the post-extract stretch noticeably
+ * faster.
+ */
+const ASSET_SYNC_CONCURRENCY = 16;
+
+/** How often to log progress during a large asset sync. */
+const ASSET_PROGRESS_INTERVAL = 100;
+
+/**
+ * Sync every freshly-extracted asset through `syncFile` in capped
+ * parallel batches. Failures are logged but never bubble — one
+ * pathological asset shouldn't block the rest of the page renders
+ * from landing.
+ */
+async function syncAssetsParallel(opts: {
+  assetNames: string[];
+  watchedRoot: string;
+  assetsSpaceRelDir: string;
+  log: ExtractionLog;
+}): Promise<void> {
+  const { assetNames, watchedRoot, assetsSpaceRelDir, log } = opts;
+  const total = assetNames.length;
+  if (total === 0) return;
+
+  let done = 0;
+  const tick = (): void => {
+    done += 1;
+    if (
+      total > ASSET_PROGRESS_INTERVAL &&
+      done % ASSET_PROGRESS_INTERVAL === 0 &&
+      done < total
+    ) {
+      log("info", `syncing assets: ${done} / ${total}`);
+    }
+  };
+
+  for (let i = 0; i < total; i += ASSET_SYNC_CONCURRENCY) {
+    const batch = assetNames.slice(i, i + ASSET_SYNC_CONCURRENCY);
+    await Promise.all(
+      batch.map(async (assetName) => {
+        const assetSpaceRelPath = `${assetsSpaceRelDir}/${assetName}`;
+        try {
+          await syncFile(watchedRoot, assetSpaceRelPath);
+        } catch (err) {
+          log(
+            "warn",
+            `failed to sync asset ${assetSpaceRelPath}: ${(err as Error).message}`,
+          );
+        } finally {
+          tick();
+        }
+      }),
+    );
+  }
 }
 
 function createStagingDir(binaryAbsPath: string): string {

--- a/packages/arkeon/src/server/extractors/runner.ts
+++ b/packages/arkeon/src/server/extractors/runner.ts
@@ -349,17 +349,44 @@ function baseName(relativePath: string): string {
 type ExtractionLog = (level: "info" | "warn" | "error", msg: string) => void;
 
 /**
+ * Read a positive integer from `process.env[name]`, falling back to
+ * `fallback` on missing/garbage/non-positive input. Used for the
+ * extractor tunables below — operators bump them via env when a
+ * specific workload pushes the defaults.
+ */
+function readPositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : fallback;
+}
+
+/**
  * Maximum number of parallel asset-sync calls per binary. PDF
  * extraction of a 600-page scan can land 600+ assets; running them
  * serially through `syncFile` (one content-hash + one SQL transaction
  * each) stalls the daemon. 16 keeps SQLite from gridlocking on
  * concurrent writes while making the post-extract stretch noticeably
- * faster.
+ * faster. Override via `ARKEON_WIKI_ASSET_SYNC_CONCURRENCY`.
+ *
+ * Calibration note: better-sqlite3 is synchronous + single-connection,
+ * so SQL itself serializes through one queue regardless of concurrency
+ * here. The win is amortizing the per-asset FS read + SHA-256, which
+ * dominates wall time for asset sync.
  */
-const ASSET_SYNC_CONCURRENCY = 16;
+const ASSET_SYNC_CONCURRENCY = readPositiveIntEnv(
+  "ARKEON_WIKI_ASSET_SYNC_CONCURRENCY",
+  16,
+);
 
-/** How often to log progress during a large asset sync. */
-const ASSET_PROGRESS_INTERVAL = 100;
+/**
+ * How often to log progress during a large asset sync. Override via
+ * `ARKEON_WIKI_ASSET_PROGRESS_INTERVAL`.
+ */
+const ASSET_PROGRESS_INTERVAL = readPositiveIntEnv(
+  "ARKEON_WIKI_ASSET_PROGRESS_INTERVAL",
+  100,
+);
 
 /**
  * Sync every freshly-extracted asset through `syncFile` in capped
@@ -367,6 +394,18 @@ const ASSET_PROGRESS_INTERVAL = 100;
  * pathological asset shouldn't block the rest of the page renders
  * from landing.
  */
+export async function _syncAssetsParallelForTest(opts: {
+  assetNames: string[];
+  watchedRoot: string;
+  assetsSpaceRelDir: string;
+  log: ExtractionLog;
+}): Promise<void> {
+  return syncAssetsParallel(opts);
+}
+
+export const _assetSyncConcurrencyForTest = ASSET_SYNC_CONCURRENCY;
+export const _assetProgressIntervalForTest = ASSET_PROGRESS_INTERVAL;
+
 async function syncAssetsParallel(opts: {
   assetNames: string[];
   watchedRoot: string;

--- a/packages/arkeon/src/server/extractors/subprocess.ts
+++ b/packages/arkeon/src/server/extractors/subprocess.ts
@@ -53,8 +53,15 @@ const DEFAULT_MAX_STDOUT = 50 * 1024 * 1024;
  * SIGTERM; jumping straight to SIGKILL strands them. Two seconds is
  * long enough for an honest cleanup and short enough not to delay
  * watcher progress meaningfully when a process really is wedged.
+ * Override via `ARKEON_WIKI_SIGTERM_GRACE_MS` if a specific handler
+ * needs longer cleanup.
  */
-const SIGTERM_GRACE_MS = 2_000;
+const SIGTERM_GRACE_MS = (() => {
+  const raw = process.env.ARKEON_WIKI_SIGTERM_GRACE_MS;
+  if (!raw) return 2_000;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 2_000;
+})();
 
 function readConcurrencyCap(): number {
   const raw = process.env.ARKEON_WIKI_INGEST_CONCURRENCY;

--- a/packages/arkeon/src/server/extractors/subprocess.ts
+++ b/packages/arkeon/src/server/extractors/subprocess.ts
@@ -47,6 +47,15 @@ export class SubprocessError extends Error {
 const DEFAULT_TIMEOUT_MS = 120_000;
 const DEFAULT_MAX_STDOUT = 50 * 1024 * 1024;
 
+/**
+ * Grace window between SIGTERM and SIGKILL. PyMuPDF (and most
+ * well-behaved CLIs) flush partial output and clean up temp files on
+ * SIGTERM; jumping straight to SIGKILL strands them. Two seconds is
+ * long enough for an honest cleanup and short enough not to delay
+ * watcher progress meaningfully when a process really is wedged.
+ */
+const SIGTERM_GRACE_MS = 2_000;
+
 function readConcurrencyCap(): number {
   const raw = process.env.ARKEON_WIKI_INGEST_CONCURRENCY;
   if (!raw) return 4;
@@ -110,6 +119,7 @@ function spawnAndCapture(opts: RunSubprocessOptions): Promise<SubprocessResult> 
     let stdoutBytes = 0;
     let settled = false;
     let killReason: string | null = null;
+    let sigkillTimer: NodeJS.Timeout | null = null;
 
     const finalize = (
       code: number | null,
@@ -118,6 +128,10 @@ function spawnAndCapture(opts: RunSubprocessOptions): Promise<SubprocessResult> 
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      if (sigkillTimer) {
+        clearTimeout(sigkillTimer);
+        sigkillTimer = null;
+      }
       opts.signal.removeEventListener("abort", onAbort);
       const stdout = Buffer.concat(stdoutChunks).toString("utf8");
       const stderr = Buffer.concat(stderrChunks).toString("utf8");
@@ -139,13 +153,34 @@ function spawnAndCapture(opts: RunSubprocessOptions): Promise<SubprocessResult> 
       }
     };
 
+    /**
+     * SIGTERM first, then SIGKILL after a short grace if the child
+     * hasn't exited. Matches how launchd/systemd treat managed
+     * services and lets PyMuPDF flush partial state. Idempotent —
+     * `killReason` only takes the first call's value so subsequent
+     * SIGKILLs from the grace timer (or back-to-back abort+timeout)
+     * don't overwrite the original cause.
+     */
     const killWith = (reason: string): void => {
-      killReason = reason;
+      if (killReason === null) killReason = reason;
       try {
-        child.kill("SIGKILL");
+        child.kill("SIGTERM");
       } catch {
         // already gone
+        return;
       }
+      if (sigkillTimer) return; // grace already armed
+      sigkillTimer = setTimeout(() => {
+        sigkillTimer = null;
+        if (settled) return;
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // already gone
+        }
+      }, SIGTERM_GRACE_MS);
+      // Don't keep the event loop alive just for the grace timer.
+      sigkillTimer.unref?.();
     };
 
     const timer = setTimeout(() => {
@@ -181,3 +216,4 @@ function spawnAndCapture(opts: RunSubprocessOptions): Promise<SubprocessResult> 
 }
 
 export const _semaphoreForTest = concurrencySemaphore;
+export const _sigtermGraceMsForTest = SIGTERM_GRACE_MS;

--- a/packages/arkeon/test/e2e/extractors-asset-sync.test.ts
+++ b/packages/arkeon/test/e2e/extractors-asset-sync.test.ts
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Focused stress test for the chunked asset-sync path in
+ * `runner.ts:syncAssetsParallel`.
+ *
+ * The path is the bottleneck a 500+ page PDF hits post-extraction —
+ * each asset goes through `syncFile` (FS read + SHA-256 + SQL
+ * insert). Without this test the contract relies on incidental
+ * coverage from the PDF e2e (which can't run in CI without PyMuPDF).
+ *
+ * What this locks in:
+ *   1. All N assets end up indexed (no batches dropped).
+ *   2. Per-asset failures are isolated — one pathological file
+ *      doesn't abort the batch.
+ *   3. Progress logging fires at every ASSET_PROGRESS_INTERVAL
+ *      boundary AND only when `done < total` (so the final batch
+ *      doesn't double-log alongside the runner's "extraction
+ *      complete" line).
+ *   4. The runtime is materially faster than serial — a sanity
+ *      check, not a perf benchmark.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  _assetProgressIntervalForTest,
+  _assetSyncConcurrencyForTest,
+  _syncAssetsParallelForTest,
+} from "../../src/server/extractors/runner.js";
+import { runMigrations } from "../../src/schema/migrate.js";
+import { closeDb, createSql, initDb } from "../../src/server/lib/sql.js";
+
+let workdir: string;
+let assetsAbsDir: string;
+const assetsRelDir = ".sidecars/stress-fixture.pdf.assets";
+
+beforeAll(async () => {
+  workdir = mkdtempSync(join(tmpdir(), "arkeon-asset-sync-"));
+  const dbPath = join(workdir, "arke.db");
+  initDb(dbPath);
+  await runMigrations({ dbPath });
+  assetsAbsDir = join(workdir, assetsRelDir);
+  mkdirSync(assetsAbsDir, { recursive: true });
+});
+
+afterAll(() => {
+  closeDb();
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+describe("syncAssetsParallel — stress + contract", () => {
+  it("indexes 250 synthetic assets and logs progress at the 100/200 boundaries", async () => {
+    // Confirm we're calibrating against the values the runner ships
+    // with, so the assertions remain meaningful if the defaults move.
+    expect(_assetSyncConcurrencyForTest).toBeGreaterThanOrEqual(1);
+    expect(_assetProgressIntervalForTest).toBe(100);
+
+    const N = 250;
+    const names: string[] = [];
+    for (let i = 1; i <= N; i++) {
+      const name = `page-${String(i).padStart(4, "0")}.png`;
+      // Distinct content per file so each row gets a real hash —
+      // otherwise SQLite dedup could mask a missed insert.
+      writeFileSync(join(assetsAbsDir, name), `synthetic-asset-${i}`);
+      names.push(name);
+    }
+
+    const logs: Array<{ level: string; msg: string }> = [];
+    const log = (level: "info" | "warn" | "error", msg: string): void => {
+      logs.push({ level, msg });
+    };
+
+    const start = Date.now();
+    await _syncAssetsParallelForTest({
+      assetNames: names,
+      watchedRoot: workdir,
+      assetsSpaceRelDir: assetsRelDir,
+      log,
+    });
+    const elapsedMs = Date.now() - start;
+
+    // Every asset must land as an artifact row.
+    const sql = createSql();
+    const rows = (await sql.query(
+      `SELECT path FROM artifacts WHERE path LIKE ? ORDER BY path`,
+      [`${assetsRelDir}/%`],
+    )) as Array<{ path: string }>;
+    expect(rows.length).toBe(N);
+    expect(rows[0]!.path).toBe(`${assetsRelDir}/page-0001.png`);
+    expect(rows[N - 1]!.path).toBe(`${assetsRelDir}/page-0250.png`);
+
+    // Progress logs at exactly 100/250 and 200/250. The 250/250
+    // final-batch log is suppressed by the `done < total` guard —
+    // the runner's "extraction complete" line covers it.
+    const progressLines = logs.filter((l) => l.msg.startsWith("syncing assets:"));
+    expect(progressLines.map((l) => l.msg)).toEqual([
+      "syncing assets: 100 / 250",
+      "syncing assets: 200 / 250",
+    ]);
+
+    // No warnings on the happy path.
+    expect(logs.filter((l) => l.level === "warn")).toEqual([]);
+
+    // Sanity: 250 sequential syncFile calls take well over 1s in
+    // local testing; concurrency 16 should finish far under that.
+    // Loose bound to stay green on slow CI runners.
+    expect(elapsedMs).toBeLessThan(10_000);
+  });
+
+  it("doesn't emit progress logs for small batches (total ≤ interval)", async () => {
+    const subdir = ".sidecars/small-fixture.pdf.assets";
+    mkdirSync(join(workdir, subdir), { recursive: true });
+    const names: string[] = [];
+    for (let i = 1; i <= 50; i++) {
+      const name = `tiny-${i}.bin`;
+      writeFileSync(join(workdir, subdir, name), `small-${i}`);
+      names.push(name);
+    }
+    const logs: string[] = [];
+    await _syncAssetsParallelForTest({
+      assetNames: names,
+      watchedRoot: workdir,
+      assetsSpaceRelDir: subdir,
+      log: (_level, msg) => logs.push(msg),
+    });
+    expect(logs.filter((m) => m.startsWith("syncing assets:"))).toEqual([]);
+  });
+
+  it("isolates per-asset failures — one missing file doesn't abort the batch", async () => {
+    const subdir = ".sidecars/partial-fixture.pdf.assets";
+    mkdirSync(join(workdir, subdir), { recursive: true });
+    const names: string[] = [];
+    for (let i = 1; i <= 5; i++) {
+      const name = `real-${i}.bin`;
+      writeFileSync(join(workdir, subdir, name), `partial-${i}`);
+      names.push(name);
+    }
+    // Inject a name that doesn't correspond to a real file on disk;
+    // syncFile will throw and the helper should log + continue.
+    names.splice(2, 0, "missing-on-disk.bin");
+
+    const logs: Array<{ level: string; msg: string }> = [];
+    await _syncAssetsParallelForTest({
+      assetNames: names,
+      watchedRoot: workdir,
+      assetsSpaceRelDir: subdir,
+      log: (level, msg) => logs.push({ level, msg }),
+    });
+
+    const sql = createSql();
+    const rows = (await sql.query(
+      `SELECT path FROM artifacts WHERE path LIKE ?`,
+      [`${subdir}/%`],
+    )) as Array<{ path: string }>;
+    // All 5 real files landed; the missing one did not.
+    expect(rows.length).toBe(5);
+    const warnLines = logs.filter((l) => l.level === "warn");
+    expect(warnLines.length).toBe(1);
+    expect(warnLines[0]!.msg).toContain("missing-on-disk.bin");
+  });
+});

--- a/packages/arkeon/test/unit/extractors-pdf-reflow.test.ts
+++ b/packages/arkeon/test/unit/extractors-pdf-reflow.test.ts
@@ -112,3 +112,98 @@ describe.skipIf(!PYTHON)("pdf_extract.py reflow", () => {
     );
   });
 });
+
+describe.skipIf(!PYTHON)("pdf_extract.py page cap", () => {
+  // Generate a tiny 3-page PDF inline so the test doesn't depend on
+  // a multi-page committed fixture. The reflow.pdf fixture is 1 page
+  // by design — wrong shape for tripping a 1-page cap.
+  function makeMultiPagePdf(workdir: string, pages: number): string {
+    const pdfPath = join(workdir, "multi.pdf");
+    const script = [
+      "import fitz",
+      `doc = fitz.open()`,
+      `for i in range(${pages}):`,
+      `    page = doc.new_page()`,
+      `    page.insert_text((50, 72), f"page {i+1}")`,
+      `doc.save(${JSON.stringify(pdfPath)})`,
+      `doc.close()`,
+    ].join("\n");
+    execFileSync(PYTHON as string, ["-c", script]);
+    return pdfPath;
+  }
+
+  it("ARKEON_WIKI_PDF_MAX_PAGES=1 bails with exit code 5 before iterating", () => {
+    const workdir = mkdtempSync(join(tmpdir(), "arkeon-pdf-cap-"));
+    const assetsDir = join(workdir, "assets");
+    const outHtml = join(workdir, "out.html");
+    execFileSync("mkdir", ["-p", assetsDir]);
+    try {
+      const pdf = makeMultiPagePdf(workdir, 3);
+      const result = spawnSync(
+        PYTHON as string,
+        [SCRIPT, pdf, assetsDir, "assets", outHtml],
+        {
+          stdio: ["ignore", "pipe", "pipe"],
+          env: { ...process.env, ARKEON_WIKI_PDF_MAX_PAGES: "1" },
+        },
+      );
+      expect(result.status).toBe(5);
+      const stderr = result.stderr.toString("utf-8");
+      expect(stderr).toContain("1-page cap");
+      expect(stderr).toContain("Raise ARKEON_WIKI_PDF_MAX_PAGES");
+    } finally {
+      rmSync(workdir, { recursive: true, force: true });
+    }
+  });
+
+  it("ARKEON_WIKI_PDF_MAX_PAGES=0 disables the cap (back to normal extraction)", () => {
+    // The runner's "failed_for_binary_hash" tag suppresses retries
+    // until content changes, so verifying the disable knob is a
+    // common operator workflow: bump cap, delete sidecar, retry.
+    // 0 is the documented disable value; assert the extractor runs
+    // to completion against a multi-page input even with a tight
+    // numeric value that would otherwise trip the guard.
+    const workdir = mkdtempSync(join(tmpdir(), "arkeon-pdf-cap-"));
+    const assetsDir = join(workdir, "assets");
+    const outHtml = join(workdir, "out.html");
+    execFileSync("mkdir", ["-p", assetsDir]);
+    try {
+      const pdf = makeMultiPagePdf(workdir, 3);
+      const result = spawnSync(
+        PYTHON as string,
+        [SCRIPT, pdf, assetsDir, "assets", outHtml],
+        {
+          stdio: ["ignore", "pipe", "pipe"],
+          env: { ...process.env, ARKEON_WIKI_PDF_MAX_PAGES: "0" },
+        },
+      );
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(workdir, { recursive: true, force: true });
+    }
+  });
+
+  it("ARKEON_WIKI_PDF_MAX_PAGES=garbage falls back to the 2000 default", () => {
+    // Defensive: an operator passing "high" or some other non-numeric
+    // value should get the safe default, not a crash. 2000 > 3 so
+    // the 3-page test PDF extracts normally.
+    const workdir = mkdtempSync(join(tmpdir(), "arkeon-pdf-cap-"));
+    const assetsDir = join(workdir, "assets");
+    const outHtml = join(workdir, "out.html");
+    execFileSync("mkdir", ["-p", assetsDir]);
+    try {
+      const pdf = makeMultiPagePdf(workdir, 3);
+      const result = spawnSync(
+        PYTHON as string,
+        [SCRIPT, pdf, assetsDir, "assets", outHtml],
+        {
+          stdio: ["ignore", "pipe", "pipe"],
+          env: { ...process.env, ARKEON_WIKI_PDF_MAX_PAGES: "not-a-number" },
+        },
+      );
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(workdir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/arkeon/test/unit/extractors-subprocess.test.ts
+++ b/packages/arkeon/test/unit/extractors-subprocess.test.ts
@@ -7,6 +7,7 @@ import {
   runSubprocess,
   SubprocessError,
   _semaphoreForTest,
+  _sigtermGraceMsForTest,
 } from "../../src/server/extractors/subprocess.js";
 
 // Use the node binary itself as a portable subprocess. -e takes a JS
@@ -70,6 +71,47 @@ describe("runSubprocess", () => {
     expect((err as SubprocessError).message).toMatch(/timed out/i);
     // Sanity check that the timer actually fired — not the 60s sleep.
     expect(elapsed).toBeLessThan(5_000);
+  });
+
+  it("SIGTERM lets a well-behaved child exit before SIGKILL fires", async () => {
+    // The child traps SIGTERM, prints a marker, and exits 0 — proving
+    // the kill path sends SIGTERM first instead of jumping straight
+    // to SIGKILL (which can't be trapped). We expect a successful
+    // resolve here, not a timeout rejection.
+    const start = Date.now();
+    const result = await runSubprocess({
+      cmd: NODE,
+      args: [
+        "-e",
+        `process.on("SIGTERM", () => { process.stdout.write("graceful"); process.exit(0); }); setTimeout(() => process.exit(0), 60_000)`,
+      ],
+      signal: new AbortController().signal,
+      timeoutMs: 200,
+    });
+    const elapsed = Date.now() - start;
+    expect(result.stdout).toBe("graceful");
+    // Should resolve well before the SIGKILL grace window expires.
+    expect(elapsed).toBeLessThan(200 + _sigtermGraceMsForTest);
+  });
+
+  it("falls back to SIGKILL when the child ignores SIGTERM", async () => {
+    // Child explicitly traps SIGTERM and refuses to exit — we should
+    // still reap it via SIGKILL within roughly the grace window.
+    const start = Date.now();
+    const err: unknown = await runSubprocess({
+      cmd: NODE,
+      args: [
+        "-e",
+        `process.on("SIGTERM", () => {}); setTimeout(() => process.exit(0), 60_000)`,
+      ],
+      signal: new AbortController().signal,
+      timeoutMs: 200,
+    }).catch((e) => e);
+    const elapsed = Date.now() - start;
+    expect(err).toBeInstanceOf(SubprocessError);
+    // Total wall time: timeout (200ms) + grace (~2s) + slack. If
+    // SIGKILL never fired we'd be at 60s.
+    expect(elapsed).toBeLessThan(200 + _sigtermGraceMsForTest + 2_000);
   });
 
   it("respects an external AbortSignal", async () => {


### PR DESCRIPTION
## Summary

Three PR-#170 follow-ups bundled because they share code paths and review context (the same three files: `runner.ts`, `subprocess.ts`, `pdf_extract.py`). Each is small in isolation; bundling avoids three rounds of context-reload.

### 1. Parallelize per-asset `syncFile` (runner.ts)

A 568-page scanned PDF lands 568+ asset files (page renders + figures). They were syncing serially through `syncFile` — one content-hash + one SQL transaction each, in series, inside the per-binary lock. The daemon log went silent for ~10s post-extraction while assets trickled in.

Now: chunked `Promise.all` at concurrency 16 (avoids SQLite write gridlock) with `info` progress logging every 100 assets so operators see motion during a large book ingest.

### 2. `ARKEON_WIKI_PDF_MAX_PAGES` guard (pdf_extract.py)

Previously bounded only by the 600s subprocess timeout — a pathological 5000-page PDF would burn hundreds of MB of disk + CPU before timing out mid-extraction with a stub fallback.

Now: read `doc.page_count` BEFORE iteration, bail with exit code 5 + a clear stderr message if it exceeds the cap. Default 2000, override via env, set to 0 to disable. The runner's existing failed-stub path captures the cause for the operator, and the `failed_for_binary_hash` tag suppresses retries until the content changes (or the cap is raised and the sidecar deleted).

### 3. SIGTERM grace before SIGKILL (subprocess.ts)

`killWith` went straight to SIGKILL — PyMuPDF couldn't flush partially-written assets or clean up temp files. Low-stakes because the runner nukes the staging dir on failure, but cleaner to match how launchd/systemd treat managed services.

Now: SIGTERM first, 2s grace timer, then SIGKILL only if the child hasn't exited. The grace timer is `unref`'d so it never holds the event loop open on its own; `finalize` clears it on normal exit; `killReason` only takes the first call's value so back-to-back abort+timeout don't clobber the original cause.

## Test plan

- [x] `npm run typecheck -w packages/arkeon`
- [x] `npm test -w packages/arkeon` — 264 unit tests, +2 new in `extractors-subprocess` (SIGTERM-graceful + SIGKILL-fallback covers both kill paths)
- [x] `npm run test:e2e -w packages/arkeon` — 59 e2e tests still green

Closes #193 (which closes #172, #173, #174).

🤖 Generated with [Claude Code](https://claude.com/claude-code)