### PR TITLE
links: HTML basename fallback — heals on disk, dumb-serve renderer

### DIFF
--- a/packages/arkeon/src/server/lib/basename-fallback.ts
+++ b/packages/arkeon/src/server/lib/basename-fallback.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Basename-fallback resolution for path-form wikilink targets.
+ *
+ * Problem this solves: HTML `<a class="wikilink" href="./X">` resolves
+ * via relative-path math. If `X` moves between folders, the inbound
+ * href no longer resolves and shows as a redlink — even though the
+ * target still exists at a different location. MD `[[X]]` already
+ * handles this via shortest-unique-basename matching; this helper
+ * brings the same convergence to HTML hrefs whose literal-resolved
+ * path is broken.
+ *
+ * Strict basename match (file extension included). `./article.html`
+ * falls back only to another `article.html` somewhere in the tree,
+ * not to `article.md` — the operator was specific about the
+ * extension; respect that.
+ *
+ * Ambiguous basename (multiple matches) returns null so the caller
+ * keeps the literal-resolved path and the anchor surfaces as a
+ * redlink. Same dedup contract as MD `[[X]]` against multiple
+ * basename matches.
+ */
+
+import { posix } from "node:path";
+
+/**
+ * Look for a known artifact whose basename matches `literalResolved`'s
+ * basename. Returns the unique match's path if exactly one exists and
+ * it differs from the literal target; otherwise null.
+ *
+ * Callers should fall back to `literalResolved` (which surfaces as a
+ * redlink) when this returns null.
+ */
+export function resolveByBasename(
+  literalResolved: string,
+  knownPaths: ReadonlySet<string>,
+): string | null {
+  if (knownPaths.has(literalResolved)) return null;
+  const targetBase = posix.basename(literalResolved).toLowerCase();
+  if (!targetBase) return null;
+  let match: string | null = null;
+  for (const p of knownPaths) {
+    if (posix.basename(p).toLowerCase() !== targetBase) continue;
+    if (match !== null) return null; // ambiguous → no fallback
+    match = p;
+  }
+  return match;
+}
+
+/**
+ * Build a relative href from `fromPath`'s directory to `targetPath`.
+ * Used by the reader when rewriting a broken href to the basename-
+ * fallback resolved target so the rendered HTML navigates correctly
+ * (the source file on disk is left untouched).
+ */
+export function relativeHref(fromPath: string, targetPath: string): string {
+  const fromDir = posix.dirname(fromPath);
+  // posix.dirname("foo.html") returns ".", which posix.relative
+  // treats as the current directory — exactly what we want for a
+  // root-level source. Pass "" through the same branch as "." so
+  // both behave identically.
+  const base = fromDir === "." || fromDir === "" ? "" : fromDir;
+  return base === "" ? targetPath : posix.relative(base, targetPath);
+}

--- a/packages/arkeon/src/server/lib/heal-html.ts
+++ b/packages/arkeon/src/server/lib/heal-html.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Source-file healing for HTML wikilinks whose literal-resolved
+ * target moved between folders.
+ *
+ * Doctrine: the filesystem is truth. When sync detects a basename-
+ * unique fallback, the on-disk source HTML is edited so that the
+ * next extraction sees coherent state — not the served response,
+ * not just SQL. "View source" matches what renders; git history
+ * carries the heal as a real edit.
+ *
+ *   1. `applyHeals` walks the parsed DOM and rewrites every
+ *      `<a class="wikilink">` whose literal-resolved href matches a
+ *      heal-from path to point at the heal-to path. Pure function:
+ *      returns the new content + the number of anchors edited.
+ *   2. `writeAtomic` writes via temp + rename so a crash mid-write
+ *      leaves the original file intact.
+ *
+ * Used by `sync.ts` from two sites: inline during `syncText` when
+ * extractHtmlLinks reports a fallback hit, and inside
+ * `reresolveBasenameRedlinks` when a newly-landed artifact heals a
+ * previously-stuck inbound href.
+ */
+
+import { renameSync, writeFileSync } from "node:fs";
+import { parse } from "node-html-parser";
+
+import { relativeHref } from "./basename-fallback.js";
+import { resolveHref } from "./html-links.js";
+
+export interface HrefHeal {
+  /** The literal-resolved (broken) target the href currently points at. */
+  brokenTarget: string;
+  /** The basename-fallback resolved target the heal should land on. */
+  healedTarget: string;
+}
+
+export interface HealResult {
+  content: string;
+  changed: number;
+}
+
+/**
+ * Apply `heals` to every matching `<a class="wikilink">` in `content`.
+ * Returns the rewritten content and how many anchors were updated.
+ * When `changed === 0` the original content is returned unchanged so
+ * the caller can skip the write entirely.
+ */
+export function applyHeals(
+  content: string,
+  sourceRelativePath: string,
+  heals: ReadonlyArray<HrefHeal>,
+): HealResult {
+  if (heals.length === 0) return { content, changed: 0 };
+  const map = new Map<string, string>();
+  for (const h of heals) map.set(h.brokenTarget, h.healedTarget);
+
+  const root = parse(content);
+  let changed = 0;
+  for (const a of root.querySelectorAll("a")) {
+    const cls = a.getAttribute("class") ?? "";
+    if (!cls.split(/\s+/).some((t) => t === "wikilink")) continue;
+    const href = a.getAttribute("href");
+    if (!href) continue;
+    const literal = resolveHref(href, sourceRelativePath);
+    if (literal === null) continue;
+    const healed = map.get(literal);
+    if (!healed) continue;
+    a.setAttribute("href", relativeHref(sourceRelativePath, healed));
+    changed++;
+  }
+  if (changed === 0) return { content, changed: 0 };
+  return { content: root.toString(), changed };
+}
+
+/**
+ * Write `content` to `absPath` atomically: write to a sibling temp
+ * file first, then rename over the destination. A crash between the
+ * two leaves the original intact (the temp file is orphaned, not the
+ * source).
+ */
+export function writeAtomic(absPath: string, content: string): void {
+  const tmp = `${absPath}.heal.tmp`;
+  writeFileSync(tmp, content, "utf-8");
+  renameSync(tmp, absPath);
+}

--- a/packages/arkeon/src/server/lib/html-links.ts
+++ b/packages/arkeon/src/server/lib/html-links.ts
@@ -30,6 +30,8 @@
 import { parse } from "node-html-parser";
 import { posix } from "node:path";
 
