### PR TITLE
reader: async fs/promises + streaming + ETag + dir-listing pagination

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,8 +65,10 @@ Wikilink hrefs resolve relative to the source file's directory: `./sources/x.pdf
 Catch-all directory browser:
 
 - `GET /` → directory listing of the watched root.
-- `GET /<path>/` → directory listing of any subfolder.
-- `GET /<path>` → file serve. HTML files run through wikilink rewriting; unresolved `<a class="wikilink">` anchors gain a `redlink` class so CSS can style them.
+- `GET /<path>/` → directory listing of any subfolder. Query params: `?limit` (default 200, max 2000), `?offset` (default 0), `?sort=name|mtime|size` (default `name`). The renderer emits `rel="prev"` / `rel="next"` links so callers can paginate without hand-building URLs.
+- `GET /<path>` → file serve. HTML files run through wikilink rewriting; unresolved `<a class="wikilink">` anchors gain a `redlink` class so CSS can style them. Binaries stream off disk via `createReadStream` so a 50 MB embedded PDF doesn't buffer fully in memory.
+
+File serves carry a weak `ETag: W/"<mtime-ms>-<size>"` plus `Cache-Control: no-cache, must-revalidate`. `If-None-Match` against the same ETag returns `304 Not Modified`. Edits on disk invalidate naturally — `syncFile` writes via atomic rename, so `mtime` bumps even when content is identical.
 
 URL structure mirrors disk structure. The same article opens identically under `file://` and `http://` (apart from the redlink class injection).
 

--- a/README.md
+++ b/README.md
@@ -135,8 +135,10 @@ Full reference at `GET /llms.txt` or `GET /help`.
 URL structure mirrors disk structure.
 
 - `GET /` — directory listing of the watched root.
-- `GET /<path>/` — directory listing of any subfolder.
-- `GET /<path>` — serve the file. HTML files run through wikilink rewriting; unresolved `<a class="wikilink">` anchors gain a `redlink` class so CSS can style them.
+- `GET /<path>/` — directory listing of any subfolder. Query params: `?limit` (default 200, max 2000), `?offset` (default 0), `?sort=name|mtime|size` (default `name`). The rendered page emits `rel="prev"` / `rel="next"` links and an active-sort marker so callers can paginate without hand-building URLs.
+- `GET /<path>` — serve the file. HTML files run through wikilink rewriting; unresolved `<a class="wikilink">` anchors gain a `redlink` class so CSS can style them. Binaries stream off disk (no full in-memory buffer) so a 50 MB embedded PDF doesn't pin the event loop.
+
+File serves carry a weak `ETag: W/"<mtime-ms>-<size>"` and `Cache-Control: no-cache, must-revalidate`. Browsers and proxies revalidate every request; `If-None-Match` with the current ETag returns `304 Not Modified`. Edits invalidate naturally — `syncFile` writes through atomic rename, which bumps `mtime` on every save.
 
 The same article opens identically under `file://` and `http://`.
 

--- a/packages/arkeon/src/server/lib/reader.ts
+++ b/packages/arkeon/src/server/lib/reader.ts
@@ -55,7 +55,20 @@ export interface DirEntry {
   short_description: string | null;
 }
 