+import { resolveByBasename } from "./basename-fallback.js";
+
 export interface HtmlLink {
   href: string;
   text: string;
@@ -42,7 +44,26 @@ function hasWikilinkClass(cls: string | undefined): boolean {
   return cls.split(/\s+/).some((token) => token === "wikilink");
 }
 
-export function extractHtmlLinks(html: string, fromPath: string): HtmlLink[] {
+/**
+ * Extract every `<a class="wikilink">` from `html` and resolve its
+ * href against the article's directory.
+ *
+ * When `knownPaths` is provided AND the literal-resolved path isn't
+ * in it, fall back to a strict basename-unique match. This makes HTML
+ * resolution symmetric with MD `[[X]]`: a target that moved between
+ * folders heals automatically as long as its basename is unique.
+ * Ambiguous basenames keep the literal path so the anchor still
+ * surfaces as a redlink — same dedup rule MD uses.
+ *
+ * Callers that don't have an index handy (or want strict literal
+ * resolution, e.g. for tests) can omit `knownPaths`; the resolver
+ * then returns only the literal-relative path.
+ */
+export function extractHtmlLinks(
+  html: string,
+  fromPath: string,
+  knownPaths?: ReadonlySet<string>,
+): HtmlLink[] {
   const root = parse(html);
   const out: HtmlLink[] = [];
   for (const a of root.querySelectorAll("a")) {
@@ -54,7 +75,13 @@ export function extractHtmlLinks(html: string, fromPath: string): HtmlLink[] {
     for (const [k, v] of Object.entries(a.attributes)) {
       if (k.startsWith("data-")) data[k.slice(5)] = String(v);
     }
-    out.push({ href, text, resolved: resolveHref(href, fromPath), data });
+    const literal = resolveHref(href, fromPath);
+    let resolved: string | null = literal;
+    if (literal !== null && knownPaths !== undefined && !knownPaths.has(literal)) {
+      const fallback = resolveByBasename(literal, knownPaths);
+      if (fallback !== null) resolved = fallback;
+    }
+    out.push({ href, text, resolved, data });
   }
   return out;
 }

--- a/packages/arkeon/src/server/lib/reader.ts
+++ b/packages/arkeon/src/server/lib/reader.ts
@@ -15,8 +15,27 @@
 import { parse } from "node-html-parser";
 import { posix } from "node:path";
 
+import { relativeHref, resolveByBasename } from "./basename-fallback.js";
 import { resolveHref } from "./html-links.js";
 
+/**
+ * Walk every `<a class="wikilink">` and reconcile its href with the
+ * current artifact index. Three outcomes per anchor:
+ *
+ *   1. Literal-resolve hits → leave alone.
+ *   2. Literal-resolve misses but basename is unique elsewhere →
+ *      rewrite the anchor's `href` to a relative path from the
+ *      source's directory to the basename-resolved target. The
+ *      on-disk source file is NOT mutated; only the served HTML
+ *      reflects the convergence, the same way the substrate
+ *      converges its own link graph at index time.
+ *   3. Literal-resolve misses AND basename match is ambiguous (or
+ *      absent) → add the `redlink` class so the reader styles it
+ *      and a click reveals the broken state.
+ *
+ * Same fallback contract `extractHtmlLinks` uses at index time, so a
+ * served page and a `/backlinks` query agree on what's resolved.
+ */
 export function rewriteWikilinks(
   html: string,
   fromPath: string,
@@ -34,10 +53,18 @@ export function rewriteWikilinks(
     if (!href) continue;
     const resolved = resolveHref(href, fromPath);
     if (!resolved) continue;
-    if (!knownPaths.has(resolved)) {
-      tokens.add("redlink");
-      a.setAttribute("class", [...tokens].join(" "));
+    if (knownPaths.has(resolved)) continue;
+    const fallback = resolveByBasename(resolved, knownPaths);
+    if (fallback !== null) {
+      // Rewrite the rendered href so the click navigates to the moved
+      // file. Source HTML on disk is untouched — basename fallback is
+      // a render-time concession to filesystem moves, not a corpus
+      // mutation.
+      a.setAttribute("href", relativeHref(fromPath, fallback));
+      continue;
     }
+    tokens.add("redlink");
+    a.setAttribute("class", [...tokens].join(" "));
   }
   return root.toString();
 }

--- a/packages/arkeon/src/server/lib/reader.ts
+++ b/packages/arkeon/src/server/lib/reader.ts
@@ -15,26 +15,21 @@
 import { parse } from "node-html-parser";
 import { posix } from "node:path";
 
-import { relativeHref, resolveByBasename } from "./basename-fallback.js";
 import { resolveHref } from "./html-links.js";
 
 /**
- * Walk every `<a class="wikilink">` and reconcile its href with the
- * current artifact index. Three outcomes per anchor:
+ * Walk every `<a class="wikilink">` in served HTML; literal-resolve
+ * each href against the artifact index. If the resolved path isn't
+ * a known artifact, tag the anchor with the `redlink` class so the
+ * reader styles it as broken.
  *
- *   1. Literal-resolve hits → leave alone.
- *   2. Literal-resolve misses but basename is unique elsewhere →
- *      rewrite the anchor's `href` to a relative path from the
- *      source's directory to the basename-resolved target. The
- *      on-disk source file is NOT mutated; only the served HTML
- *      reflects the convergence, the same way the substrate
- *      converges its own link graph at index time.
- *   3. Literal-resolve misses AND basename match is ambiguous (or
- *      absent) → add the `redlink` class so the reader styles it
- *      and a click reveals the broken state.
- *
- * Same fallback contract `extractHtmlLinks` uses at index time, so a
- * served page and a `/backlinks` query agree on what's resolved.
+ * The reader is intentionally dumb-serve: no basename fallback, no
+ * href rewriting. If a href doesn't resolve here it's because sync
+ * couldn't (or chose not to) heal it on disk — that's a signal the
+ * user should see, not something the renderer should paper over.
+ * Basename-fallback heals happen in the sync path via source-file
+ * rewrites; by the time content reaches the reader, the href is
+ * either coherent on disk or genuinely broken.
  */
 export function rewriteWikilinks(
   html: string,
@@ -53,18 +48,10 @@ export function rewriteWikilinks(
     if (!href) continue;
     const resolved = resolveHref(href, fromPath);
     if (!resolved) continue;
-    if (knownPaths.has(resolved)) continue;
-    const fallback = resolveByBasename(resolved, knownPaths);
-    if (fallback !== null) {
-      // Rewrite the rendered href so the click navigates to the moved
-      // file. Source HTML on disk is untouched — basename fallback is
-      // a render-time concession to filesystem moves, not a corpus
-      // mutation.
-      a.setAttribute("href", relativeHref(fromPath, fallback));
-      continue;
+    if (!knownPaths.has(resolved)) {
+      tokens.add("redlink");
+      a.setAttribute("class", [...tokens].join(" "));
     }
-    tokens.add("redlink");
-    a.setAttribute("class", [...tokens].join(" "));
   }
   return root.toString();
 }

--- a/packages/arkeon/src/server/lib/sync.ts
+++ b/packages/arkeon/src/server/lib/sync.ts
@@ -18,7 +18,12 @@ import { posix } from "node:path";
 import { createSql, withTransaction } from "./sql.js";
 import { classifyFile } from "./fs-watcher.js";
 import { parseHtmlMeta } from "./html-meta.js";
-import { extractHtmlLinks } from "./html-links.js";
+import {
+  applyHeals,
+  writeAtomic,
+  type HrefHeal,
+} from "./heal-html.js";
+import { extractHtmlLinks, resolveHref } from "./html-links.js";
 import { extractMarkdownLinks } from "./md-links.js";
 
 export type ArtifactKind = "text" | "asset";
@@ -166,7 +171,14 @@ export async function syncFile(
   }
 
   // (4) Real content change.
-  const result = await syncText(relativePath, content, hash, fingerprint, existing[0] ?? null);
+  const result = await syncText(
+    watchedRoot,
+    relativePath,
+    content,
+    hash,
+    fingerprint,
+    existing[0] ?? null,
+  );
 
   // A new text artifact may have just resolved one or more previously-
   // stuck redlinks — both MD `[[X]]` (slug-form) and HTML hrefs whose
@@ -174,12 +186,13 @@ export async function syncFile(
   // between folders). Run the resolver after every create so live
   // watcher writes converge, not just the initial reconcile.
   if (result.action === "created") {
-    await reresolveBasenameRedlinks();
+    await reresolveBasenameRedlinks(watchedRoot);
   }
   return result;
 }
 
 async function syncText(
+  watchedRoot: string,
   relativePath: string,
   content: string,
   hash: string,
@@ -191,7 +204,8 @@ async function syncText(
   const resolvedLinks: { target: string; text: string | null; attrs: Record<string, string> }[] = [];
 
   if (isHtmlPath(relativePath)) {
-    const meta = parseHtmlMeta(content);
+    let workingContent = content;
+    const meta = parseHtmlMeta(workingContent);
     // Sidecars: always derive label from the binary's basename so
     // asset.label and sidecar.label match (paper.pdf → "paper" on
     // both rows). The embedded <title> is for human display, not
@@ -209,14 +223,39 @@ async function syncText(
     const pathRows = await sql`SELECT path FROM artifacts`;
     const known = new Set<string>();
     for (const row of pathRows) known.add(row.path as string);
-    for (const l of extractHtmlLinks(content, relativePath, known)) {
+    const heals: HrefHeal[] = [];
+    for (const l of extractHtmlLinks(workingContent, relativePath, known)) {
       if (l.resolved == null) continue;
+      // If extractHtmlLinks healed the resolution via basename
+      // fallback, queue the source-file edit. The doctrine: rewrite
+      // the href on disk so subsequent extractions see coherent
+      // state and "view source" matches what renders.
+      const literal = resolveHref(l.href, relativePath);
+      if (literal !== null && literal !== l.resolved) {
+        heals.push({ brokenTarget: literal, healedTarget: l.resolved });
+      }
       resolvedLinks.push({
         target: l.resolved,
         text: l.text || null,
         attrs: l.data ?? {},
       });
     }
+    if (heals.length > 0) {
+      const healed = applyHeals(workingContent, relativePath, heals);
+      if (healed.changed > 0) {
+        const absPath = join(watchedRoot, relativePath);
+        writeAtomic(absPath, healed.content);
+        // Re-derive hash + fingerprint from the post-heal file so
+        // the row we're about to write matches what's on disk —
+        // when the watcher fires on our own write, it'll hit the
+        // stat-fingerprint fast path and skip a redundant sync.
+        workingContent = healed.content;
+        hash = contentHash(workingContent);
+        const newStats = statSync(absPath);
+        fingerprint = statFingerprint(newStats);
+      }
+    }
+    content = workingContent;
   } else if (isMarkdownPath(relativePath)) {
     label = basename(relativePath, extname(relativePath));
     propsJson = JSON.stringify({ file_type: extname(relativePath).slice(1) });
@@ -420,7 +459,7 @@ export async function syncDirectory(
   // B.md was indexed, A's link to [[B]] got persisted as a literal
   // "B" redlink and would never converge without this sweep. Same
   // shape applies to HTML hrefs that pointed at an old folder path.
-  await reresolveBasenameRedlinks();
+  await reresolveBasenameRedlinks(watchedRoot);
 
   return summary;
 }
@@ -432,28 +471,40 @@ export async function syncDirectory(
  *   - MD slug-form (`target_path` with no slash, e.g. "B"): match
  *     against basename OR stem (with-or-without-extension), per the
  *     existing MD `[[X]]` semantics. Lets `[[paper]]` heal to
- *     `paper.pdf.html`.
+ *     `paper.pdf.html`. Index-only — the source `.md` keeps its
+ *     abstract `[[X]]` syntax (that's the point of slug resolution).
  *   - HTML path-form (`target_path` with a slash, e.g.
  *     "chartbook/article-one.html"): match against the target's own
- *     basename, extension-strict. Lets a moved-between-folders
- *     `./article-one.html` heal symmetrically with MD.
+ *     basename, extension-strict. When a unique fallback exists, ALSO
+ *     edit the source HTML on disk so the href spells the new path —
+ *     the doctrine is that the filesystem is truth, so corrections
+ *     get propagated as real file edits. Source-file write is
+ *     skipped silently when the inbound source can't be read
+ *     (deleted, permissions); the next reconcile retries.
  *
  * Ambiguous basenames (>1 match) are skipped in both shapes — the
  * link stays a redlink. For MD the operator can disambiguate with
- * `[[folder/X]]`; for HTML, the inbound article has to be edited.
+ * `[[folder/X]]`; for HTML, the inbound article has to be edited
+ * manually.
  *
  * Called after `syncDirectory` (reconcile case) and after every
  * `syncFile` create (live watcher case) so resolution converges
  * regardless of file-arrival order.
  */
-export async function reresolveBasenameRedlinks(): Promise<void> {
+export async function reresolveBasenameRedlinks(
+  watchedRoot: string,
+): Promise<void> {
   const sql = createSql();
+  // Pull source_path alongside target_path so we can locate the
+  // inbound article(s) for HTML source-file healing. Multiple inbound
+  // articles can share the same broken target — each needs its own
+  // file rewrite, so don't DISTINCT the target away.
   const rows = (await sql`
-    SELECT DISTINCT l.target_path
+    SELECT l.source_path, l.target_path
     FROM links l
     LEFT JOIN artifacts a ON a.path = l.target_path
     WHERE a.path IS NULL
-  `) as { target_path: string }[];
+  `) as { source_path: string; target_path: string }[];
   if (rows.length === 0) return;
 
   const allRows = (await sql`SELECT path FROM artifacts`) as { path: string }[];
@@ -478,11 +529,20 @@ export async function reresolveBasenameRedlinks(): Promise<void> {
     (byStrictBase[b] ??= []).push(r.path);
   }
 
+  // Group heals: SQL updates per unique target, HTML file edits per
+  // (source, [heals]) tuple. Same broken target can heal once in SQL
+  // but require N file rewrites if N inbound HTML articles point at
+  // it.
+  const sqlHeals = new Map<string, string>(); // brokenTarget → healedTarget
+  const htmlFileHeals = new Map<string, HrefHeal[]>(); // source_path → heals
+
   for (const row of rows) {
     const target = row.target_path;
+    const source = row.source_path;
     let candidates: string[] | undefined;
+    let isPathForm = false;
     if (target.includes("/")) {
-      // HTML path-form. Strict-basename match.
+      isPathForm = true;
       const targetBase = posix.basename(target).toLowerCase();
       candidates = byStrictBase[targetBase];
       // Don't self-rewrite to the same path (defensive; the redlink
@@ -491,13 +551,49 @@ export async function reresolveBasenameRedlinks(): Promise<void> {
         continue;
       }
     } else {
-      // MD slug-form: basename-or-stem match, original MD semantics.
       candidates = byBaseAndStem[target.toLowerCase()];
     }
     if (!candidates || candidates.length !== 1) continue;
+    const healed = candidates[0]!;
+    sqlHeals.set(target, healed);
+    // Source-file healing is HTML-only by design: MD `[[X]]` is an
+    // abstract slug that already resolves by basename — keeping
+    // `[[X]]` as written is the operator's intent. HTML hrefs claim
+    // a specific path; rewriting them to match reality is the honest
+    // move.
+    if (isPathForm && (source.endsWith(".html") || source.endsWith(".htm"))) {
+      const list = htmlFileHeals.get(source) ?? [];
+      list.push({ brokenTarget: target, healedTarget: healed });
+      htmlFileHeals.set(source, list);
+    }
+  }
+
+  for (const [broken, healed] of sqlHeals) {
     await sql.query(
       `UPDATE links SET target_path = ? WHERE target_path = ?`,
-      [candidates[0], target],
+      [healed, broken],
     );
+  }
+
+  for (const [sourcePath, heals] of htmlFileHeals) {
+    const absPath = join(watchedRoot, sourcePath);
+    let content: string;
+    try {
+      content = readFileSync(absPath, "utf-8");
+    } catch (err) {
+      console.error(
+        `[sync] heal: source ${sourcePath} unreadable — ${(err as Error).message}`,
+      );
+      continue;
+    }
+    const result = applyHeals(content, sourcePath, heals);
+    if (result.changed === 0) continue;
+    try {
+      writeAtomic(absPath, result.content);
+    } catch (err) {
+      console.error(
+        `[sync] heal: write failed for ${sourcePath} — ${(err as Error).message}`,
+      );
+    }
   }
 }

--- a/packages/arkeon/src/server/lib/sync.ts
+++ b/packages/arkeon/src/server/lib/sync.ts
@@ -169,11 +169,12 @@ export async function syncFile(
   const result = await syncText(relativePath, content, hash, fingerprint, existing[0] ?? null);
 
   // A new text artifact may have just resolved one or more previously-
-  // stuck markdown redlinks (their [[X]] target slug matches the new
-  // file's basename). Run the resolver after every create so live
+  // stuck redlinks — both MD `[[X]]` (slug-form) and HTML hrefs whose
+  // basename matches the new file (path-form, healed when X moves
+  // between folders). Run the resolver after every create so live
   // watcher writes converge, not just the initial reconcile.
   if (result.action === "created") {
-    await reresolveMarkdownRedlinks();
+    await reresolveBasenameRedlinks();
   }
   return result;
 }
@@ -201,7 +202,14 @@ async function syncText(
       meta.title ??
       basename(relativePath, extname(relativePath));
     propsJson = JSON.stringify(meta.properties);
-    for (const l of extractHtmlLinks(content, relativePath)) {
+    // Pass `known` so extractHtmlLinks can apply basename fallback
+    // when a literal-relative-resolved href misses a file that's
+    // been moved between folders. Same shape MD already uses.
+    const sql = createSql();
+    const pathRows = await sql`SELECT path FROM artifacts`;
+    const known = new Set<string>();
+    for (const row of pathRows) known.add(row.path as string);
+    for (const l of extractHtmlLinks(content, relativePath, known)) {
       if (l.resolved == null) continue;
       resolvedLinks.push({
         target: l.resolved,
@@ -405,53 +413,91 @@ export async function syncDirectory(
     }
   }
 
-  // Second pass: re-resolve markdown redlinks whose target slug now
-  // matches an artifact basename. Necessary because syncFile resolves
-  // [[X]] against the index as it stood when the source was synced —
-  // if A.md was processed before B.md was indexed, A's link to [[B]]
-  // got persisted as a literal "B" redlink and would never converge
-  // without this sweep.
-  await reresolveMarkdownRedlinks();
+  // Second pass: re-resolve unresolved redlinks (both MD slug-form
+  // and HTML path-form) whose basename now matches an artifact.
+  // Necessary because syncFile resolves links against the index as it
+  // stood when the source was synced — if A.md was processed before
+  // B.md was indexed, A's link to [[B]] got persisted as a literal
+  // "B" redlink and would never converge without this sweep. Same
+  // shape applies to HTML hrefs that pointed at an old folder path.
+  await reresolveBasenameRedlinks();
 
   return summary;
 }
 
 /**
- * Walk every unresolved slug-form redlink and re-resolve against the
- * current artifact index. Called after `syncDirectory` (reconcile case)
- * and after every `syncFile` create (live watcher case) so markdown
- * link resolution converges regardless of file-arrival order.
+ * Walk every unresolved redlink and re-resolve against the current
+ * artifact index by basename. Two shapes handled in one pass:
+ *
+ *   - MD slug-form (`target_path` with no slash, e.g. "B"): match
+ *     against basename OR stem (with-or-without-extension), per the
+ *     existing MD `[[X]]` semantics. Lets `[[paper]]` heal to
+ *     `paper.pdf.html`.
+ *   - HTML path-form (`target_path` with a slash, e.g.
+ *     "chartbook/article-one.html"): match against the target's own
+ *     basename, extension-strict. Lets a moved-between-folders
+ *     `./article-one.html` heal symmetrically with MD.
+ *
+ * Ambiguous basenames (>1 match) are skipped in both shapes — the
+ * link stays a redlink. For MD the operator can disambiguate with
+ * `[[folder/X]]`; for HTML, the inbound article has to be edited.
+ *
+ * Called after `syncDirectory` (reconcile case) and after every
+ * `syncFile` create (live watcher case) so resolution converges
+ * regardless of file-arrival order.
  */
-export async function reresolveMarkdownRedlinks(): Promise<void> {
+export async function reresolveBasenameRedlinks(): Promise<void> {
   const sql = createSql();
   const rows = (await sql`
     SELECT DISTINCT l.target_path
     FROM links l
     LEFT JOIN artifacts a ON a.path = l.target_path
-    WHERE a.path IS NULL AND l.target_path NOT LIKE '%/%'
+    WHERE a.path IS NULL
   `) as { target_path: string }[];
   if (rows.length === 0) return;
 
   const allRows = (await sql`SELECT path FROM artifacts`) as { path: string }[];
-  // Index artifacts by both basename and basename-without-extension
-  // so [[paper]] resolves to paper.pdf.html and [[paper.pdf.html]] also
-  // resolves. Ambiguous basenames (>1 match) are skipped — the user can
-  // disambiguate with [[folder/X]].
-  const byBase: Record<string, string[]> = {};
+  // Two indices because the two redlink shapes need different match
+  // semantics:
+  //
+  //   - `byBaseAndStem` unions full basename AND stem (basename
+  //     without final extension). Mirrors the pre-change MD logic so
+  //     `[[paper]]` keeps resolving to `paper.pdf.html` and
+  //     `[[paper.pdf]]` keeps being ambiguous when both a `.pdf`
+  //     asset and its `.pdf.html` sidecar exist.
+  //   - `byStrictBase` indexes full basename only. HTML hrefs are
+  //     explicit about the extension; `./article.html` shouldn't
+  //     quietly heal to `article.md`.
+  const byBaseAndStem: Record<string, string[]> = {};
+  const byStrictBase: Record<string, string[]> = {};
   for (const r of allRows) {
     const b = posix.basename(r.path).toLowerCase();
     const s = b.replace(/\.[^.]+$/, "");
-    (byBase[b] ??= []).push(r.path);
-    if (s !== b) (byBase[s] ??= []).push(r.path);
+    (byBaseAndStem[b] ??= []).push(r.path);
+    if (s !== b) (byBaseAndStem[s] ??= []).push(r.path);
+    (byStrictBase[b] ??= []).push(r.path);
   }
 
   for (const row of rows) {
-    const slug = row.target_path.toLowerCase();
-    const candidates = byBase[slug];
+    const target = row.target_path;
+    let candidates: string[] | undefined;
+    if (target.includes("/")) {
+      // HTML path-form. Strict-basename match.
+      const targetBase = posix.basename(target).toLowerCase();
+      candidates = byStrictBase[targetBase];
+      // Don't self-rewrite to the same path (defensive; the redlink
+      // wouldn't exist if it already pointed at the present row).
+      if (candidates && candidates.length === 1 && candidates[0] === target) {
+        continue;
+      }
+    } else {
+      // MD slug-form: basename-or-stem match, original MD semantics.
+      candidates = byBaseAndStem[target.toLowerCase()];
+    }
     if (!candidates || candidates.length !== 1) continue;
     await sql.query(
       `UPDATE links SET target_path = ? WHERE target_path = ?`,
-      [candidates[0], row.target_path],
+      [candidates[0], target],
     );
   }
 }

--- a/packages/arkeon/test/e2e/substrate.test.ts
+++ b/packages/arkeon/test/e2e/substrate.test.ts
@@ -13,6 +13,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   unlinkSync,
   utimesSync,
@@ -1367,13 +1368,13 @@ describe("substrate", () => {
     expect(Array.isArray(body.artifacts)).toBe(true);
   });
 
-  it("HTML href to a moved-between-folders file heals to the new location", async () => {
+  it("HTML href to a moved-between-folders file heals on disk + index", async () => {
     // Setup: inbound article references a sibling article via
     // `./moved-target.html`. The target lives one folder down at
-    // `bf/sub/moved-target.html`. Today the literal-resolved path is
-    // `bf/moved-target.html` — wrong location. Basename fallback in
-    // sync + reader should heal the link to bf/sub/moved-target.html
-    // automatically.
+    // `bf/sub/moved-target.html`. Doctrine: the watcher detects the
+    // mismatch, the basename fallback finds the unique match, and
+    // the SOURCE HTML on disk gets rewritten so its href spells
+    // `sub/moved-target.html`. SQL converges naturally.
     mkdirSync(join(workdir, "bf/sub"), { recursive: true });
     writeFileSync(
       join(workdir, "bf/sub/moved-target.html"),
@@ -1386,20 +1387,31 @@ describe("substrate", () => {
        </body></html>`,
     );
 
-    // Wait for both files to land.
+    // Wait for both files to land AND for the inbound to reflect
+    // the healed target (covers both arrival orders: target-first
+    // heals during inbound's syncText; inbound-first heals during
+    // the reresolve sweep triggered by target's create).
     const sql = createSql();
-    const deadline = Date.now() + 3000;
+    const deadline = Date.now() + 4000;
     while (Date.now() < deadline) {
-      const rows = await sql`
+      const arrived = (await sql`
         SELECT COUNT(*) AS n FROM artifacts
         WHERE path IN ('bf/inbound.html', 'bf/sub/moved-target.html')
-      `;
-      if ((rows[0] as { n: number }).n === 2) break;
+      `) as { n: number }[];
+      const linked = (await sql`
+        SELECT target_path FROM links WHERE source_path = 'bf/inbound.html'
+      `) as { target_path: string }[];
+      if (
+        (arrived[0]?.n ?? 0) === 2 &&
+        linked.some((r) => r.target_path === "bf/sub/moved-target.html")
+      ) {
+        break;
+      }
       await new Promise((r) => setTimeout(r, 50));
     }
 
-    // Index-level convergence: the link row should target the moved
-    // location, not the literal-resolved (and absent) bf/moved-target.html.
+    // Index-level convergence: the link row targets the moved
+    // location, not the literal-resolved (and absent) path.
     const linkRows = (await sql`
       SELECT target_path FROM links WHERE source_path = 'bf/inbound.html'
     `) as { target_path: string }[];
@@ -1407,12 +1419,20 @@ describe("substrate", () => {
       "bf/sub/moved-target.html",
     );
 
-    // Backlinks convergence: the moved file's backlinks should
-    // surface the inbound article without manual rewrites.
+    // Doctrine assertion: the SOURCE file on disk has been edited so
+    // the href spells the new relative path. View-source matches what
+    // renders; the daemon doesn't lie at render time.
+    const sourceOnDisk = readFileSync(
+      join(workdir, "bf/inbound.html"),
+      "utf-8",
+    );
+    expect(sourceOnDisk).toMatch(/href="sub\/moved-target\.html"/);
+    expect(sourceOnDisk).not.toMatch(/href="\.\/moved-target\.html"/);
+
+    // Backlinks convergence: the moved file's backlinks surface the
+    // inbound article via the SQL link row.
     const back = await app.fetch(
-      new Request(
-        "http://test/backlinks?path=bf/sub/moved-target.html",
-      ),
+      new Request("http://test/backlinks?path=bf/sub/moved-target.html"),
     );
     expect(back.status).toBe(200);
     const backBody = (await back.json()) as {
@@ -1422,8 +1442,8 @@ describe("substrate", () => {
       "bf/inbound.html",
     );
 
-    // /redlinks should NOT report bf/moved-target.html — the basename
-    // fallback resolved it at sync time.
+    // /redlinks does not surface the broken literal — the link row
+    // got healed by the reresolve sweep (or by sync extraction).
     const red = await app.fetch(new Request("http://test/redlinks"));
     const redBody = (await red.json()) as {
       redlinks: Array<{ target_path: string }>;
@@ -1432,25 +1452,23 @@ describe("substrate", () => {
       "bf/moved-target.html",
     );
 
-    // Reader: served HTML should rewrite the href to the resolved
-    // path AND NOT carry the redlink class.
+    // Reader is intentionally dumb-serve: the served HTML reflects
+    // the file on disk, which now has the corrected href. No
+    // render-time magic, no redlink class.
     const served = await app.fetch(
       new Request("http://test/bf/inbound.html"),
     );
     expect(served.status).toBe(200);
     const html = await served.text();
-    // href rewritten to the sub-relative path.
-    expect(html).toMatch(
-      /<a class="wikilink" href="sub\/moved-target\.html">/,
-    );
-    // No redlink class added.
+    expect(html).toMatch(/href="sub\/moved-target\.html"/);
     expect(html).not.toMatch(/wikilink[^"]*redlink/);
   });
 
   it("HTML href stays a redlink when basename is ambiguous (no silent guess)", async () => {
-    // Two files share the same basename in different folders.
-    // The inbound href spelling can't be auto-resolved because
-    // fallback has two candidates — it should remain a redlink.
+    // Two files share the same basename in different folders. The
+    // inbound href can't be auto-healed because fallback has two
+    // candidates. Doctrine consequence: no SQL rewrite, no file
+    // edit, anchor surfaces as a redlink at render time.
     mkdirSync(join(workdir, "ambig/a"), { recursive: true });
     mkdirSync(join(workdir, "ambig/b"), { recursive: true });
     writeFileSync(
@@ -1461,12 +1479,10 @@ describe("substrate", () => {
       join(workdir, "ambig/b/dup.html"),
       `<!doctype html><html><head><title>B dup</title></head><body>b</body></html>`,
     );
-    writeFileSync(
-      join(workdir, "ambig/in.html"),
-      `<!doctype html><html><head><title>In</title></head><body>
+    const inSrc = `<!doctype html><html><head><title>In</title></head><body>
          <a class="wikilink" href="./dup.html">dup</a>
-       </body></html>`,
-    );
+       </body></html>`;
+    writeFileSync(join(workdir, "ambig/in.html"), inSrc);
 
     const sql = createSql();
     const deadline = Date.now() + 3000;
@@ -1486,7 +1502,14 @@ describe("substrate", () => {
     `) as { target_path: string }[];
     expect(linkRows.map((r) => r.target_path)).toContain("ambig/dup.html");
 
-    // Reader marks the anchor as a redlink (still ambiguous at render time).
+    // Source HTML on disk is untouched — no heal write happened.
+    const sourceOnDisk = readFileSync(
+      join(workdir, "ambig/in.html"),
+      "utf-8",
+    );
+    expect(sourceOnDisk).toContain(`href="./dup.html"`);
+
+    // Reader marks the anchor as a redlink (visible-broken).
     const served = await app.fetch(
       new Request("http://test/ambig/in.html"),
     );

--- a/packages/arkeon/test/e2e/substrate.test.ts
+++ b/packages/arkeon/test/e2e/substrate.test.ts
@@ -1366,4 +1366,131 @@ describe("substrate", () => {
     const body = (await res.json()) as { artifacts: unknown[] };
     expect(Array.isArray(body.artifacts)).toBe(true);
   });
+
+  it("HTML href to a moved-between-folders file heals to the new location", async () => {
+    // Setup: inbound article references a sibling article via
+    // `./moved-target.html`. The target lives one folder down at
+    // `bf/sub/moved-target.html`. Today the literal-resolved path is
+    // `bf/moved-target.html` — wrong location. Basename fallback in
+    // sync + reader should heal the link to bf/sub/moved-target.html
+    // automatically.
+    mkdirSync(join(workdir, "bf/sub"), { recursive: true });
+    writeFileSync(
+      join(workdir, "bf/sub/moved-target.html"),
+      `<!doctype html><html><head><title>Moved Target</title></head><body><p>moved</p></body></html>`,
+    );
+    writeFileSync(
+      join(workdir, "bf/inbound.html"),
+      `<!doctype html><html><head><title>Inbound</title></head><body>
+         <a class="wikilink" href="./moved-target.html">moved</a>
+       </body></html>`,
+    );
+
+    // Wait for both files to land.
+    const sql = createSql();
+    const deadline = Date.now() + 3000;
+    while (Date.now() < deadline) {
+      const rows = await sql`
+        SELECT COUNT(*) AS n FROM artifacts
+        WHERE path IN ('bf/inbound.html', 'bf/sub/moved-target.html')
+      `;
+      if ((rows[0] as { n: number }).n === 2) break;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    // Index-level convergence: the link row should target the moved
+    // location, not the literal-resolved (and absent) bf/moved-target.html.
+    const linkRows = (await sql`
+      SELECT target_path FROM links WHERE source_path = 'bf/inbound.html'
+    `) as { target_path: string }[];
+    expect(linkRows.map((r) => r.target_path)).toContain(
+      "bf/sub/moved-target.html",
+    );
+
+    // Backlinks convergence: the moved file's backlinks should
+    // surface the inbound article without manual rewrites.
+    const back = await app.fetch(
+      new Request(
+        "http://test/backlinks?path=bf/sub/moved-target.html",
+      ),
+    );
+    expect(back.status).toBe(200);
+    const backBody = (await back.json()) as {
+      backlinks: Array<{ source_path: string }>;
+    };
+    expect(backBody.backlinks.map((b) => b.source_path)).toContain(
+      "bf/inbound.html",
+    );
+
+    // /redlinks should NOT report bf/moved-target.html — the basename
+    // fallback resolved it at sync time.
+    const red = await app.fetch(new Request("http://test/redlinks"));
+    const redBody = (await red.json()) as {
+      redlinks: Array<{ target_path: string }>;
+    };
+    expect(redBody.redlinks.map((r) => r.target_path)).not.toContain(
+      "bf/moved-target.html",
+    );
+
+    // Reader: served HTML should rewrite the href to the resolved
+    // path AND NOT carry the redlink class.
+    const served = await app.fetch(
+      new Request("http://test/bf/inbound.html"),
+    );
+    expect(served.status).toBe(200);
+    const html = await served.text();
+    // href rewritten to the sub-relative path.
+    expect(html).toMatch(
+      /<a class="wikilink" href="sub\/moved-target\.html">/,
+    );
+    // No redlink class added.
+    expect(html).not.toMatch(/wikilink[^"]*redlink/);
+  });
+
+  it("HTML href stays a redlink when basename is ambiguous (no silent guess)", async () => {
+    // Two files share the same basename in different folders.
+    // The inbound href spelling can't be auto-resolved because
+    // fallback has two candidates — it should remain a redlink.
+    mkdirSync(join(workdir, "ambig/a"), { recursive: true });
+    mkdirSync(join(workdir, "ambig/b"), { recursive: true });
+    writeFileSync(
+      join(workdir, "ambig/a/dup.html"),
+      `<!doctype html><html><head><title>A dup</title></head><body>a</body></html>`,
+    );
+    writeFileSync(
+      join(workdir, "ambig/b/dup.html"),
+      `<!doctype html><html><head><title>B dup</title></head><body>b</body></html>`,
+    );
+    writeFileSync(
+      join(workdir, "ambig/in.html"),
+      `<!doctype html><html><head><title>In</title></head><body>
+         <a class="wikilink" href="./dup.html">dup</a>
+       </body></html>`,
+    );
+
+    const sql = createSql();
+    const deadline = Date.now() + 3000;
+    while (Date.now() < deadline) {
+      const rows = await sql`
+        SELECT COUNT(*) AS n FROM artifacts
+        WHERE path IN ('ambig/a/dup.html','ambig/b/dup.html','ambig/in.html')
+      `;
+      if ((rows[0] as { n: number }).n === 3) break;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    // Link row points at the literal-resolved (missing) path —
+    // ambiguous fallback is not taken.
+    const linkRows = (await sql`
+      SELECT target_path FROM links WHERE source_path = 'ambig/in.html'
+    `) as { target_path: string }[];
+    expect(linkRows.map((r) => r.target_path)).toContain("ambig/dup.html");
+
+    // Reader marks the anchor as a redlink (still ambiguous at render time).
+    const served = await app.fetch(
+      new Request("http://test/ambig/in.html"),
+    );
+    const html = await served.text();
+    expect(html).toMatch(/class="wikilink redlink"/);
+  });
 });

--- a/packages/arkeon/test/unit/basename-fallback.test.ts
+++ b/packages/arkeon/test/unit/basename-fallback.test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  relativeHref,
+  resolveByBasename,
+} from "../../src/server/lib/basename-fallback.js";
+
+describe("resolveByBasename", () => {
+  it("returns null when the literal target already exists (no fallback needed)", () => {
+    const known = new Set(["chartbook/article-one.html"]);
+    expect(resolveByBasename("chartbook/article-one.html", known)).toBeNull();
+  });
+
+  it("returns the unique basename match when the literal target is missing", () => {
+    // Simulates a file moved from chartbook/ to root: an inbound
+    // href that still spells chartbook/article-one.html heals to
+    // root article-one.html.
+    const known = new Set(["article-one.html", "chartbook/other.html"]);
+    expect(
+      resolveByBasename("chartbook/article-one.html", known),
+    ).toBe("article-one.html");
+  });
+
+  it("returns null when basename match is ambiguous (keeps redlink)", () => {
+    // Same basename in two places. The render-time fallback can't
+    // guess which one; surfaces as a redlink so a human disambiguates.
+    const known = new Set([
+      "iarpa/article.html",
+      "chartbook/article.html",
+    ]);
+    expect(resolveByBasename("missing/article.html", known)).toBeNull();
+  });
+
+  it("returns null when basename has zero matches", () => {
+    const known = new Set(["iarpa/other.html"]);
+    expect(resolveByBasename("missing/article.html", known)).toBeNull();
+  });
+
+  it("is extension-strict (article.html does not heal to article.md)", () => {
+    // Operators that specify .html in the href mean .html. A `.md`
+    // file with a matching stem is NOT a valid fallback — it would
+    // silently rewrite a wiki article link to its markdown source.
+    const known = new Set(["iarpa/article.md"]);
+    expect(resolveByBasename("chartbook/article.html", known)).toBeNull();
+  });
+
+  it("is case-insensitive (matches OS filesystem norms)", () => {
+    const known = new Set(["iarpa/Article-One.html"]);
+    expect(
+      resolveByBasename("chartbook/article-one.html", known),
+    ).toBe("iarpa/Article-One.html");
+  });
+});
+
+describe("relativeHref", () => {
+  it("computes a sibling href when source and target share a directory", () => {
+    expect(relativeHref("chartbook/index.html", "chartbook/about.html")).toBe(
+      "about.html",
+    );
+  });
+
+  it("computes a parent-relative href when target lives one level up", () => {
+    expect(
+      relativeHref("chartbook/article-one.html", "article-one.html"),
+    ).toBe("../article-one.html");
+  });
+
+  it("computes a child-relative href when target lives in a subfolder", () => {
+    expect(relativeHref("iarpa/index.html", "iarpa/sources/notes.md")).toBe(
+      "sources/notes.md",
+    );
+  });
+
+  it("returns the bare target when the source lives at the watched root", () => {
+    expect(relativeHref("index.html", "iarpa/article.html")).toBe(
+      "iarpa/article.html",
+    );
+  });
+});

--- a/packages/arkeon/test/unit/heal-html.test.ts
+++ b/packages/arkeon/test/unit/heal-html.test.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Arkeon Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { applyHeals } from "../../src/server/lib/heal-html.js";
+
+describe("applyHeals", () => {
+  it("rewrites a matching anchor's href and reports one change", () => {
+    const html = `<a class="wikilink" href="./moved.html">x</a>`;
+    const result = applyHeals(html, "bf/inbound.html", [
+      { brokenTarget: "bf/moved.html", healedTarget: "bf/sub/moved.html" },
+    ]);
+    expect(result.changed).toBe(1);
+    expect(result.content).toContain(`href="sub/moved.html"`);
+    expect(result.content).not.toContain(`href="./moved.html"`);
+  });
+
+  it("returns content unchanged when no anchors match", () => {
+    const html = `<a class="wikilink" href="./other.html">x</a>`;
+    const result = applyHeals(html, "bf/inbound.html", [
+      { brokenTarget: "bf/moved.html", healedTarget: "bf/sub/moved.html" },
+    ]);
+    expect(result.changed).toBe(0);
+    expect(result.content).toBe(html);
+  });
+
+  it("preserves data-* attrs verbatim while rewriting href", () => {
+    // Citation metadata is the whole point of `data-*` on wikilinks;
+    // healing the href must not touch it.
+    const html = `<a class="wikilink" href="./moved.html" data-quote="On day 3" data-page="7" data-cite-type="evidence">x</a>`;
+    const result = applyHeals(html, "bf/inbound.html", [
+      { brokenTarget: "bf/moved.html", healedTarget: "bf/sub/moved.html" },
+    ]);
+    expect(result.changed).toBe(1);
+    expect(result.content).toContain(`data-quote="On day 3"`);
+    expect(result.content).toContain(`data-page="7"`);
+    expect(result.content).toContain(`data-cite-type="evidence"`);
+  });
+
+  it("does not touch plain <a> anchors — only `class=\"wikilink\"`", () => {
+    // Mirrors extractHtmlLinks's contract: plain anchors aren't part
+    // of the link graph and aren't healed.
+    const html = `<a href="./moved.html">external</a><a class="wikilink" href="./moved.html">wiki</a>`;
+    const result = applyHeals(html, "bf/inbound.html", [
+      { brokenTarget: "bf/moved.html", healedTarget: "bf/sub/moved.html" },
+    ]);
+    expect(result.changed).toBe(1);
+    expect(result.content).toContain(`<a href="./moved.html">external</a>`);
+    expect(result.content).toContain(`href="sub/moved.html"`);
+  });
+
+  it("applies multiple heals in one parse", () => {
+    const html =
+      `<a class="wikilink" href="./a.html">a</a>` +
+      `<a class="wikilink" href="./b.html">b</a>`;
+    const result = applyHeals(html, "bf/inbound.html", [
+      { brokenTarget: "bf/a.html", healedTarget: "bf/x/a.html" },
+      { brokenTarget: "bf/b.html", healedTarget: "bf/y/b.html" },
+    ]);
+    expect(result.changed).toBe(2);
+    expect(result.content).toContain(`href="x/a.html"`);
+    expect(result.content).toContain(`href="y/b.html"`);
+  });
+
+  it("no-ops on empty heals list (cheap idempotency)", () => {
+    const html = `<a class="wikilink" href="./moved.html">x</a>`;
+    const result = applyHeals(html, "bf/inbound.html", []);
+    expect(result.changed).toBe(0);
+    expect(result.content).toBe(html);
+  });
+});

--- a/packages/arkeon/test/unit/html-links.test.ts
+++ b/packages/arkeon/test/unit/html-links.test.ts
@@ -129,4 +129,41 @@ describe("extractHtmlLinks", () => {
     const html = `<img src="../images/chart.png" alt="chart">`;
     expect(extractHtmlLinks(html, "wiki/foo.html")).toEqual([]);
   });
+
+  it("falls back to a basename-unique match when knownPaths is provided and literal misses", () => {
+    // chartbook/article.html was the inbound href when the target
+    // lived there; the file has since moved to root. With knownPaths
+    // provided, extraction should heal the link to root article.html.
+    const html = `<a class="wikilink" href="./article.html">x</a>`;
+    const known = new Set(["chartbook/index.html", "article.html"]);
+    const out = extractHtmlLinks(html, "chartbook/index.html", known);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.resolved).toBe("article.html");
+  });
+
+  it("keeps the literal resolution when basename is ambiguous", () => {
+    // Two files share the basename — fallback can't pick, so the
+    // anchor stays a redlink at the literal-resolved path.
+    const html = `<a class="wikilink" href="./article.html">x</a>`;
+    const known = new Set([
+      "chartbook/index.html",
+      "iarpa/article.html",
+      "chartbook/article.html",
+    ]);
+    // Note: chartbook/article.html IS in known, so this is the
+    // "literal hit" path. Use a different fromPath to force the
+    // fallback consideration.
+    const out = extractHtmlLinks(html, "missing/index.html", known);
+    expect(out).toHaveLength(1);
+    // literal-resolved is missing/article.html → ambiguous fallback
+    // (two matches) → keep literal.
+    expect(out[0]!.resolved).toBe("missing/article.html");
+  });
+
+  it("without knownPaths, behavior is the pre-change literal resolve", () => {
+    const html = `<a class="wikilink" href="./article.html">x</a>`;
+    const out = extractHtmlLinks(html, "chartbook/index.html");
+    expect(out).toHaveLength(1);
+    expect(out[0]!.resolved).toBe("chartbook/article.html");
+  });
 });


### PR DESCRIPTION
## Summary

When a file moves between folders, MD `[[X]]` references heal automatically (shortest-unique-basename). HTML `<a class="wikilink" href="./X">` references didn't, because `resolveHref` uses relative-path math. So `chartbook/article-one.html` → `article-one.html` left every inbound `./article-one.html` broken as a redlink even though the file still existed.

This PR makes HTML resolution symmetric — and lands the heal **through real source-file edits**, not render-time rewrites. The filesystem stays truth.

Closes the auto-heal half of #122. The remaining basename-rename case (where the file's basename itself changes) still needs the explicit rename tool, which is the next PR.

## Doctrine

> The daemon propagates corrections to disk so the next extraction sees coherent state. View-source matches what renders. Git history carries each heal as a real edit.

Reshape rationale (the original PR did a render-time rewrite — feedback flagged the same shape that bit us in PR #117/#121's content-hash auto-rewire; we walked it back to a sync-path file edit instead). The watcher → daemon-write → watcher cycle terminates in one pass because the post-heal extraction needs no further fallback.

## Mechanics

**New `src/server/lib/basename-fallback.ts`** — `resolveByBasename` (strict, extension-included, null on ambiguity) + `relativeHref` (href math from a source's directory to a resolved target).

**New `src/server/lib/heal-html.ts`** — `applyHeals(content, source, heals)` returns rewritten content + change count; `writeAtomic` does a temp+rename write so a crash mid-write leaves the original intact. Pure function for content, side-effect helper for FS.

**`extractHtmlLinks`** takes optional `knownPaths`. When provided, a literal-resolved path that misses the index is reconciled against basename-unique fallback before the link row is written. Extension-strict — `article.html` doesn't quietly heal to `article.md`.

**`syncText`** HTML branch: when extraction returns a fallback target (literal differs from resolved), apply heals to in-memory content, atomically write back, then recompute `hash` + `fingerprint` from the post-heal state. The watcher's next event on our own write hits the stat-fingerprint fast path — no redundant resync.

**`reresolveMarkdownRedlinks` → `reresolveBasenameRedlinks`** (renamed + generalized): one sweep, two shapes.
- MD slug-form keeps the basename+stem union (original semantics: `[[paper]]` still resolves to `paper.pdf.html`, `[[paper.pdf]]` still ambiguates).
- HTML path-form uses strict basename and ALSO reads each healed source HTML file, applies heals, and writes it back atomically. MD source `.md` files are NOT rewritten — `[[X]]` is abstract slug syntax, keep the operator's intent. Errors during read/write are logged but don't abort the sweep.

**`reader.ts`** is dumb-serve again. Literal hit → leave alone. Miss → `redlink` class. No fallback logic, no href rewriting. If a redlink reaches the renderer, sync genuinely couldn't heal it (ambiguous, or hadn't healed yet).

## Test plan

- [x] `npm run typecheck -w packages/arkeon`
- [x] `npm test -w packages/arkeon` — **287 unit tests** (was 268, +19):
  - `basename-fallback.test.ts` — strict match, unique fallback, ambiguous, zero matches, extension strictness, case insensitivity, `relativeHref` math from various depths.
  - `heal-html.test.ts` — matching anchor rewrites + change count, no-op when no match, `data-*` attrs preserved verbatim (citation metadata is the whole point), plain `<a>` left alone, multi-heal in one parse, empty-list idempotency.
  - `html-links.test.ts` — extraction-time fallback hit, ambiguous keeps literal, no-knownPaths is the pre-change literal resolve.
- [x] `npm run test:e2e -w packages/arkeon` — **87 e2e tests** (was 85, +2):
  - End-to-end heal: link row points at the new location, SOURCE HTML on disk has been rewritten to spell the new path (no `./moved-target.html` remaining), backlinks/redlinks agree, served HTML reflects the corrected source.
  - Ambiguous: link row keeps literal, SOURCE HTML on disk untouched (no heal write), reader marks the anchor as a redlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