-export function renderDirectoryListing(dirPath: string, entries: DirEntry[]): string {
+export type ListingSort = "name" | "mtime" | "size";
+
+export interface ListingPage {
+  offset: number;
+  limit: number;
+  total: number;
+  sort: ListingSort;
+}
+
+export function renderDirectoryListing(
+  dirPath: string,
+  entries: DirEntry[],
+  page?: ListingPage,
+): string {
   const title = dirPath === "" ? "arkeon-wiki" : dirPath;
   const items = entries
     .map((e) => {
@@ -82,6 +95,7 @@ export function renderDirectoryListing(dirPath: string, entries: DirEntry[]): st
       return `<li><a href="${escapeAttr(href)}">${anchor}</a>${subtitle}</li>`;
     })
     .join("\n");
+  const controls = page ? renderListingControls(page) : "";
   return `<!DOCTYPE html>
 <html>
 <head>
@@ -91,13 +105,69 @@ export function renderDirectoryListing(dirPath: string, entries: DirEntry[]): st
     body { font: 14px system-ui, sans-serif; max-width: 760px; margin: 2rem auto; padding: 0 1rem; }
     .ark-sub { color: #666; }
     .ark-empty { color: #999; font-style: italic; }
+    .ark-controls { display: flex; justify-content: space-between; align-items: baseline; margin: 1rem 0; gap: 1rem; flex-wrap: wrap; }
+    .ark-controls a { margin-right: 0.5rem; }
+    .ark-controls a.ark-active { font-weight: 600; text-decoration: none; color: #000; }
+    .ark-page-count { color: #666; }
   </style>
 </head>
 <body>
   <h1>${escapeHtml(title || "/")}</h1>
+  ${controls}
   ${entries.length === 0 ? `<p class="ark-empty">(empty)</p>` : `<ul>${items}</ul>`}
+  ${controls}
 </body>
 </html>`;
+}
+
+function renderListingControls(page: ListingPage): string {
+  const { offset, limit, total, sort } = page;
+  const end = Math.min(offset + limit, total);
+  const sortLinks: ListingSort[] = ["name", "mtime", "size"];
+  const sortHtml = sortLinks
+    .map((s) => {
+      const href = buildPageHref(0, limit, s);
+      const cls = s === sort ? ' class="ark-active"' : "";
+      return `<a href="${escapeAttr(href)}"${cls}>${escapeHtml(s)}</a>`;
+    })
+    .join("");
+
+  let pager = "";
+  if (total > limit) {
+    const prevOffset = Math.max(offset - limit, 0);
+    const nextOffset = offset + limit;
+    const links: string[] = [];
+    if (offset > 0) {
+      links.push(
+        `<a href="${escapeAttr(buildPageHref(prevOffset, limit, sort))}" rel="prev">← prev</a>`,
+      );
+    }
+    if (nextOffset < total) {
+      links.push(
+        `<a href="${escapeAttr(buildPageHref(nextOffset, limit, sort))}" rel="next">next →</a>`,
+      );
+    }
+    pager = links.join(" ");
+  }
+
+  const range =
+    total === 0
+      ? ""
+      : `<span class="ark-page-count">${offset + 1}–${end} of ${total}</span>`;
+
+  return `<div class="ark-controls">
+  <div>sort: ${sortHtml}</div>
+  <div>${pager}${pager && range ? " · " : ""}${range}</div>
+</div>`;
+}
+
+function buildPageHref(offset: number, limit: number, sort: ListingSort): string {
+  const params = new URLSearchParams();
+  if (offset > 0) params.set("offset", String(offset));
+  params.set("limit", String(limit));
+  if (sort !== "name") params.set("sort", sort);
+  const qs = params.toString();
+  return qs ? `?${qs}` : "./";
 }
 
 export function renderNotFound(path: string): string {

--- a/packages/arkeon/src/server/routes/reader.ts
+++ b/packages/arkeon/src/server/routes/reader.ts
@@ -10,11 +10,19 @@
  *
  * The reader is the catch-all; mount it last so explicit API routes
  * (/query, /tag, /tags, …) win.
+ *
+ * I/O posture: every filesystem touch goes through `node:fs/promises`
+ * so the event loop keeps moving for concurrent API requests during
+ * a long file read. Binary serves stream via `createReadStream` →
+ * `Readable.toWeb` so a 50 MB embedded PDF doesn't buffer fully into
+ * memory before flushing.
  */
 
 import { Hono, type Context } from "hono";
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { extname } from "node:path";
+import { createReadStream, type Stats } from "node:fs";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { Readable } from "node:stream";
+import { extname, join } from "node:path";
 
 import type { AppBindings } from "../types.js";
 import { ApiError } from "../lib/errors.js";
@@ -26,9 +34,15 @@ import {
   renderNotFound,
   rewriteWikilinks,
   type DirEntry,
+  type ListingPage,
+  type ListingSort,
 } from "../lib/reader.js";
 
 export const readerRouter = new Hono<AppBindings>();
+
+const DEFAULT_LISTING_LIMIT = 200;
+const MAX_LISTING_LIMIT = 2000;
+const VALID_SORTS: ListingSort[] = ["name", "mtime", "size"];
 
 function decodePath(rawUrl: string): string {
   const u = new URL(rawUrl);
@@ -64,29 +78,61 @@ readerRouter.get("/*", async (c) => {
   } catch {
     return c.html(renderNotFound(relPath), 404);
   }
-  if (!existsSync(abs)) return c.html(renderNotFound(relPath), 404);
 
-  const stat = statSync(abs);
-  if (stat.isDirectory()) {
+  let st: Stats;
+  try {
+    st = await stat(abs);
+  } catch {
+    return c.html(renderNotFound(relPath), 404);
+  }
+  if (st.isDirectory()) {
     // Browsers usually trailing-slash directory URLs, but treat
     // /<dir> as a directory listing too.
     return serveDirectory(c, root, relPath);
   }
 
+  // Weak ETag from mtime + size. Edits on disk invalidate naturally
+  // because syncFile writes go through atomic rename, which bumps
+  // mtime even when the content hash is identical.
+  const etag = buildEtag(st);
+  const ifNoneMatch = c.req.header("if-none-match");
+  if (ifNoneMatch && etagMatches(etag, ifNoneMatch)) {
+    return new Response(null, { status: 304, headers: cacheHeaders(etag) });
+  }
+
   const ext = extname(relPath).toLowerCase();
   if (ext === ".html" || ext === ".htm") {
+    // HTML still buffers — wikilink rewriting needs the full document
+    // and HTML sidecars are bounded by sane corpus sizes (KB to a few
+    // MB). The streaming win is on raw binaries.
     const sql = createSql();
     const rows = await sql`SELECT path FROM artifacts`;
     const knownPaths = new Set<string>();
     for (const row of rows) knownPaths.add(row.path as string);
-    const original = readFileSync(abs, "utf-8");
-    return c.html(rewriteWikilinks(original, relPath, knownPaths));
+    const original = await readFile(abs, "utf-8");
+    const html = rewriteWikilinks(original, relPath, knownPaths);
+    return new Response(html, {
+      status: 200,
+      headers: {
+        "content-type": "text/html; charset=utf-8",
+        ...cacheHeaders(etag),
+      },
+    });
   }
 
-  const body = readFileSync(abs);
-  return new Response(body, {
+  // Binary serve: stream off disk so a 50 MB PDF isn't buffered in
+  // full before the first byte ships. `Readable.toWeb` is the
+  // node-stream → web-stream adapter Hono / `new Response(...)`
+  // consume directly.
+  const stream = createReadStream(abs);
+  const webStream = Readable.toWeb(stream) as unknown as ReadableStream<Uint8Array>;
+  return new Response(webStream, {
     status: 200,
-    headers: { "content-type": mimeTypeFor(abs) },
+    headers: {
+      "content-type": mimeTypeFor(abs),
+      "content-length": String(st.size),
+      ...cacheHeaders(etag),
+    },
   });
 });
 
@@ -96,9 +142,19 @@ async function serveDirectory(
   relPath: string,
 ): Promise<Response> {
   const abs = relPath === "" ? root : safeResolve(root, relPath);
-  if (!existsSync(abs) || !statSync(abs).isDirectory()) {
+  let st: Stats;
+  try {
+    st = await stat(abs);
+  } catch {
     return c.html(renderNotFound(relPath), 404);
   }
+  if (!st.isDirectory()) {
+    return c.html(renderNotFound(relPath), 404);
+  }
+
+  const limit = parseLimit(c.req.query("limit"));
+  const offset = parseOffset(c.req.query("offset"));
+  const sort = parseSort(c.req.query("sort"));
 
   // Pull labels + short_description for every immediate child of this
   // directory in one query, so we don't re-read each HTML file from
@@ -107,31 +163,119 @@ async function serveDirectory(
   // properties — re-reading would just duplicate that work.
   const childIndex = await loadChildIndex(relPath);
 
-  const entries: DirEntry[] = [];
-  for (const entry of readdirSync(abs, { withFileTypes: true })) {
-    if (entry.name.startsWith(".")) continue;
-    if (entry.isDirectory()) {
-      entries.push({
-        name: entry.name,
-        is_dir: true,
-        label: null,
-        short_description: null,
-      });
-    } else if (entry.isFile()) {
-      const meta = childIndex.get(entry.name);
-      entries.push({
-        name: entry.name,
-        is_dir: false,
-        label: meta?.label ?? null,
-        short_description: meta?.short_description ?? null,
-      });
-    }
+  const dirents = (await readdir(abs, { withFileTypes: true })).filter(
+    (d) => !d.name.startsWith("."),
+  );
+
+  // For mtime / size sorts we need a stat per entry. Name sort skips
+  // the syscall entirely so the cheap path stays cheap.
+  let entries: SortableEntry[];
+  if (sort === "name") {
+    entries = dirents.map((d) => ({
+      name: d.name,
+      is_dir: d.isDirectory(),
+      mtime_ms: 0,
+      size: 0,
+    }));
+  } else {
+    const stats = await Promise.all(
+      dirents.map((d) => stat(join(abs, d.name)).catch(() => null)),
+    );
+    entries = dirents.map((d, i) => ({
+      name: d.name,
+      is_dir: d.isDirectory(),
+      mtime_ms: stats[i]?.mtimeMs ?? 0,
+      size: stats[i]?.size ?? 0,
+    }));
   }
-  entries.sort((a, b) => {
+
+  entries.sort(sorterFor(sort));
+
+  const total = entries.length;
+  const page = entries.slice(offset, offset + limit).map((e): DirEntry => {
+    const meta = e.is_dir ? null : childIndex.get(e.name);
+    return {
+      name: e.name,
+      is_dir: e.is_dir,
+      label: meta?.label ?? null,
+      short_description: meta?.short_description ?? null,
+    };
+  });
+
+  const pagination: ListingPage = { offset, limit, total, sort };
+  return c.html(renderDirectoryListing(relPath, page, pagination));
+}
+
+interface SortableEntry {
+  name: string;
+  is_dir: boolean;
+  mtime_ms: number;
+  size: number;
+}
+
+function sorterFor(sort: ListingSort): (a: SortableEntry, b: SortableEntry) => number {
+  if (sort === "mtime") {
+    return (a, b) => {
+      if (a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1;
+      // Most recent first.
+      return b.mtime_ms - a.mtime_ms;
+    };
+  }
+  if (sort === "size") {
+    return (a, b) => {
+      if (a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1;
+      // Largest first; directories sort by name among themselves
+      // (their size is always 0).
+      if (a.is_dir && b.is_dir) return a.name.localeCompare(b.name);
+      return b.size - a.size;
+    };
+  }
+  return (a, b) => {
     if (a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1;
     return a.name.localeCompare(b.name);
-  });
-  return c.html(renderDirectoryListing(relPath, entries));
+  };
+}
+
+function parseLimit(raw: string | undefined): number {
+  if (!raw) return DEFAULT_LISTING_LIMIT;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1) {
+    return DEFAULT_LISTING_LIMIT;
+  }
+  return Math.min(n, MAX_LISTING_LIMIT);
+}
+
+function parseOffset(raw: string | undefined): number {
+  if (!raw) return 0;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) return 0;
+  return n;
+}
+
+function parseSort(raw: string | undefined): ListingSort {
+  if (raw && (VALID_SORTS as string[]).includes(raw)) return raw as ListingSort;
+  return "name";
+}
+
+function buildEtag(st: Stats): string {
+  return `W/"${Math.floor(st.mtimeMs)}-${st.size}"`;
+}
+
+function etagMatches(etag: string, header: string): boolean {
+  // RFC 9110: If-None-Match is a comma-separated list. `*` matches
+  // anything. Weak-compare both sides (everything we emit is weak).
+  if (header.trim() === "*") return true;
+  return header
+    .split(",")
+    .map((s) => s.trim())
+    .some((candidate) => candidate === etag);
+}
+
+function cacheHeaders(etag: string): Record<string, string> {
+  return {
+    "cache-control": "no-cache, must-revalidate",
+    etag,
+  };
 }
 
 interface ChildMeta {

--- a/packages/arkeon/test/e2e/substrate.test.ts
+++ b/packages/arkeon/test/e2e/substrate.test.ts
@@ -9,7 +9,15 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  unlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -874,6 +882,170 @@ describe("substrate", () => {
     // The resolved wikilink still carries its class, no redlink.
     expect(text).toContain(`class="wikilink"`);
     expect(text).not.toMatch(/wikilink[^"]*redlink/);
+  });
+
+  it("file serve includes a weak ETag + cache-control", async () => {
+    const res = await app.fetch(new Request("http://test/iarpa/article.html"));
+    expect(res.status).toBe(200);
+    const etag = res.headers.get("etag");
+    expect(etag).toMatch(/^W\/"\d+-\d+"$/);
+    expect(res.headers.get("cache-control")).toBe("no-cache, must-revalidate");
+  });
+
+  it("If-None-Match with the current ETag returns 304 + empty body", async () => {
+    const first = await app.fetch(
+      new Request("http://test/iarpa/article.html"),
+    );
+    const etag = first.headers.get("etag")!;
+    expect(etag).toBeTruthy();
+    const second = await app.fetch(
+      new Request("http://test/iarpa/article.html", {
+        headers: { "if-none-match": etag },
+      }),
+    );
+    expect(second.status).toBe(304);
+    expect(second.headers.get("etag")).toBe(etag);
+    expect(second.headers.get("cache-control")).toBe("no-cache, must-revalidate");
+    // 304 body must be empty per RFC 9110.
+    expect(await second.text()).toBe("");
+  });
+
+  it("If-None-Match: * is the wildcard match → 304", async () => {
+    const res = await app.fetch(
+      new Request("http://test/iarpa/article.html", {
+        headers: { "if-none-match": "*" },
+      }),
+    );
+    expect(res.status).toBe(304);
+  });
+
+  it("If-None-Match with a stale ETag still returns the body", async () => {
+    const res = await app.fetch(
+      new Request("http://test/iarpa/article.html", {
+        headers: { "if-none-match": 'W/"0-0"' },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect((await res.text()).length).toBeGreaterThan(0);
+  });
+
+  it("binary serve streams the file with content-type + content-length", async () => {
+    // derived-fixture.pdf is set up in beforeAll with deterministic
+    // ASCII bytes — the reader should serve them verbatim with the
+    // PDF content-type and a matching content-length.
+    const res = await app.fetch(
+      new Request("http://test/iarpa/derived-fixture.pdf"),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/pdf");
+    const len = Number(res.headers.get("content-length"));
+    expect(len).toBeGreaterThan(0);
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    expect(bytes.length).toBe(len);
+    expect(new TextDecoder().decode(bytes)).toBe(
+      "%PDF-1.4 derived-fixture placeholder\n",
+    );
+  });
+
+  it("directory listing paginates with offset / limit + total + prev/next links", async () => {
+    // Self-contained fixture so the page math is deterministic
+    // regardless of other tests dropping files in iarpa/.
+    mkdirSync(join(workdir, "pagination-fixture"), { recursive: true });
+    for (let i = 1; i <= 12; i++) {
+      writeFileSync(
+        join(workdir, "pagination-fixture", `file-${String(i).padStart(2, "0")}.txt`),
+        `entry ${i}`,
+      );
+    }
+
+    const first = await app.fetch(
+      new Request("http://test/pagination-fixture/?limit=5"),
+    );
+    expect(first.status).toBe(200);
+    const firstHtml = await first.text();
+    expect(firstHtml).toContain("1–5 of 12");
+    expect(firstHtml).toContain("file-01.txt");
+    expect(firstHtml).toContain("file-05.txt");
+    expect(firstHtml).not.toContain("file-06.txt");
+    expect(firstHtml).toContain('rel="next"');
+    expect(firstHtml).not.toContain('rel="prev"');
+
+    const middle = await app.fetch(
+      new Request("http://test/pagination-fixture/?limit=5&offset=5"),
+    );
+    const middleHtml = await middle.text();
+    expect(middleHtml).toContain("6–10 of 12");
+    expect(middleHtml).toContain('rel="prev"');
+    expect(middleHtml).toContain('rel="next"');
+    expect(middleHtml).toContain("file-06.txt");
+    expect(middleHtml).toContain("file-10.txt");
+    expect(middleHtml).not.toContain("file-01.txt");
+
+    const last = await app.fetch(
+      new Request("http://test/pagination-fixture/?limit=5&offset=10"),
+    );
+    const lastHtml = await last.text();
+    expect(lastHtml).toContain("11–12 of 12");
+    expect(lastHtml).toContain('rel="prev"');
+    expect(lastHtml).not.toContain('rel="next"');
+  });
+
+  it("directory listing sort=mtime orders entries newest-first", async () => {
+    mkdirSync(join(workdir, "mtime-fixture"), { recursive: true });
+    const files = ["a.txt", "b.txt", "c.txt"];
+    for (const n of files) {
+      writeFileSync(join(workdir, "mtime-fixture", n), n);
+    }
+    // a oldest → c newest.
+    utimesSync(
+      join(workdir, "mtime-fixture/a.txt"),
+      new Date("2026-01-01"),
+      new Date("2026-01-01"),
+    );
+    utimesSync(
+      join(workdir, "mtime-fixture/b.txt"),
+      new Date("2026-01-02"),
+      new Date("2026-01-02"),
+    );
+    utimesSync(
+      join(workdir, "mtime-fixture/c.txt"),
+      new Date("2026-01-03"),
+      new Date("2026-01-03"),
+    );
+
+    const res = await app.fetch(
+      new Request("http://test/mtime-fixture/?sort=mtime"),
+    );
+    const html = await res.text();
+    const idxA = html.indexOf(">a.txt<");
+    const idxB = html.indexOf(">b.txt<");
+    const idxC = html.indexOf(">c.txt<");
+    expect(idxA).toBeGreaterThan(0);
+    expect(idxB).toBeGreaterThan(0);
+    expect(idxC).toBeGreaterThan(0);
+    // Newest first → c, then b, then a.
+    expect(idxC).toBeLessThan(idxB);
+    expect(idxB).toBeLessThan(idxA);
+    // The sort link for mtime should carry the ark-active marker.
+    expect(html).toMatch(/<a [^>]*class="ark-active"[^>]*>mtime<\/a>/);
+  });
+
+  it("invalid sort / limit / offset query params fall back to defaults", async () => {
+    mkdirSync(join(workdir, "validation-fixture"), { recursive: true });
+    writeFileSync(join(workdir, "validation-fixture/only.txt"), "x");
+    const res = await app.fetch(
+      new Request(
+        "http://test/validation-fixture/?sort=bogus&limit=-7&offset=garbage",
+      ),
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // Default sort=name should be marked active.
+    expect(html).toMatch(/<a [^>]*class="ark-active"[^>]*>name<\/a>/);
+    // Single entry, default limit 200 → no pager.
+    expect(html).not.toContain('rel="next"');
+    expect(html).not.toContain('rel="prev"');
+    expect(html).toContain("only.txt");
   });
 
   it("reader only marks redlinks on <a class='wikilink'>, not plain anchors", async () => {


### PR DESCRIPTION
## Summary

Three PR-#125 follow-ups bundled (consolidates #129/#130/#131 via #192) re-scoped to the current flat-reader shape.

### 1. Async I/O + binary streaming

Every filesystem touch in `reader.ts` now goes through `node:fs/promises`. Binary serves stream off disk via `createReadStream` → `Readable.toWeb` so a 50 MB embedded PDF doesn't buffer fully into memory before the first byte ships. HTML still buffers — wikilink rewriting needs the whole document and sidecars are bounded by sane corpus sizes.

### 2. ETag + Cache-Control

File serves carry:

```
ETag: W/"<mtimeMs>-<size>"
Cache-Control: no-cache, must-revalidate
```

`If-None-Match` against the current ETag returns `304 Not Modified` (RFC 9110 — empty body, ETag echoed, cache-control echoed). Wildcard `*` matches anything. Stale ETags fall through to a normal 200. Edits invalidate naturally — `syncFile` writes through atomic rename which bumps `mtime` on every save.

### 3. Dir-listing pagination + sort

`GET /<dir>/` accepts:

- `?limit=<n>` (default 200, max 2000)
- `?offset=<n>` (default 0)
- `?sort=name|mtime|size` (default `name`)

Name sort skips the per-entry `stat` syscall to keep the cheap path cheap; mtime/size stat in parallel via `Promise.all`. The rendered HTML gains an active-sort marker and `rel="prev"` / `rel="next"` links so callers can paginate without hand-building URLs.

Invalid query params silently fall back to defaults — the reader is for humans; a malformed `?sort=bogus` shouldn't 400 a casual browse.

## Test plan

- [x] `npm run typecheck -w packages/arkeon`
- [x] `npm test -w packages/arkeon` — 267 unit tests, all green
- [x] `npm run test:e2e -w packages/arkeon` — 70 e2e tests, +8 new:
  - Weak ETag shape on file serves
  - `If-None-Match` with current ETag → 304 + empty body + headers echoed
  - `If-None-Match: *` → 304
  - Stale ETag → 200 with body
  - Binary serve: content-type + content-length + verbatim bytes
  - 3-page pagination over a 12-file fixture with offset math + prev/next link presence
  - `?sort=mtime` orders newest-first (verified via `utimesSync` fixture)
  - Invalid `?sort` / `?limit` / `?offset` silently fall back to defaults

Closes #192 (which closes #129, #130, #131).

🤖 Generated with [Claude Code](https://claude.com/claude-code)